### PR TITLE
refactor(jwt): restrict JwtTokenProvider constructor visibility

### DIFF
--- a/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/JwtProviderIntegrationTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/JwtProviderIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.renewsim.backend.auth_service.infrastructure.security;
+
+import com.renewsim.backend.auth_service.config.SecurityJwtProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtProviderIntegrationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TestConfig.class));
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        SecurityJwtProperties securityJwtProperties() {
+            return new SecurityJwtProperties(
+                    "renewsim-auth",
+                    "renewsim-app",
+                    null,  
+                    null,  
+                    3600L,
+                    0L,
+                    0L
+            );
+        }
+
+        @Bean
+        JwtTokenProvider jwtTokenProvider(SecurityJwtProperties props) {
+            return new JwtTokenProvider(props, null);
+        }
+    }
+
+    @Test
+    @DisplayName("Spring context should fail to start without JWT secret")
+    void contextFailsWithoutSecret() {
+        contextRunner.run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(context.getStartupFailure())
+                    .hasMessageContaining("No JWT secret configured");
+        });
+    }
+}
+

--- a/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/JwtTokenProviderTest.java
@@ -300,6 +300,33 @@ class JwtTokenProviderTest {
         assertThat(assertUUID(claims.getId())).isTrue();
     }
 
+    @Test
+    @DisplayName("constructor → lanza excepción cuando faltan ambos secretos (plain y base64)")
+    void constructor_throws_whenBothSecretsMissing() {
+        var p = new SecurityJwtProperties(
+                "iss", "aud",
+                null,
+                null, 
+                3600L,
+                0L,
+                0L);
+        Clock clock = Clock.fixed(Instant.parse("2025-01-01T10:00:00Z"), ZoneOffset.UTC);
+
+        assertThatThrownBy(() -> new JwtTokenProvider(p, clock))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No JWT secret configured");
+    }
+
+    @Test
+    @DisplayName("constructor → NO debe ser público (package-private)")
+    void constructor_isPackagePrivate() throws Exception {
+        var ctor = JwtTokenProvider.class.getDeclaredConstructor(SecurityJwtProperties.class, Clock.class);
+        int mod = ctor.getModifiers();
+        assertThat(java.lang.reflect.Modifier.isPublic(mod)).isFalse();
+        assertThat(java.lang.reflect.Modifier.isPrivate(mod)).isFalse();
+        assertThat(java.lang.reflect.Modifier.isProtected(mod)).isFalse();
+    }
+
     private static boolean assertUUID(String maybeUuid) {
         try {
             UUID.fromString(maybeUuid);


### PR DESCRIPTION
## What / Why
- Restrict instantiation of `JwtTokenProvider` to Spring by making its constructor package-private.  
- Enforce fail-fast startup when JWT secret is missing or too short (<32 bytes).  
- Keep HS256 as the only allowed algorithm to avoid negotiation risks.  
- Add brief documentation (`SECURITY.md` / `README-auth.md`) to guide developers on JWT configuration.

## Scope
- [x] Backend
- [x] Tests
- [x] Docs

## Changes
- [x] `JwtTokenProvider`: constructor visibility set to package-private.  
- [x] Fail-fast in `resolveKey(...)` when `secretBase64` and `secret` are missing or too short.  
- [x] Explicit enforcement of HS256 during signing and validation.  
- [x] Unit tests: configuration validation (missing/short secrets).  
- [x] Integration tests: context startup fails when no secret is provided.  
- [x] Documentation: added `SECURITY.md` section with secret length, env variables, algorithm, and observability notes.  

## Acceptance Criteria
- GIVEN the application starts  
- WHEN no JWT secret (`JWT_SECRET` or `JWT_SECRET_BASE64`) is configured  
- THEN the application fails to start with a clear error  

- GIVEN a JWT secret shorter than 32 bytes  
- WHEN the application initializes  
- THEN it throws `IllegalStateException` and logs ERROR  

- GIVEN a valid 32+ byte secret  
- WHEN a token is generated and validated  
- THEN the process succeeds using HS256 only  

## Test Plan
- [x] Unit: constructor throws exception when both secrets are missing.  
- [x] Unit: constructor throws exception when plain or base64 secret is <32 bytes.  
- [x] Unit: constructor is package-private (verified by reflection).  
- [x] Integration: Spring context startup fails without configured secret.  
- [x] Positive path: token generation/validation works with valid secrets.  

## Docs Update
Added to `SECURITY.md` / `README-auth.md`:

```markdown
## JWT Security Notes

### Secret Key Requirements
- **Minimum length:** 32 bytes (256 bits) of real entropy (not just string length).  
- **Accepted sources:**
  - `JWT_SECRET` → plain text string.
  - `JWT_SECRET_BASE64` → Base64-encoded secret.

The application will **fail fast** at startup if no secret is configured or if the secret is shorter than 32 bytes.

### Algorithm
- **HS256** is the only supported signing algorithm.  
- Tokens signed with other algorithms (HS384, HS512, etc.) will be **rejected**.

### Observability
- When an invalid or missing secret is detected at bean instantiation, the application logs a **WARN/ERROR** with a clear message.  
- Recommended to monitor logs on startup to ensure the JWT provider is correctly initialized.