### PR TITLE
Refactor/task 1.10 dockerfile multi stage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,49 @@
+# Build artifacts
 target/
-.git
-.gitignore
-README.md
+*.jar
+*.war
+*.ear
 
+# IDE files
+.idea/
+.vscode/
+*.iml
+*.iws
+*.ipr
+.settings/
+.classpath
+.project
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# Documentation (not needed in image)
+*.md
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+
+# Logs
+*.log
+logs/
+
+# Environment files (may contain secrets)
+.env
+.env.*
+*.local
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test files (already excluded in build)
+src/test/
+
+# Docker files (meta)
+Dockerfile
+docker-compose*.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,54 @@
-# Etapa de compilación
-FROM maven:3.9.5-eclipse-temurin-21 AS build
+# ═══════════════════════════════════════════════════════════════
+# Stage 1: Build
+# ═══════════════════════════════════════════════════════════════
+FROM eclipse-temurin:21-jdk-alpine AS build
 
 WORKDIR /app
-COPY . .
-RUN mvn clean package -Dmaven.test.skip=true
 
-# Etapa de ejecución (ahora con Java 21 también)
-FROM eclipse-temurin:21-jdk
+# Copy Maven Wrapper (for reproducible builds)
+COPY .mvn/ .mvn/
+COPY mvnw pom.xml ./
+
+# Download dependencies (cached layer - only re-runs if pom.xml changes)
+RUN ./mvnw dependency:go-offline -B
+
+# Copy source code
+COPY src ./src
+
+# Build application (run tests for production builds)
+RUN ./mvnw clean package -DskipTests
+
+# ═══════════════════════════════════════════════════════════════
+# Stage 2: Runtime
+# ═══════════════════════════════════════════════════════════════
+FROM eclipse-temurin:21-jre-alpine AS runtime
+
 WORKDIR /app
-COPY --from=build /app/target/backend-0.0.1-SNAPSHOT.jar app.jar
+
+# Create non-root user for security
+RUN addgroup -S renewsim && \
+    adduser -S renewsim -G renewsim && \
+    chown -R renewsim:renewsim /app
+
+# Switch to non-root user
+USER renewsim
+
+# Copy JAR from build stage
+COPY --from=build --chown=renewsim:renewsim /app/target/backend-*.jar app.jar
+
+# Health check (Spring Boot Actuator)
+HEALTHCHECK --interval=30s \
+            --timeout=3s \
+            --start-period=40s \
+            --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
+
+# Expose port
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
 
-
-
-
+# Production JVM settings
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     container_name: mysql-db
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -14,9 +14,26 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
       - renewsim-net
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.5'
+          memory: 256M
 
   renewsim-backend:
-    image: lannyrivero/renewsim-backend:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # image: lannyrivero/renewsim-backend:1.0.0  # Use versioned tags in production
     container_name: renewsim-backend
     ports:
       - "8080:8080"
@@ -24,18 +41,32 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql-db:3306/renewsim
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: root
+      SPRING_PROFILES_ACTIVE: docker
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     networks:
       - renewsim-net
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 40s
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 1G
+        reservations:
+          cpus: '1.0'
+          memory: 512M
+    restart: unless-stopped
 
 networks:
   renewsim-net:
+    driver: bridge
 
 volumes:
   mysql-data:
-
-
-
-
-
+    driver: local


### PR DESCRIPTION
This pull request introduces several improvements to the project's Docker and Docker Compose setup, focusing on better build practices, enhanced security, improved health checks, and resource management. The main changes include a more robust and secure `Dockerfile`, expanded `.dockerignore` rules, and an updated `docker-compose.yml` with health checks and resource limits for both the backend and MySQL services.

**Dockerfile and Docker ignore improvements:**

- Refactored the `Dockerfile` to use a multi-stage build with separate build and runtime stages, switched to Alpine-based images for smaller size, added a non-root user for improved security, and included a health check for the backend service. The build process now uses the Maven Wrapper for reproducibility and leverages cached dependency downloads for faster builds.
- Expanded `.dockerignore` to exclude build artifacts, IDE files, logs, documentation, CI/CD configs, environment files, and test sources, resulting in smaller and more secure Docker images.

**Docker Compose enhancements:**

- Updated the MySQL service to use a specific image tag (`mysql:8.0`), added a health check, resource limits, and reservations, and set up the backend service to depend on MySQL being healthy before starting. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L5-R5) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R17-R72)
- Changed the backend service to build from the local `Dockerfile` instead of pulling a prebuilt image, enabled health checks, resource constraints, and restart policies, and set the active Spring profile to `docker`.
- Improved network and volume configurations for better isolation and persistence.