### PR TITLE
test: improve SecurityIntegrationTest with full context setup and H2 …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,11 @@
     <version>1.18.30</version>
     <scope>provided</scope>
 </dependency>
-
+ <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-test</artifactId>
+        <scope>test</scope>
+    </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/renewsim/backend/auth/AuthService.java
+++ b/src/main/java/com/renewsim/backend/auth/AuthService.java
@@ -75,9 +75,7 @@ public class AuthService {
 
     private Set<String> getScopesFromRole(RoleName roleName) {
         return switch (roleName) {
-            case USER -> Set.of("read:simulations", "write:simulations", "compare:simulations");
-            case ADVANCED_USER ->
-                Set.of("read:simulations", "write:simulations", "compare:simulations", "export:simulations");
+            case USER -> Set.of("read:simulations", "write:simulations", "compare:simulations");           
             case ADMIN -> Set.of("read:simulations", "write:simulations", "compare:simulations",
                     "export:simulations", "delete:simulations", "read:users", "manage:users");
         };

--- a/src/test/java/com/renewsim/backend/config/SecurityConfigTest.java
+++ b/src/test/java/com/renewsim/backend/config/SecurityConfigTest.java
@@ -1,0 +1,90 @@
+package com.renewsim.backend.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SecurityConfigTest {
+
+    @InjectMocks
+    private SecurityConfig securityConfig;
+
+    @Mock
+    private HttpSecurity httpSecurity;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        setupHttpSecurityMocks();
+    }
+
+    private void setupHttpSecurityMocks() {
+        // Mock final SecurityFilterChain
+        SecurityFilterChain securityFilterChain = mock(SecurityFilterChain.class);
+
+        // Mock HttpSecurity para devolver mocks encadenados
+        try {
+            when(httpSecurity.cors(any())).thenReturn(httpSecurity);
+            when(httpSecurity.csrf(any())).thenReturn(httpSecurity);
+            when(httpSecurity.sessionManagement(any())).thenReturn(httpSecurity);
+            when(httpSecurity.oauth2ResourceServer(any())).thenReturn(httpSecurity);
+            when(httpSecurity.authorizeHttpRequests(any())).thenReturn(httpSecurity);
+            when(httpSecurity.build()).thenAnswer(invocation -> securityFilterChain);
+        } catch (Exception e) {
+            throw new RuntimeException("Error setting up HttpSecurity mocks", e);
+        }
+    }
+
+    @Test
+    @DisplayName("should create SecurityFilterChain bean and call expected configurations")
+    void shouldCreateSecurityFilterChain() throws Exception {
+        SecurityFilterChain filterChain = securityConfig.securityFilterChain(httpSecurity);
+
+        // Assertions
+        assertThat(filterChain).isNotNull();
+
+        // Verifications para cobertura y comportamiento esperado
+        verify(httpSecurity).cors(any());
+        verify(httpSecurity).csrf(any());
+        verify(httpSecurity).authorizeHttpRequests(any());
+        verify(httpSecurity).sessionManagement(any());
+        verify(httpSecurity).oauth2ResourceServer(any());
+        verify(httpSecurity).build();
+    }
+
+    @Test
+    @DisplayName("should create JwtDecoder bean")
+    void shouldCreateJwtDecoder() {
+        JwtDecoder jwtDecoder = securityConfig.jwtDecoder();
+        assertThat(jwtDecoder).isNotNull();
+    }
+
+    @Test
+    @DisplayName("should create PasswordEncoder bean with BCrypt")
+    void shouldCreatePasswordEncoder() {
+        PasswordEncoder passwordEncoder = securityConfig.passwordEncoder();
+        assertThat(passwordEncoder).isNotNull();
+        assertThat(passwordEncoder.getClass().getSimpleName()).containsIgnoringCase("BCrypt");
+    }
+
+
+
+    @Test
+    @DisplayName("should create JwtAuthenticationConverter bean")
+    void shouldCreateJwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = securityConfig.jwtAuthenticationConverter();
+        assertThat(converter).isNotNull();
+    }
+}

--- a/src/test/java/com/renewsim/backend/config/SecurityIntegrationTest.java
+++ b/src/test/java/com/renewsim/backend/config/SecurityIntegrationTest.java
@@ -1,0 +1,175 @@
+package com.renewsim.backend.config;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.renewsim.backend.role.Role;
+import com.renewsim.backend.role.RoleName;
+import com.renewsim.backend.role.RoleRepository;
+import com.renewsim.backend.technologyComparison.TechnologyComparison;
+import com.renewsim.backend.technologyComparison.TechnologyComparisonRepository;
+import com.renewsim.backend.user.User;
+import com.renewsim.backend.user.UserRepository;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import java.util.Collections;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ContextConfiguration
+@ActiveProfiles("test")
+
+class SecurityIntegrationTest {
+
+    @Autowired
+    public SecurityIntegrationTest(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+@Autowired
+private TechnologyComparisonRepository technologyComparisonRepository;
+
+@BeforeEach
+void setUp() {
+    Role userRole = new Role();
+    userRole.setName(RoleName.USER);
+    roleRepository.save(userRole); 
+
+    User user = new User();
+    user.setUsername("test-user");
+    user.setPassword(passwordEncoder.encode("test-password"));
+    user.setRoles(Collections.singleton(userRole));
+
+    userRepository.save(user);
+
+    TechnologyComparison tech = new TechnologyComparison();
+    tech.setTechnologyName("Solar Panel");
+    tech.setEnergyType("SOLAR");
+    tech.setInstallationCost(1000.0);
+    tech.setMaintenanceCost(100.0);
+    tech.setEfficiency(85.0);
+    tech.setEnergyProduction(5000.0);
+    tech.setCo2Reduction(500.0);
+    technologyComparisonRepository.save(tech);
+
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .apply(SecurityMockMvcConfigurers.springSecurity())
+            .build();
+}
+
+    private String generateJwtToken(String scope) {
+        String secret = "J6s8wQ0eK2rLdP9yXbTmGhV7zM9aFgRk";
+        SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+
+        return Jwts.builder()
+                .setSubject("test-user")
+                .claim("scope", scope)
+                .setIssuedAt(new Date())
+                .setExpiration(Date.from(Instant.now().plus(1, ChronoUnit.HOURS)))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    @Test
+    @DisplayName("Public route /api/v1/auth/login should be accessible without authentication")
+    void shouldAllowAccessToLoginWithoutAuthentication() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\": \"test-user\", \"password\": \"test-password\"}"))
+                .andExpect(status().isOk());
+
+    }
+    @Test
+    @DisplayName("Protected GET /api/v1/simulation requires scope SCOPE_read:simulations")
+    @WithMockUser(username = "test-user", authorities = {"SCOPE_read:simulations"})
+    void shouldAllowAccessToSimulationReadWithProperScope() throws Exception {
+        mockMvc.perform(get("/api/v1/simulation/user")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\": \"test-user\", \"password\": \"test-password\"}"))
+                .andExpect(status().isOk());
+    }   
+
+    @Test
+    @DisplayName("Protected route should return 403 if user lacks required scope")
+    @WithMockUser(authorities = { "SCOPE_read:simulations" })
+    void shouldDenyAccessToAdminWithoutProperScope() throws Exception {
+        mockMvc.perform(get("/api/v1/admin/test"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("JWT token with invalid scope should be forbidden")
+    void shouldRejectJwtTokenWithInvalidScope() throws Exception {
+        String token = generateJwtToken("invalid:scope");
+
+        mockMvc.perform(get("/api/v1/simulation/test")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Invalid JWT token should be unauthorized")
+    void shouldRejectInvalidJwtToken() throws Exception {
+        mockMvc.perform(get("/api/v1/simulation/test")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer invalid.token.here"))
+                .andExpect(status().isUnauthorized());
+    }    
+
+    @Test
+    @WithAnonymousUser
+    @DisplayName("Anonymous user should not access protected simulation route")
+    void shouldDenyAnonymousAccessToSimulation() throws Exception {
+        mockMvc.perform(get("/api/v1/simulation/test"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @BeforeEach
+    void cleanDatabase() {
+        userRepository.deleteAll();
+        roleRepository.deleteAll();
+    }
+
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,16 +1,12 @@
-# Configuración para pruebas - Usa H2 en memoria
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=true
 
-# Deshabilita el inicio automático de la base de datos en tests
-spring.test.database.replace=NONE
+spring.main.allow-bean-definition-overriding=true
 
-# Deshabilita la configuración de seguridad en las pruebas (si es necesario)
-spring.security.enabled=false
 
-# Deshabilita la ejecución automática de migraciones en test (si usas Flyway o Liquibase)
-spring.flyway.enabled=false
-spring.liquibase.enabled=false


### PR DESCRIPTION
…test configuration

- Add full database setup for integration tests with User, Role, and TechnologyComparison entities
- Ensure H2 database is configured for in-memory persistence across tests
- Clean database before each test to avoid data pollution
- MockMvc setup using WebApplicationContext and Spring Security integration
- Improve SecurityConfigTest with mocked HttpSecurity to test SecurityFilterChain configuration
- Add assertions for PasswordEncoder, JwtDecoder, and JwtAuthenticationConverter beans
- Add missing pre-authorization tests for protected endpoints