### PR TITLE
Feat/task 1.9 openapi swagger config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,6 @@
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                 </configuration>
-              
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/config/SecurityConfig.java
@@ -56,16 +56,22 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        // OpenAPI/Swagger endpoints
                         .requestMatchers(
-                                "/v3/api-docs/**",
-                                "/v3/api-docs.yaml",
+                                "/api-docs",
+                                "/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html")
+                                "/swagger-ui.html",
+                                "/swagger-resources/**",
+                                "/webjars/**")
                         .permitAll()
+                        // Auth endpoints
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
+                        // User service internal endpoints
                         .requestMatchers("/api/v1/users/exists").permitAll()
                         .requestMatchers("/api/v1/users/by-username").permitAll()
+                        // Actuator & error
                         .requestMatchers("/actuator/health", "/error").permitAll()
                         .anyRequest().authenticated())
                 .headers(h -> h.cacheControl(HeadersConfigurer.CacheControlConfig::disable))

--- a/src/main/java/com/renewsim/backend/shared/config/OpenApiConfig.java
+++ b/src/main/java/com/renewsim/backend/shared/config/OpenApiConfig.java
@@ -1,10 +1,13 @@
 package com.renewsim.backend.shared.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,13 +17,17 @@ import java.util.List;
 @Configuration
 public class OpenApiConfig {
 
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
     @Bean
     public OpenAPI renewSimOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("RenewSim API")
-                        .description("API documentation for RenewSim microservices (Role, User, Simulation, etc.)")
-                        .version("v1.0.0")
+                        .description("REST API for renewable energy simulation platform. " +
+                                "Provides endpoints for authentication, user management, " +
+                                "technology catalog, and energy simulation workflows.")
+                        .version("1.0.0")
                         .contact(new Contact()
                                 .name("RenewSim Dev Team")
                                 .url("https://github.com/RenewSim")
@@ -34,6 +41,13 @@ public class OpenApiConfig {
                 ))
                 .externalDocs(new ExternalDocumentation()
                         .description("RenewSim GitHub Repository")
-                        .url("https://github.com/RenewSim"));
+                        .url("https://github.com/RenewSim"))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("JWT token obtained from /api/v1/auth/login endpoint")))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
     }
 }

--- a/src/main/java/com/renewsim/backend/technology_service/web/controller/TechnologyController.java
+++ b/src/main/java/com/renewsim/backend/technology_service/web/controller/TechnologyController.java
@@ -5,6 +5,14 @@ import com.renewsim.backend.shared.dto.OperationResponse;
 import com.renewsim.backend.technology_service.application.command.*;
 import com.renewsim.backend.technology_service.application.port.in.*;
 import com.renewsim.backend.technology_service.application.result.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +27,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/technologies")
 @RequiredArgsConstructor
+@Tag(name = "Technologies", description = "Renewable energy technology catalog management")
 public class TechnologyController {
 
     private final CreateTechnologyUseCase createUseCase;
@@ -29,6 +38,13 @@ public class TechnologyController {
     // CREATE
     @PostMapping
     @PreAuthorize("hasAuthority('SCOPE_admin:write') or hasRole('ADMIN')")
+    @Operation(summary = "Create new technology", description = "Creates a new renewable energy technology in the catalog. Requires ADMIN role or scope admin:write.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Technology created successfully", content = @Content(schema = @Schema(implementation = TechnologyCreationResultDTO.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request - validation error or duplicate technology name", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - JWT token missing or invalid", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+    })
     public ResponseEntity<OperationResponse<TechnologyCreationResultDTO>> create(
             @Valid @RequestBody CreateTechnologyCommand command) {
 
@@ -41,7 +57,14 @@ public class TechnologyController {
     // GET by ID
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('SCOPE_user:read') or hasAnyRole('USER','ADMIN')")
-    public ResponseEntity<OperationResponse<TechnologyQueryResultDTO>> getById(@PathVariable Long id) {
+    @Operation(summary = "Get technology by ID", description = "Retrieves detailed information about a specific renewable energy technology", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Technology found", content = @Content(schema = @Schema(implementation = TechnologyQueryResultDTO.class))),
+            @ApiResponse(responseCode = "404", description = "Technology not found", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content)
+    })
+    public ResponseEntity<OperationResponse<TechnologyQueryResultDTO>> getById(
+            @Parameter(description = "Technology unique identifier", required = true) @PathVariable Long id) {
         var result = getUseCase.getTechnologyById(new GetTechnologyByIdCommand(id));
         return ResponseEntity.ok(ApiResponseFactory.ok(result, "Technology retrieved successfully"));
     }
@@ -49,6 +72,11 @@ public class TechnologyController {
     // GET ALL
     @GetMapping
     @PreAuthorize("hasAuthority('SCOPE_user:read') or hasAnyRole('USER','ADMIN')")
+    @Operation(summary = "List all technologies", description = "Retrieves all available renewable energy technologies with their technical specifications", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Technologies retrieved successfully", content = @Content(schema = @Schema(implementation = List.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - JWT token missing or invalid", content = @Content)
+    })
     public ResponseEntity<OperationResponse<List<TechnologyQueryResultDTO>>> getAll() {
         var results = getUseCase.getAllTechnologies();
         return ResponseEntity.ok(ApiResponseFactory.ok(results, "All technologies retrieved"));
@@ -57,8 +85,16 @@ public class TechnologyController {
     // UPDATE
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('SCOPE_admin:write') or hasRole('ADMIN')")
+    @Operation(summary = "Update technology", description = "Updates an existing renewable energy technology. Requires ADMIN role or scope admin:write.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Technology updated successfully", content = @Content(schema = @Schema(implementation = TechnologyUpdateResultDTO.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request - validation error", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Technology not found", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+    })
     public ResponseEntity<OperationResponse<TechnologyUpdateResultDTO>> update(
-            @PathVariable Long id,
+            @Parameter(description = "Technology unique identifier", required = true) @PathVariable Long id,
             @Valid @RequestBody UpdateTechnologyCommand command) {
 
         // Crear un nuevo record con el id del path
@@ -68,10 +104,18 @@ public class TechnologyController {
         return ResponseEntity.ok(ApiResponseFactory.ok(result, "Technology updated successfully"));
     }
 
-    //  DELETE
+    // DELETE
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('SCOPE_admin:delete') or hasRole('ADMIN')")
-    public ResponseEntity<OperationResponse<Void>> delete(@PathVariable Long id) {
+    @Operation(summary = "Delete technology", description = "Permanently removes a technology from the catalog. Requires ADMIN role or scope admin:delete.", security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Technology deleted successfully", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Technology not found", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
+    })
+    public ResponseEntity<OperationResponse<Void>> delete(
+            @Parameter(description = "Technology unique identifier", required = true) @PathVariable Long id) {
         deleteUseCase.deleteTechnology(new DeleteTechnologyCommand(id));
         return ResponseEntity.ok(ApiResponseFactory.noContent("Technology deleted successfully"));
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -119,3 +119,12 @@ role-service:
 
 technology-service:
   url: ${TECHNOLOGY_SERVICE_URL:http://localhost:8080}
+
+# =============================
+# OPENAPI/SWAGGER (DISABLED IN PROD)
+# =============================
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,3 +147,16 @@ role-service:
 
 technology-service:
   url: http://localhost:8080
+
+# =============================
+# OPENAPI/SWAGGER DOCUMENTATION
+# =============================
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method
+    tags-sorter: alpha
+    enabled: ${SWAGGER_ENABLED:true}
+    disable-swagger-default-url: true


### PR DESCRIPTION
This pull request introduces comprehensive improvements to OpenAPI/Swagger documentation and security integration for the Technology service, as well as updates to security configuration and environment settings. The main focus is on enhancing API documentation clarity, ensuring JWT authentication is reflected in the docs, and refining endpoint access control. Additionally, Swagger is now disabled in production by default.

**OpenAPI/Swagger Documentation & Security Integration:**

* Added JWT bearer authentication scheme to the OpenAPI configuration, ensuring all endpoints are documented as requiring a JWT token, and provided detailed API metadata and server information in `OpenApiConfig.java`. [[1]](diffhunk://#diff-fbaf3e1fdd44932595460789452492ac684fb364f872daeed4ec3c7b19bc0fc2R3-R10) [[2]](diffhunk://#diff-fbaf3e1fdd44932595460789452492ac684fb364f872daeed4ec3c7b19bc0fc2R20-R30) [[3]](diffhunk://#diff-fbaf3e1fdd44932595460789452492ac684fb364f872daeed4ec3c7b19bc0fc2L37-R51)
* Annotated all endpoints in `TechnologyController` with detailed Swagger annotations (`@Operation`, `@ApiResponses`, `@SecurityRequirement`, etc.), improving the generated API docs with descriptions, expected responses, and security requirements. [[1]](diffhunk://#diff-3b56ba02903ac2c3c86969a72e146764ee71ed1402ce3c42d536757e1f194b6dR8-R15) [[2]](diffhunk://#diff-3b56ba02903ac2c3c86969a72e146764ee71ed1402ce3c42d536757e1f194b6dR30) [[3]](diffhunk://#diff-3b56ba02903ac2c3c86969a72e146764ee71ed1402ce3c42d536757e1f194b6dR41-R47) [[4]](diffhunk://#diff-3b56ba02903ac2c3c86969a72e146764ee71ed1402ce3c42d536757e1f194b6dL44-R79) [[5]](diffhunk://#diff-3b56ba02903ac2c3c86969a72e146764ee71ed1402ce3c42d536757e1f194b6dR88-R97) [[6]](diffhunk://#diff-3b56ba02903ac2c3c86969a72e146764ee71ed1402ce3c42d536757e1f194b6dL74-R118)

**Security Configuration:**

* Expanded the list of publicly accessible endpoints in `SecurityConfig.java` to include all relevant OpenAPI/Swagger resources, actuator health, and error endpoints, while keeping the rest of the API secured.

**Environment & Swagger Settings:**

* Added configuration to disable Swagger and OpenAPI endpoints in production (`application-prod.yml`), and set custom paths and options for Swagger UI in development (`application.yml`). [[1]](diffhunk://#diff-272166538026361b7bdb5379430d7e416752e07cb68d0b1a5ff26d1899427308R122-R130) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR150-R162)

**Other:**

* Minor cleanup in `pom.xml` (removed trailing whitespace).