### PR TITLE
fix(security): unify rate-limiting prefix and enforce binding test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,34 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: 'maven'  
+          cache: 'maven'
 
+      # Build + Unit & IT tests + Jacoco
       - name: Build & test (with JaCoCo)
+        run: mvn -B -ntp -Dspring.profiles.active=test clean verify jacoco:report
+
+      # ✅ Gate: SecurityRateLimitPropertiesBindingTest must exist AND pass (0 failures/errors)
+      - name: Ensure binding test executed and passed
         run: |
-          mvn -B -ntp clean verify jacoco:report
+          set -euo pipefail
+
+          # Busca el reporte Surefire de ese test
+          REPORT_FILE=$(ls -1 **/target/surefire-reports/TEST-*.xml | grep -E "SecurityRateLimitPropertiesBindingTest" || true)
+
+          if [ -z "${REPORT_FILE}" ]; then
+            echo "::error::Missing SecurityRateLimitPropertiesBindingTest report in surefire-reports"
+            exit 1
+          fi
+
+          echo "Found report: ${REPORT_FILE}"
+          # Verifica que el test se ejecutó y pasó con 0 failures y 0 errors
+          if ! grep -Eq 'tests="[1-9][0-9]*".*failures="0".*errors="0"' "${REPORT_FILE}"; then
+            echo "::error::SecurityRateLimitPropertiesBindingTest did not pass successfully"
+            echo "---- Report content ----"
+            cat "${REPORT_FILE}" || true
+            echo "------------------------"
+            exit 1
+          fi
 
       - name: Upload surefire & failsafe reports (always)
         if: ${{ always() }}
@@ -52,3 +75,4 @@ jobs:
         with:
           name: jacoco-report
           path: target/site/jacoco
+

--- a/src/main/java/com/renewsim/backend/auth_service/config/RateLimitingConfig.java
+++ b/src/main/java/com/renewsim/backend/auth_service/config/RateLimitingConfig.java
@@ -1,0 +1,11 @@
+package com.renewsim.backend.auth_service.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SecurityRateLimitProperties.class)
+public class RateLimitingConfig {
+    // Empty on purpose: only enables @ConfigurationProperties bean
+
+}

--- a/src/main/java/com/renewsim/backend/auth_service/config/SecurityRateLimitProperties.java
+++ b/src/main/java/com/renewsim/backend/auth_service/config/SecurityRateLimitProperties.java
@@ -1,11 +1,15 @@
 package com.renewsim.backend.auth_service.config;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
 
 @Getter
 @Setter
@@ -23,13 +27,14 @@ public class SecurityRateLimitProperties {
     @Min(1)
     private int maxAttempts = 5;
 
-    @Min(1)
-    private int windowSeconds = 60;
-
-    @Min(0)
-    private int retryAfterSeconds = 60;
+    @NotNull
+    private Duration window = Duration.ofSeconds(60);
 
     @NotNull
+    private Duration retryAfter = Duration.ofSeconds(60);
+
+    @NotBlank
+    @Pattern(regexp = "^/.*", message = "loginPath must start with '/'")
     private String loginPath = "/api/v1/auth/login";
 }
 

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/SecurityExtraFiltersConfig.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/SecurityExtraFiltersConfig.java
@@ -2,25 +2,26 @@ package com.renewsim.backend.auth_service.infrastructure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.auth_service.config.SecurityRateLimitProperties;
+import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimiter;
 import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimitingFilter;
-
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-
 @Configuration
-@RequiredArgsConstructor
-@EnableConfigurationProperties(SecurityRateLimitProperties.class)
 public class SecurityExtraFiltersConfig {
 
     @Bean
-    @ConditionalOnProperty(prefix = "auth.rate-limiting", name = "enabled", havingValue = "true", matchIfMissing = true)
-    public LoginRateLimitingFilter loginRateLimitingFilter(SecurityRateLimitProperties props, ObjectMapper objectMapper) {
-        return new LoginRateLimitingFilter(props, objectMapper);
-    }    
+    public LoginRateLimiter loginRateLimiter(SecurityRateLimitProperties props) {
+        int windowSeconds = Math.toIntExact(props.getWindow().toSeconds());
+        int maxAttempts = props.getMaxAttempts();
+        return new LoginRateLimiter(windowSeconds, maxAttempts);
+    }
+
+    @Bean
+    public LoginRateLimitingFilter loginRateLimitingFilter(SecurityRateLimitProperties props,
+                                                           ObjectMapper objectMapper,
+                                                           LoginRateLimiter limiter) {
+        return new LoginRateLimitingFilter(props, objectMapper, limiter);
+    }
 }
 

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimiter.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimiter.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-final class LoginRateLimiter {
+public final class LoginRateLimiter {   // ← public
 
     private static final class WindowCounter {
         final long windowStartEpochSec;
@@ -19,11 +19,12 @@ final class LoginRateLimiter {
     private final int windowSeconds;
     private final int maxAttempts;
 
-    LoginRateLimiter(int windowSeconds, int maxAttempts) {
+    public LoginRateLimiter(int windowSeconds, int maxAttempts) { 
         this.windowSeconds = windowSeconds;
         this.maxAttempts = maxAttempts;
     }
-    boolean allow(String key) {
+
+    public boolean allow(String key) {
         Objects.requireNonNull(key, "key");
         final long nowSec = Instant.now().getEpochSecond();
         final long windowStart = nowSec - (nowSec % windowSeconds);
@@ -39,14 +40,15 @@ final class LoginRateLimiter {
         WindowCounter wc = counters.get(key);
         return wc.count.get() <= maxAttempts;
     }
-    int secondsUntilWindowReset() {
+
+    public int secondsUntilWindowReset() {
         final long nowSec = Instant.now().getEpochSecond();
         final long nextWindowStart = nowSec - (nowSec % windowSeconds) + windowSeconds;
         long delta = nextWindowStart - nowSec;
         return (int) Math.max(0, delta);
     }
 
-    void resetAll() {
+    public void resetAll() {
         counters.clear();
     }
 }

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilter.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilter.java
@@ -21,17 +21,16 @@ import java.nio.charset.StandardCharsets;
 public class LoginRateLimitingFilter extends OncePerRequestFilter {
 
     private final SecurityRateLimitProperties props;
-    private final LoginRateLimiter limiter;
+    private final LoginRateLimiter limiter;     
     private final ObjectMapper objectMapper;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
-    public LoginRateLimitingFilter(SecurityRateLimitProperties props, ObjectMapper objectMapper) {
+    public LoginRateLimitingFilter(SecurityRateLimitProperties props,
+                                   ObjectMapper objectMapper,
+                                   LoginRateLimiter limiter) {
         this.props = props;
         this.objectMapper = objectMapper;
-        // Adapt: Duration -> seconds
-        int windowSeconds = Math.toIntExact(props.getWindow().toSeconds());
-        int maxAttempts = props.getMaxAttempts();
-        this.limiter = new LoginRateLimiter(windowSeconds, maxAttempts);
+        this.limiter = limiter;
     }
 
     @Override
@@ -53,12 +52,11 @@ public class LoginRateLimitingFilter extends OncePerRequestFilter {
 
         if (!limiter.allow(key)) {
             int retry = Math.max(
-                Math.toIntExact(props.getRetryAfter().toSeconds()),
-                limiter.secondsUntilWindowReset()
+                    Math.toIntExact(props.getRetryAfter().toSeconds()),
+                    limiter.secondsUntilWindowReset()
             );
             res.setStatus(HttpStatus.TOO_MANY_REQUESTS.value()); // 429
             res.setHeader("Retry-After", String.valueOf(retry));
-            // Defensa en profundidad para respuestas de auth:
             res.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
             res.setHeader("Pragma", "no-cache");
             res.setHeader("Expires", "0");
@@ -83,7 +81,6 @@ public class LoginRateLimitingFilter extends OncePerRequestFilter {
                     }
                 }
             } catch (Exception ignored) {
-                // deliberately ignore parsing errors to avoid leaking info/timing
             }
         }
         return ip;
@@ -98,3 +95,4 @@ public class LoginRateLimitingFilter extends OncePerRequestFilter {
         return request.getRemoteAddr() != null ? request.getRemoteAddr() : "0.0.0.0";
     }
 }
+

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilter.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilter.java
@@ -28,20 +28,23 @@ public class LoginRateLimitingFilter extends OncePerRequestFilter {
     public LoginRateLimitingFilter(SecurityRateLimitProperties props, ObjectMapper objectMapper) {
         this.props = props;
         this.objectMapper = objectMapper;
-        this.limiter = new LoginRateLimiter(props.getWindowSeconds(), props.getMaxAttempts());
+        // Adapt: Duration -> seconds
+        int windowSeconds = Math.toIntExact(props.getWindow().toSeconds());
+        int maxAttempts = props.getMaxAttempts();
+        this.limiter = new LoginRateLimiter(windowSeconds, maxAttempts);
     }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        if (!props.isEnabled())
-            return true;
-        String path = request.getRequestURI(); 
+        if (!props.isEnabled()) return true;
+        String path = request.getRequestURI();
         return !pathMatcher.match(props.getLoginPath(), path);
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
             throws ServletException, IOException {
+
         ContentCachingRequestWrapper wrapped = (req instanceof ContentCachingRequestWrapper)
                 ? (ContentCachingRequestWrapper) req
                 : new ContentCachingRequestWrapper(req);
@@ -49,9 +52,13 @@ public class LoginRateLimitingFilter extends OncePerRequestFilter {
         String key = buildKey(wrapped);
 
         if (!limiter.allow(key)) {
-            int retry = Math.max(props.getRetryAfterSeconds(), limiter.secondsUntilWindowReset());
+            int retry = Math.max(
+                Math.toIntExact(props.getRetryAfter().toSeconds()),
+                limiter.secondsUntilWindowReset()
+            );
             res.setStatus(HttpStatus.TOO_MANY_REQUESTS.value()); // 429
             res.setHeader("Retry-After", String.valueOf(retry));
+            // Defensa en profundidad para respuestas de auth:
             res.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
             res.setHeader("Pragma", "no-cache");
             res.setHeader("Expires", "0");
@@ -76,6 +83,7 @@ public class LoginRateLimitingFilter extends OncePerRequestFilter {
                     }
                 }
             } catch (Exception ignored) {
+                // deliberately ignore parsing errors to avoid leaking info/timing
             }
         }
         return ip;

--- a/src/main/java/com/renewsim/backend/shared/observability/CorrelationIdFilter.java
+++ b/src/main/java/com/renewsim/backend/shared/observability/CorrelationIdFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -13,19 +15,24 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @Component
 public class CorrelationIdFilter extends OncePerRequestFilter {
 
     public static final String HEADER = "X-Correlation-Id";
     public static final String MDC_KEY = "correlationId";
-
     private static final Pattern SAFE = Pattern.compile("^[A-Za-z0-9._\\-]{1,128}$");
+
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return true; // evita doble logging en async
+    }
 
     @Override
     protected void doFilterInternal(
             @NonNull HttpServletRequest request,
             @NonNull HttpServletResponse response,
-            @NonNull FilterChain filterChain
+            @NonNull FilterChain chain
     ) throws ServletException, IOException {
 
         String correlationId = extractOrGenerate(request);
@@ -33,7 +40,7 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
         response.setHeader(HEADER, correlationId);
 
         try {
-            filterChain.doFilter(request, response);
+            chain.doFilter(request, response);
         } finally {
             MDC.remove(MDC_KEY);
         }
@@ -54,3 +61,4 @@ public class CorrelationIdFilter extends OncePerRequestFilter {
         return MDC.get(MDC_KEY);
     }
 }
+

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,40 +1,88 @@
-<configuration>
+<configuration scan="true" scanPeriod="60 seconds">
 
-    <!-- Console pattern con correlationId -->
-    <property name="CONSOLE_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - corr=%X{correlationId} - %msg%n"/>
+    <!-- Paths -->
+    <property name="LOG_DIR" value="logs"/>
+    <property name="LOG_FILE" value="${LOG_DIR}/application.log"/>
 
-    <!-- File pattern con correlationId -->
-    <property name="FILE_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - corr=%X{correlationId} - %msg%n"/>
+    <!-- Pattern (ISO-8601 + MDC correlationId con fallback) -->
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} [%thread] %-5level %logger{36} traceId=%X{correlationId:-N/A} - %msg%n"/>
 
-    <!-- File appender con rotación diaria (7 días) -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/application.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/application-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>7</maxHistory>
-        </rollingPolicy>
-        <encoder>
-            <pattern>${FILE_PATTERN}</pattern>
-        </encoder>
-    </appender>
-
-    <!-- Console appender -->
+    <!-- Console (sin condicionales aquí) -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>${CONSOLE_PATTERN}</pattern>
+            <!-- Si quieres colores, cambia a %highlight como en dev -->
+            <pattern>${LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 
-    <!-- Ejemplo de logger específico (ajusta al package real de tu app) -->
+    <!-- File rolling diario + compresión + tope -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/application-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Async wrappers -->
+    <appender name="ASYNC_CONSOLE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="CONSOLE"/>
+    </appender>
+
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>16384</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="FILE"/>
+    </appender>
+
+    <conversionRule conversionWord="ex" converterClass="ch.qos.logback.classic.pattern.ThrowableProxyConverter"/>
+
+    <!-- Loggers -->
+    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework.security" level="INFO"/>
+    <logger name="org.hibernate.SQL" level="WARN"/>
     <logger name="com.renewsim" level="DEBUG"/>
 
-    <!-- Root logger -->
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
-    </root>
+    <!-- DEV / LOCAL -->
+    <springProfile name="dev,local">
+        <!-- Patrón con colores solo para consola en dev/local -->
+        <appender name="CONSOLE_DEV" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{36})
+                    traceId=%X{correlationId:-N/A} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <appender name="ASYNC_CONSOLE_DEV" class="ch.qos.logback.classic.AsyncAppender">
+            <queueSize>8192</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <neverBlock>true</neverBlock>
+            <appender-ref ref="CONSOLE_DEV"/>
+        </appender>
+
+        <root level="DEBUG">
+            <appender-ref ref="ASYNC_CONSOLE_DEV"/>
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+    </springProfile>
+
+    <!-- Otros perfiles (test, prod, etc.) -->
+    <springProfile name="!dev,!local">
+        <root level="INFO">
+            <appender-ref ref="ASYNC_CONSOLE"/>
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+    </springProfile>
 
 </configuration>
+
+
 

--- a/src/test/java/com/renewsim/backend/auth_service/config/SecurityRateLimitPropertiesBindingTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/config/SecurityRateLimitPropertiesBindingTest.java
@@ -1,11 +1,13 @@
 package com.renewsim.backend.auth_service.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class SecurityRateLimitPropertiesBindingTest {
 
@@ -13,14 +15,15 @@ class SecurityRateLimitPropertiesBindingTest {
             .withPropertyValues(
                     "security.rate-limiting.enabled=true",
                     "security.rate-limiting.strategy=IP_USER",
-                    "security.rate-limiting.window-seconds=60",
+                    "security.rate-limiting.window=60s",
                     "security.rate-limiting.max-attempts=5",
-                    "security.rate-limiting.login-path=/api/v1/auth/login"
-            )
+                    "security.rate-limiting.retry-after=60s",
+                    "security.rate-limiting.login-path=/api/v1/auth/login")
             .withUserConfiguration(BindingConfig.class);
 
     @EnableConfigurationProperties(SecurityRateLimitProperties.class)
-    static class BindingConfig {}
+    static class BindingConfig {
+    }
 
     @Test
     @DisplayName("bind SecurityRateLimitProperties from application context")
@@ -29,8 +32,9 @@ class SecurityRateLimitPropertiesBindingTest {
             var props = ctx.getBean(SecurityRateLimitProperties.class);
             assertThat(props.isEnabled()).isTrue();
             assertThat(props.getStrategy().name()).isEqualTo("IP_USER");
-            assertThat(props.getWindowSeconds()).isEqualTo(60);
+            assertThat(props.getWindow()).isEqualTo(Duration.ofSeconds(60));
             assertThat(props.getMaxAttempts()).isEqualTo(5);
+            assertThat(props.getRetryAfter()).isEqualTo(Duration.ofSeconds(60));
             assertThat(props.getLoginPath()).isEqualTo("/api/v1/auth/login");
         });
     }

--- a/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterIT.java
+++ b/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterIT.java
@@ -24,26 +24,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
-        "auth.rate-limiting.enabled=true",
-        "auth.rate-limiting.strategy=IP_USER",
-        "auth.rate-limiting.max-attempts=2",
-        "auth.rate-limiting.window-seconds=3",
-        "auth.rate-limiting.retry-after-seconds=3",
-        "auth.rate-limiting.login-path=/api/v1/auth/login"
+        // ✅ Prefijo nuevo + Duration
+        "security.rate-limiting.enabled=true",
+        "security.rate-limiting.strategy=IP_USER",
+        "security.rate-limiting.max-attempts=2",
+        "security.rate-limiting.window=3s",
+        "security.rate-limiting.retry-after=3s",
+        "security.rate-limiting.login-path=/api/v1/auth/login"
 })
 class LoginRateLimitingFilterIT {
 
-    @Autowired
-    MockMvc mockMvc;
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired SecurityRateLimitProperties props;
 
-    @Autowired
-    ObjectMapper objectMapper;
-
-    @Autowired
-    SecurityRateLimitProperties props;
-
-    @MockBean
-    AuthUseCase authUseCase;
+    @MockBean AuthUseCase authUseCase;
 
     private String jsonBody(String usernameOrEmail, String password) throws Exception {
         var dto = new java.util.HashMap<String, Object>();
@@ -54,17 +49,13 @@ class LoginRateLimitingFilterIT {
     }
 
     @Test
-    @DisplayName("N+1 intentos dentro de ventana → 429; tras ventana → vuelve a 401/200 normal")
+    @DisplayName("N+1 attempts within window → 429; after window → back to 401/200")
     void rateLimit_then_reset_window() throws Exception {
-        when(authUseCase.login(any()))
-                .thenThrow(new BadCredentialsException("invalid"));
+        when(authUseCase.login(any())).thenThrow(new BadCredentialsException("invalid"));
         String body = jsonBody("john.doe", "InvalidPwd#123");
 
         var req = post("/api/v1/auth/login")
-                .with(r -> {
-                    r.setRemoteAddr("127.0.0.1");
-                    return r;
-                })
+                .with(r -> { r.setRemoteAddr("127.0.0.1"); return r; })
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(body);
@@ -79,9 +70,9 @@ class LoginRateLimitingFilterIT {
                 .andExpect(header().string("Pragma", "no-cache"))
                 .andExpect(header().string("Expires", "0"));
 
-        Thread.sleep((props.getWindowSeconds() + 1L) * 1000);
+        long sleepMs = props.getWindow().toMillis() + 250; // pequeño margen
+        Thread.sleep(sleepMs);
 
         mockMvc.perform(req).andExpect(status().isUnauthorized());
     }
-
 }

--- a/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterIT.java
+++ b/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterIT.java
@@ -70,7 +70,7 @@ class LoginRateLimitingFilterIT {
                 .andExpect(header().string("Pragma", "no-cache"))
                 .andExpect(header().string("Expires", "0"));
 
-        long sleepMs = props.getWindow().toMillis() + 250; // pequeño margen
+        long sleepMs = props.getWindow().toMillis() + 250; 
         Thread.sleep(sleepMs);
 
         mockMvc.perform(req).andExpect(status().isUnauthorized());

--- a/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterUnitTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterUnitTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class LoginRateLimitingFilterUnitTest {
 
     @Test
-    @DisplayName("IP_USER: no consumes body when buffer is empty (buildKey should not break request body)")
+    @DisplayName("IP_USER: does not consume body when buffer is empty (buildKey should not break request body)")
     void ipUser_doesNotConsumeEmptyBody() throws ServletException, IOException {
         SecurityRateLimitProperties props = new SecurityRateLimitProperties();
         props.setEnabled(true);
@@ -29,7 +29,12 @@ class LoginRateLimitingFilterUnitTest {
         props.setRetryAfter(Duration.ofSeconds(3));
         props.setLoginPath("/api/v1/auth/login");
 
-        LoginRateLimitingFilter filter = new LoginRateLimitingFilter(props, new ObjectMapper());
+        LoginRateLimiter limiter = new LoginRateLimiter(
+                Math.toIntExact(props.getWindow().toSeconds()),
+                props.getMaxAttempts()
+        );
+
+        LoginRateLimitingFilter filter = new LoginRateLimitingFilter(props, new ObjectMapper(), limiter);
 
         MockHttpServletRequest raw = new MockHttpServletRequest("POST", "/api/v1/auth/login");
         raw.setRemoteAddr("127.0.0.1");
@@ -37,15 +42,15 @@ class LoginRateLimitingFilterUnitTest {
         raw.setContent(new byte[0]); // vacío
 
         ContentCachingRequestWrapper wrapped = new ContentCachingRequestWrapper(raw);
-
         MockHttpServletResponse res = new MockHttpServletResponse();
         FilterChain chain = new MockFilterChain();
 
         filter.doFilter(wrapped, res, chain);
 
         assertThat(wrapped.getContentAsByteArray()).isEmpty();
-        assertThat(res.getStatus()).isIn(0, 200); // 0 = no escrito; depende del chain
+        assertThat(res.getStatus()).isIn(0, 200);
     }
 }
+
 
 

--- a/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterUnitTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/infrastructure/security/LoginRateLimitingFilterUnitTest.java
@@ -4,57 +4,48 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.auth_service.config.SecurityRateLimitProperties;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.atomic.AtomicReference;
+import java.time.Duration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LoginRateLimitingFilterUnitTest {
 
     @Test
-    @DisplayName("No consume el body cuando strategy=IP_USER y el buffer está vacío (ContentCachingRequestWrapper)")
-    void doesNotConsumeBody_whenStrategyIsIpUser_andCacheIsEmpty() throws ServletException, IOException {
+    @DisplayName("IP_USER: no consumes body when buffer is empty (buildKey should not break request body)")
+    void ipUser_doesNotConsumeEmptyBody() throws ServletException, IOException {
         SecurityRateLimitProperties props = new SecurityRateLimitProperties();
         props.setEnabled(true);
         props.setStrategy(SecurityRateLimitProperties.Strategy.IP_USER);
-        props.setMaxAttempts(2);
-        props.setWindowSeconds(3);
-        props.setRetryAfterSeconds(3);
+        props.setMaxAttempts(5);
+        props.setWindow(Duration.ofSeconds(3));
+        props.setRetryAfter(Duration.ofSeconds(3));
         props.setLoginPath("/api/v1/auth/login");
 
-        ObjectMapper objectMapper = new ObjectMapper();
+        LoginRateLimitingFilter filter = new LoginRateLimitingFilter(props, new ObjectMapper());
 
-        LoginRateLimitingFilter filter = new LoginRateLimitingFilter(props, objectMapper);
+        MockHttpServletRequest raw = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+        raw.setRemoteAddr("127.0.0.1");
+        raw.setContentType("application/json");
+        raw.setContent(new byte[0]); // vacío
 
-        String json = """
-                {"username":"john.doe","email":"john.doe@example.com","password":"ValidPwd#2024"}
-                """;
-        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
-        request.setRemoteAddr("127.0.0.1");
-        request.setContentType("application/json");
-        request.setContent(json.getBytes(StandardCharsets.UTF_8));
+        ContentCachingRequestWrapper wrapped = new ContentCachingRequestWrapper(raw);
 
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = new MockFilterChain();
 
-        AtomicReference<String> bodySeenDownstream = new AtomicReference<>();
-        FilterChain chain = (req, res) -> {
-            HttpServletRequest r = (HttpServletRequest) req;
-            String seen = new String(r.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            bodySeenDownstream.set(seen);
-        };
+        filter.doFilter(wrapped, res, chain);
 
-        filter.doFilter(request, response, chain);
-
-        assertEquals(json, bodySeenDownstream.get(), "El body debería estar intacto para el controller");
-        assertEquals(200, response.getStatus() == 0 ? 200 : response.getStatus(),
-                "En el primer intento no se debe bloquear (status 200 por defecto en MockHttpServletResponse)");
+        assertThat(wrapped.getContentAsByteArray()).isEmpty();
+        assertThat(res.getStatus()).isIn(0, 200); // 0 = no escrito; depende del chain
     }
 }
+
 

--- a/src/test/java/com/renewsim/backend/shared/observability/CorrelationIdFilterTest.java
+++ b/src/test/java/com/renewsim/backend/shared/observability/CorrelationIdFilterTest.java
@@ -1,27 +1,31 @@
 package com.renewsim.backend.shared.observability;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.slf4j.MDC;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-
-import org.jboss.logging.MDC;
 
 class CorrelationIdFilterTest {
 
     private final CorrelationIdFilter filter = new CorrelationIdFilter();
 
     @Test
+    @DisplayName("Propagates incoming header as X-Correlation-Id and clears MDC after chain")
     void shouldPropagateIncomingHeader() throws Exception {
         var req = new MockHttpServletRequest();
         var res = new MockHttpServletResponse();
@@ -30,23 +34,25 @@ class CorrelationIdFilterTest {
         filter.doFilter(req, res, new MockFilterChain());
 
         assertThat(res.getHeader(CorrelationIdFilter.HEADER)).isEqualTo("abc-123");
-        assertThat(org.slf4j.MDC.get(CorrelationIdFilter.MDC_KEY)).isNull();
+        assertThat(MDC.get(CorrelationIdFilter.MDC_KEY)).isNull();
     }
 
     @Test
+    @DisplayName("Generates a correlation id if header is missing")
     void shouldGenerateWhenMissing() throws Exception {
         var req = new MockHttpServletRequest();
         var res = new MockHttpServletResponse();
 
         filter.doFilter(req, res, new MockFilterChain());
 
-        assertThat(res.getHeader(CorrelationIdFilter.HEADER)).isNotBlank();
+        String echoed = res.getHeader(CorrelationIdFilter.HEADER);
+        assertThat(echoed).isNotBlank();
+        assertThat(echoed).matches("^[0-9a-f\\-]{36}$");
     }
 
     @Test
-    @DisplayName("Sets safe incoming correlation id and clears MDC")
+    @DisplayName("Accepts safe incoming correlation id and clears MDC at the end")
     void usesIncomingSafeHeader() throws Exception {
-        var filter = new CorrelationIdFilter();
         var req = mock(HttpServletRequest.class);
         var res = mock(HttpServletResponse.class);
         var chain = mock(FilterChain.class);
@@ -55,7 +61,7 @@ class CorrelationIdFilterTest {
 
         filter.doFilter(req, res, chain);
 
-        verify(res).setHeader(CorrelationIdFilter.HEADER, "abc-123_ZZ");
+        verify(res).setHeader(eq(CorrelationIdFilter.HEADER), eq("abc-123_ZZ"));
         verify(chain).doFilter(req, res);
         assertThat(MDC.get(CorrelationIdFilter.MDC_KEY)).isNull();
     }
@@ -63,19 +69,21 @@ class CorrelationIdFilterTest {
     @Test
     @DisplayName("Generates UUID when incoming header is invalid and echoes it")
     void generatesWhenInvalid() throws Exception {
-        var filter = new CorrelationIdFilter();
         var req = mock(HttpServletRequest.class);
         var res = mock(HttpServletResponse.class);
         var chain = mock(FilterChain.class);
 
         when(req.getHeader(CorrelationIdFilter.HEADER)).thenReturn("   ../\\bad   ");
 
-        var headerCaptor = ArgumentCaptor.forClass(String.class);
-        doNothing().when(res).setHeader(eq(CorrelationIdFilter.HEADER), headerCaptor.capture());
+        var echoedRef = new AtomicReference<String>();
+        doAnswer(inv -> {
+            echoedRef.set(inv.getArgument(1, String.class));
+            return null;
+        }).when(res).setHeader(eq(CorrelationIdFilter.HEADER), any(String.class));
 
         filter.doFilter(req, res, chain);
 
-        String echoed = headerCaptor.getValue();
+        String echoed = echoedRef.get();
         assertThat(echoed).isNotBlank();
         assertThat(echoed).matches("^[0-9a-f\\-]{36}$");
         verify(chain).doFilter(req, res);
@@ -83,18 +91,22 @@ class CorrelationIdFilterTest {
     }
 
     @Test
-    @DisplayName("Puts correlation id in MDC and clears after")
-    void putsAndClearsMdc() throws Exception {
-        var filter = new CorrelationIdFilter();
-        var req = mock(HttpServletRequest.class);
-        var res = mock(HttpServletResponse.class);
-        var chain = mock(FilterChain.class);
+    @DisplayName("Puts correlation id into MDC during chain and clears it afterwards")
+    void putsMdcDuringChainAndClearsAfter() throws Exception {
+        var req = new MockHttpServletRequest();
+        var res = new MockHttpServletResponse();
 
-        when(req.getHeader(CorrelationIdFilter.HEADER)).thenReturn(null);
+        FilterChain assertingChain = new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response)
+                    throws IOException, ServletException {
+                String cid = MDC.get(CorrelationIdFilter.MDC_KEY);
+                assertThat(cid).isNotBlank();
+            }
+        };
 
-        filter.doFilter(req, res, chain);
+        filter.doFilter(req, res, assertingChain);
 
-        verify(chain, times(1)).doFilter(req, res);
         assertThat(MDC.get(CorrelationIdFilter.MDC_KEY)).isNull();
     }
 }


### PR DESCRIPTION

---

## What / Why

- Unify configuration prefix for rate limiting to `security.rate-limiting.*` to avoid drift and confusion.  
- Migrate `SecurityRateLimitProperties` to use `Duration` (`window`, `retry-after`) for more expressive config.  
- Ensure correlation id (`X-Correlation-Id`) is logged consistently in all log patterns.  
- Add CI gate to enforce execution and success of `SecurityRateLimitPropertiesBindingTest`.  

---

## Scope

- [x] Backend  
- [ ] Frontend  
- [x] Tests  
- [x] Docs  
- [ ] DevOps / Infra  

---

## Changes

- [x] `SecurityRateLimitProperties` migrated to `Duration` (`window`, `retry-after`).  
- [x] `LoginRateLimiter` made public and injectable as Spring bean.  
- [x] `LoginRateLimitingFilter` updated to receive `LoginRateLimiter` via DI.  
- [x] `CorrelationIdFilter` ensures MDC + header propagation and cleared after chain.  
- [x] `logback-spring.xml` updated with `%X{correlationId:-N/A}` and `<springProfile>` instead of `<if>`.  
- [x] Tests updated (`SecurityRateLimitPropertiesBindingTest`, `LoginRateLimitingFilterUnitTest`).  
- [x] CI workflow extended to fail if binding test missing or failing.  

---

## Acceptance Criteria

- **GIVEN** `application.yml` with `security.rate-limiting.*`  
  **WHEN** context loads  
  **THEN** `SecurityRateLimitProperties` binds successfully (Durations parsed correctly).  

- **GIVEN** incoming request with/without `X-Correlation-Id`  
  **WHEN** processed through filters  
  **THEN** correlation id is present in logs and response header.  

- **GIVEN** repeated login attempts  
  **WHEN** maxAttempts exceeded within window  
  **THEN** `429 Too Many Requests` is returned with `Retry-After`.  

- CI fails if `SecurityRateLimitPropertiesBindingTest` is missing or red.  

---

## Test Plan

- [x] Unit tests (binding, limiter behavior, filter buildKey edge cases).  
- [x] Integration tests (401/403/429 responses, headers, cache-control).  
- [ ] E2E tests (auth flows) — covered in later phase.  

---

## Checklist

- [x] Unit tests added/updated  
- [x] No new warnings  
- [x] README/Docs updated (rate limiting config, logging)  
