### PR TITLE
add rate limiting for /auth/login

### DIFF
--- a/src/main/java/com/renewsim/backend/RenewSimBackendApplication.java
+++ b/src/main/java/com/renewsim/backend/RenewSimBackendApplication.java
@@ -3,7 +3,6 @@ package com.renewsim.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 
 import javax.sql.DataSource;
@@ -16,9 +15,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
+
 @SpringBootApplication
 @EnableMethodSecurity
-@EnableConfigurationProperties
 @EnableCaching 
 @ConfigurationPropertiesScan
 public class RenewSimBackendApplication {

--- a/src/main/java/com/renewsim/backend/RenewSimBackendApplication.java
+++ b/src/main/java/com/renewsim/backend/RenewSimBackendApplication.java
@@ -3,6 +3,7 @@ package com.renewsim.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 
 import javax.sql.DataSource;
@@ -17,6 +18,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 
 @SpringBootApplication
 @EnableMethodSecurity
+@EnableConfigurationProperties
 @EnableCaching 
 @ConfigurationPropertiesScan
 public class RenewSimBackendApplication {

--- a/src/main/java/com/renewsim/backend/auth_service/config/SecurityConfig.java
+++ b/src/main/java/com/renewsim/backend/auth_service/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.renewsim.backend.auth_service.config;
 
 import com.renewsim.backend.auth_service.infrastructure.AuthNoCacheFilter;
 import com.renewsim.backend.auth_service.infrastructure.security.JwtAuthenticationFilter;
+import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimitingFilter;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +34,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final LoginRateLimitingFilter loginRateLimitingFilter;
 
     @Value("${cors.allowed-origins}")
     private String allowedOrigins;
@@ -76,6 +79,7 @@ public class SecurityConfig {
                                 "geolocation=(), microphone=(), camera=()")))
 
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(loginRateLimitingFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAfter(authNoCacheFilter(), UsernamePasswordAuthenticationFilter.class)
 
                 .exceptionHandling(ex -> ex

--- a/src/main/java/com/renewsim/backend/auth_service/config/SecurityRateLimitProperties.java
+++ b/src/main/java/com/renewsim/backend/auth_service/config/SecurityRateLimitProperties.java
@@ -1,0 +1,19 @@
+package com.renewsim.backend.auth_service.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "auth.rate-limiting")
+public class SecurityRateLimitProperties {
+    public enum Strategy { IP, IP_USER }
+
+    private boolean enabled = true;
+    private Strategy strategy = Strategy.IP;
+    private int maxAttempts = 5;
+    private int windowSeconds = 60;
+    private int retryAfterSeconds = 60;
+    private String loginPath = "/api/v1/auth/login";
+}

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/SecurityExtraFiltersConfig.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/SecurityExtraFiltersConfig.java
@@ -7,11 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.web.SecurityFilterChain;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableConfigurationProperties(SecurityRateLimitProperties.class)
@@ -21,19 +17,6 @@ public class SecurityExtraFiltersConfig {
     @ConditionalOnProperty(prefix = "auth.rate-limiting", name = "enabled", havingValue = "true", matchIfMissing = true)
     public LoginRateLimitingFilter loginRateLimitingFilter(SecurityRateLimitProperties props, ObjectMapper objectMapper) {
         return new LoginRateLimitingFilter(props, objectMapper);
-    }
-
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, LoginRateLimitingFilter rateFilter) throws Exception {
-        http
-          .csrf(csrf -> csrf.disable())
-          .authorizeHttpRequests(auth -> auth
-              .requestMatchers("/api/v1/auth/**").permitAll()
-              .anyRequest().authenticated()
-          )
-          .addFilterBefore(rateFilter, UsernamePasswordAuthenticationFilter.class)
-          .httpBasic(withDefaults());
-        return http.build();
-    }
+    }    
 }
 

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/SecurityExtraFiltersConfig.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/SecurityExtraFiltersConfig.java
@@ -1,0 +1,39 @@
+package com.renewsim.backend.auth_service.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.auth_service.config.SecurityRateLimitProperties;
+import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimitingFilter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableConfigurationProperties(SecurityRateLimitProperties.class)
+public class SecurityExtraFiltersConfig {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "auth.rate-limiting", name = "enabled", havingValue = "true", matchIfMissing = true)
+    public LoginRateLimitingFilter loginRateLimitingFilter(SecurityRateLimitProperties props, ObjectMapper objectMapper) {
+        return new LoginRateLimitingFilter(props, objectMapper);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, LoginRateLimitingFilter rateFilter) throws Exception {
+        http
+          .csrf(csrf -> csrf.disable())
+          .authorizeHttpRequests(auth -> auth
+              .requestMatchers("/api/v1/auth/**").permitAll()
+              .anyRequest().authenticated()
+          )
+          .addFilterBefore(rateFilter, UsernamePasswordAuthenticationFilter.class)
+          .httpBasic(withDefaults());
+        return http.build();
+    }
+}
+

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimiter.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimiter.java
@@ -1,0 +1,53 @@
+package com.renewsim.backend.auth_service.infrastructure.security;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class LoginRateLimiter {
+
+    private static final class WindowCounter {
+        final long windowStartEpochSec;
+        final AtomicInteger count = new AtomicInteger(1);
+        WindowCounter(long windowStartEpochSec) {
+            this.windowStartEpochSec = windowStartEpochSec;
+        }
+    }
+
+    private final ConcurrentHashMap<String, WindowCounter> counters = new ConcurrentHashMap<>();
+    private final int windowSeconds;
+    private final int maxAttempts;
+
+    LoginRateLimiter(int windowSeconds, int maxAttempts) {
+        this.windowSeconds = windowSeconds;
+        this.maxAttempts = maxAttempts;
+    }
+    boolean allow(String key) {
+        Objects.requireNonNull(key, "key");
+        final long nowSec = Instant.now().getEpochSecond();
+        final long windowStart = nowSec - (nowSec % windowSeconds);
+
+        counters.compute(key, (k, current) -> {
+            if (current == null || current.windowStartEpochSec != windowStart) {
+                return new WindowCounter(windowStart);
+            }
+            current.count.incrementAndGet();
+            return current;
+        });
+
+        WindowCounter wc = counters.get(key);
+        return wc.count.get() <= maxAttempts;
+    }
+    int secondsUntilWindowReset() {
+        final long nowSec = Instant.now().getEpochSecond();
+        final long nextWindowStart = nowSec - (nowSec % windowSeconds) + windowSeconds;
+        long delta = nextWindowStart - nowSec;
+        return (int) Math.max(0, delta);
+    }
+
+    void resetAll() {
+        counters.clear();
+    }
+}
+

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilter.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilter.java
@@ -1,0 +1,94 @@
+package com.renewsim.backend.auth_service.infrastructure.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.auth_service.config.SecurityRateLimitProperties;
+import com.renewsim.backend.auth_service.web.dto.LoginUsernameProbe;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Order(5) 
+public class LoginRateLimitingFilter extends OncePerRequestFilter {
+
+    private final SecurityRateLimitProperties props;
+    private final LoginRateLimiter limiter;
+    private final ObjectMapper objectMapper;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public LoginRateLimitingFilter(SecurityRateLimitProperties props, ObjectMapper objectMapper) {
+        this.props = props;
+        this.objectMapper = objectMapper;
+        this.limiter = new LoginRateLimiter(props.getWindowSeconds(), props.getMaxAttempts());
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        if (!props.isEnabled()) return true;
+        String servletPath = request.getServletPath();
+        return !pathMatcher.match(props.getLoginPath(), servletPath);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws ServletException, IOException {
+        ContentCachingRequestWrapper wrapped = (req instanceof ContentCachingRequestWrapper)
+                ? (ContentCachingRequestWrapper) req
+                : new ContentCachingRequestWrapper(req);
+
+        String key = buildKey(wrapped);
+
+        if (!limiter.allow(key)) {
+            int retry = Math.max(props.getRetryAfterSeconds(), limiter.secondsUntilWindowReset());
+            res.setStatus(HttpStatus.TOO_MANY_REQUESTS.value()); // 429
+            res.setHeader("Retry-After", String.valueOf(retry));
+            res.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+            res.setHeader("Pragma", "no-cache");
+            res.setHeader("Expires", "0");
+            return;
+        }
+
+        chain.doFilter(wrapped, res);
+    }
+
+    private String buildKey(ContentCachingRequestWrapper req) {
+        String ip = clientIp(req);
+        if (props.getStrategy() == SecurityRateLimitProperties.Strategy.IP_USER) {
+            try {
+                byte[] buf = req.getContentAsByteArray();
+                String body = buf.length == 0
+                        ? new String(req.getInputStream().readAllBytes(), StandardCharsets.UTF_8)
+                        : new String(buf, 0, buf.length, StandardCharsets.UTF_8);
+                if (body != null && !body.isBlank()) {
+                    LoginUsernameProbe probe = objectMapper.readValue(body, LoginUsernameProbe.class);
+                    String user = probe.getUsername();
+                    if (user != null && !user.isBlank()) {
+                        return ip + "|" + user.toLowerCase();
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return ip;
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            int idx = xff.indexOf(',');
+            return (idx > 0 ? xff.substring(0, idx) : xff).trim();
+        }
+        String ip = request.getRemoteAddr();
+        return ip != null ? ip : "0.0.0.0";
+    }
+}
+

--- a/src/main/java/com/renewsim/backend/auth_service/web/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/renewsim/backend/auth_service/web/controller/ApiExceptionHandler.java
@@ -3,8 +3,12 @@ package com.renewsim.backend.auth_service.web.controller;
 import com.renewsim.backend.shared.exception.AuthenticationException;
 import com.renewsim.backend.shared.exception.ResourceConflictException;
 import org.springframework.http.*;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
+import java.nio.file.AccessDeniedException;
 import java.time.Instant;
 import java.util.Map;
 
@@ -27,8 +31,7 @@ public class ApiExceptionHandler {
                         "timestamp", Instant.now().toString(),
                         "status", 401,
                         "error", "Unauthorized",
-                        "message", ex.getMessage()
-                ));
+                        "message", ex.getMessage()));
     }
 
     @ExceptionHandler(ResourceConflictException.class)
@@ -39,8 +42,53 @@ public class ApiExceptionHandler {
                         "timestamp", Instant.now().toString(),
                         "status", 409,
                         "error", "Conflict",
-                        "message", ex.getMessage()
-                ));
+                        "message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<Map<String, Object>> handleBadCredentials(BadCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .headers(noStoreHeaders())
+                .body(Map.of(
+                        "timestamp", Instant.now().toString(),
+                        "status", 401,
+                        "error", "Unauthorized",
+                        "message", "Invalid username or password"));
+    }
+
+    // (Opcional, para que 400 estén bien formateados y no se confundan con 500)
+    @ExceptionHandler({ MethodArgumentNotValidException.class, HttpMessageNotReadableException.class })
+    public ResponseEntity<Map<String, Object>> handleBadRequest(Exception ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .headers(noStoreHeaders())
+                .body(Map.of(
+                        "timestamp", Instant.now().toString(),
+                        "status", 400,
+                        "error", "Bad Request",
+                        "message", "Invalid request payload"));
+    }
+
+    // (Opcional, 403 coherente)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, Object>> handleForbidden(AccessDeniedException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .headers(noStoreHeaders())
+                .body(Map.of(
+                        "timestamp", Instant.now().toString(),
+                        "status", 403,
+                        "error", "Forbidden",
+                        "message", "Access is denied"));
+    }
+
+    // (Recomendado: fallback para no ver 500 “en crudo”)
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGeneric(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .headers(noStoreHeaders())
+                .body(Map.of(
+                        "timestamp", Instant.now().toString(),
+                        "status", 500,
+                        "error", "Internal Server Error",
+                        "message", "Unexpected error"));
     }
 }
-

--- a/src/main/java/com/renewsim/backend/auth_service/web/dto/LoginUsernameProbe.java
+++ b/src/main/java/com/renewsim/backend/auth_service/web/dto/LoginUsernameProbe.java
@@ -1,0 +1,14 @@
+package com.renewsim.backend.auth_service.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LoginUsernameProbe {
+    private String username;
+    private String email;
+
+    public String getUsername() { return username != null ? username : email; }
+    public void setUsername(String username) { this.username = username; }
+    public void setEmail(String email) { this.email = email; }
+}
+

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -57,3 +57,14 @@ security.jwt.allowed-clock-skew-seconds=60
 # Para .properties, lista separada por comas:
 cors.allowed-origins=http://localhost:5173
 
+# =============================
+# AUTH — RATE LIMITING (Brute-force guard)
+# =============================
+auth.rate-limiting.enabled=true
+# Estrategias: IP | IP_USER  (recomendado: IP_USER)
+auth.rate-limiting.strategy=IP_USER
+auth.rate-limiting.max-attempts=3        # Umbral bajo en dev para probar fácil
+auth.rate-limiting.window-seconds=15      # Ventana (segundos)
+auth.rate-limiting.retry-after-seconds=15 # Sugerencia al cliente
+auth.rate-limiting.login-path=/api/v1/auth/login
+

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -59,4 +59,17 @@ security.jwt.expiration-seconds=3600
 security.jwt.not-before-skew-seconds=0
 security.jwt.allowed-clock-skew-seconds=60
 
+# =============================
+# AUTH — RATE LIMITING (Brute-force guard)
+# =============================
+auth.rate-limiting.enabled=true
+# Estrategias: IP | IP_USER  (recomendado: IP_USER)
+auth.rate-limiting.strategy=IP_USER
+auth.rate-limiting.max-attempts=10        # Umbral bajo en dev para probar fácil
+auth.rate-limiting.window-seconds=60      # Ventana (segundos)
+auth.rate-limiting.retry-after-seconds=60 # Sugerencia al cliente
+
+
+
+
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,16 @@ auth:
       - delete:simulations
       - read:users
       - manage:users
+ # =============================
+ # RATE LIMITING (Brute-force guard)
+ # =============================
+  rate-limiting:
+    enabled: true                # on/off global
+    strategy: IP_USER            # IP | IP_USER (recomendada para login)
+    max-attempts: 5              # N intentos permitidos en la ventana
+    window-seconds: 60           # T (segundos) de la ventana fija
+    retry-after-seconds: 60      # sugerencia al cliente para reintentar
+    login-path: /api/v1/auth/login     
 
 # =============================
 # CORS CONFIG

--- a/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterIT.java
+++ b/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterIT.java
@@ -1,0 +1,87 @@
+package com.renewsim.backend.auth_service.infrastructure.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.auth_service.config.SecurityRateLimitProperties;
+import com.renewsim.backend.auth_service.application.port.in.AuthUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "auth.rate-limiting.enabled=true",
+        "auth.rate-limiting.strategy=IP_USER",
+        "auth.rate-limiting.max-attempts=2",
+        "auth.rate-limiting.window-seconds=3",
+        "auth.rate-limiting.retry-after-seconds=3",
+        "auth.rate-limiting.login-path=/api/v1/auth/login"
+})
+class LoginRateLimitingFilterIT {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    SecurityRateLimitProperties props;
+
+    @MockBean
+    AuthUseCase authUseCase;
+
+    private String jsonBody(String usernameOrEmail, String password) throws Exception {
+        var dto = new java.util.HashMap<String, Object>();
+        dto.put("username", usernameOrEmail);
+        dto.put("email", usernameOrEmail);
+        dto.put("password", password);
+        return objectMapper.writeValueAsString(dto);
+    }
+
+    @Test
+    @DisplayName("N+1 intentos dentro de ventana → 429; tras ventana → vuelve a 401/200 normal")
+    void rateLimit_then_reset_window() throws Exception {
+        when(authUseCase.login(any()))
+                .thenThrow(new BadCredentialsException("invalid"));
+        String body = jsonBody("john.doe", "InvalidPwd#123");
+
+        var req = post("/api/v1/auth/login")
+                .with(r -> {
+                    r.setRemoteAddr("127.0.0.1");
+                    return r;
+                })
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(body);
+
+        mockMvc.perform(req).andExpect(status().isUnauthorized());
+        mockMvc.perform(req).andExpect(status().isUnauthorized());
+
+        mockMvc.perform(req)
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists("Retry-After"))
+                .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("no-store")))
+                .andExpect(header().string("Pragma", "no-cache"))
+                .andExpect(header().string("Expires", "0"));
+
+        Thread.sleep((props.getWindowSeconds() + 1L) * 1000);
+
+        mockMvc.perform(req).andExpect(status().isUnauthorized());
+    }
+
+}

--- a/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterUnitTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterUnitTest.java
@@ -1,0 +1,60 @@
+package com.renewsim.backend.auth_service.infrastructure.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.auth_service.config.SecurityRateLimitProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoginRateLimitingFilterUnitTest {
+
+    @Test
+    @DisplayName("No consume el body cuando strategy=IP_USER y el buffer está vacío (ContentCachingRequestWrapper)")
+    void doesNotConsumeBody_whenStrategyIsIpUser_andCacheIsEmpty() throws ServletException, IOException {
+        SecurityRateLimitProperties props = new SecurityRateLimitProperties();
+        props.setEnabled(true);
+        props.setStrategy(SecurityRateLimitProperties.Strategy.IP_USER);
+        props.setMaxAttempts(2);
+        props.setWindowSeconds(3);
+        props.setRetryAfterSeconds(3);
+        props.setLoginPath("/api/v1/auth/login");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        LoginRateLimitingFilter filter = new LoginRateLimitingFilter(props, objectMapper);
+
+        String json = """
+                {"username":"john.doe","email":"john.doe@example.com","password":"ValidPwd#2024"}
+                """;
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+        request.setRemoteAddr("127.0.0.1");
+        request.setContentType("application/json");
+        request.setContent(json.getBytes(StandardCharsets.UTF_8));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        AtomicReference<String> bodySeenDownstream = new AtomicReference<>();
+        FilterChain chain = (req, res) -> {
+            HttpServletRequest r = (HttpServletRequest) req;
+            String seen = new String(r.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            bodySeenDownstream.set(seen);
+        };
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(json, bodySeenDownstream.get(), "El body debería estar intacto para el controller");
+        assertEquals(200, response.getStatus() == 0 ? 200 : response.getStatus(),
+                "En el primer intento no se debe bloquear (status 200 por defecto en MockHttpServletResponse)");
+    }
+}
+


### PR DESCRIPTION
# feat(security): add rate limiting for /auth/login

## What / Why
- Introduce brute-force protection on `/auth/login` using a fixed-window rate limiter with configurable thresholds.
- Returns **429 Too Many Requests** with `Retry-After` to guide clients on backoff.
- Strategy selectable: **IP** or **IP+username** to balance fairness vs. abuse resistance.

## Scope
- [x] Backend
- [x] Tests
- [x] Docs (properties & behavior)

## Changes
- New `SecurityRateLimitProperties` (`auth.rate-limiting.*`)
- `LoginRateLimiter` (thread-safe fixed window)
- `LoginRateLimitingFilter` with `Retry-After`, `Cache-Control: no-store`
- Wiring in `SecurityFilterChain` (`addFilterBefore(...)`)
- IT: `LoginRateLimitingFilterIT`

## Acceptance Criteria
- GIVEN more than **N** login attempts within **T** seconds  
  WHEN the client performs the **N+1** attempt  
  THEN the API responds **429 Too Many Requests** with a `Retry-After` header.
- GIVEN the time window has passed  
  WHEN a new login attempt is made  
  THEN the API behaves normally (401/200).

## Test Plan
- Integration (MockMvc):
  - Simulate **N** failed attempts → 401
  - Attempt **N+1** within `windowSeconds` → **429** + `Retry-After`
  - Sleep `windowSeconds + 1` → next attempt returns 401

## Config
```yaml
auth:
  rate-limiting:
    enabled: true
    strategy: IP        # IP | IP_USER
    max-attempts: 5
    window-seconds: 60
    retry-after-seconds: 60
    login-path: /api/v1/auth/login
```

##Checklist 

- [ ] Unit/IT tests added
- [ ]  No new warnings
- [ ]  README-auth updated (rate limit section)

---

# 11) Mensajes de commit sugeridos

1. `feat(security): add rate limiting filter for /auth/login with Retry-After`
2. `test(security): assert 429 after exceeding login attempts and reset after window`
3. `docs(auth): document rate-limiting properties and behavior`

---