### PR TITLE
Fix/phase2 complete

### DIFF
--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/email/BrevoEmailAdapter.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/email/BrevoEmailAdapter.java
@@ -1,0 +1,115 @@
+package com.renewsim.backend.auth_service.infrastructure.email;
+
+import com.renewsim.backend.auth_service.application.port.out.EmailPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@Profile({ "docker", "prod" })
+public class BrevoEmailAdapter implements EmailPort {
+
+    private final RestTemplate restTemplate;
+    private final String apiKey;
+    private final String senderEmail;
+    private final String senderName;
+
+    public BrevoEmailAdapter(
+            @Value("${email.brevo.api-key:}") String apiKey,
+            @Value("${email.brevo.sender-email:}") String senderEmail,
+            @Value("${email.brevo.sender-name:}") String senderName) {
+        
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException("BREVO_API_KEY is not configured");
+        }
+        if (senderEmail == null || senderEmail.isBlank()) {
+            throw new IllegalStateException("BREVO_SENDER_EMAIL is not configured");
+        }
+        
+        this.apiKey = apiKey;
+        this.senderEmail = senderEmail;
+        this.senderName = senderName != null ? senderName : "RenewSim";
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Override
+    public void sendOtp(String toEmail, String rawOtp, int expiresInSeconds) {
+        try {
+            Map<String, Object> request = new HashMap<>();
+            request.put("sender", Map.of("email", senderEmail, "name", senderName));
+            request.put("to", new Object[] { Map.of("email", toEmail) });
+            request.put("subject", "Your RenewSim OTP Code");
+            request.put("htmlContent", buildOtpHtml(rawOtp, expiresInSeconds));
+
+            restTemplate.postForEntity(
+                    "https://api.brevo.com/v3/smtp/email",
+                    request,
+                    String.class);
+
+            log.info("OTP email sent to={}", maskEmail(toEmail));
+        } catch (Exception e) {
+            log.error("Failed to send OTP: {}", e.getMessage());
+            throw new RuntimeException("Failed to send OTP email", e);
+        }
+    }
+
+    @Override
+    public void sendActivationEmail(String toEmail, String activationToken) {
+        try {
+            String link = "https://renewsim.example.com/activate?token=" + activationToken;
+            
+            Map<String, Object> request = new HashMap<>();
+            request.put("sender", Map.of("email", senderEmail, "name", senderName));
+            request.put("to", new Object[] { Map.of("email", toEmail) });
+            request.put("subject", "Activate your RenewSim account");
+            request.put("htmlContent", buildActivationHtml(link));
+
+            restTemplate.postForEntity(
+                    "https://api.brevo.com/v3/smtp/email",
+                    request,
+                    String.class);
+
+            log.info("Activation email sent to={}", maskEmail(toEmail));
+        } catch (Exception e) {
+            log.error("Failed to send activation: {}", e.getMessage());
+            throw new RuntimeException("Failed to send activation email", e);
+        }
+    }
+
+    private String buildOtpHtml(String otp, int secs) {
+        return String.format("""
+            <!DOCTYPE html><html><head><meta charset="UTF-8"></head><body style="font-family:Arial,sans-serif;padding:20px;">
+            <div style="max-width:600px;margin:0 auto;">
+            <h2 style="color:#2E7D32;">RenewSim</h2>
+            <p>Your verification code is:</p>
+            <div style="background:#f5f5f5;padding:20px;text-align:center;font-size:32px;font-weight:bold;letter-spacing:8px;">%s</div>
+            <p style="color:#666;font-size:14px;">This code expires in %d minutes.</p>
+            <p style="color:#999;font-size:12px;">If you didn't request this code, please ignore this email.</p>
+            </div></body></html>""", otp, secs / 60);
+    }
+
+    private String buildActivationHtml(String link) {
+        return String.format("""
+            <!DOCTYPE html><html><head><meta charset="UTF-8"></head><body style="font-family:Arial,sans-serif;padding:20px;">
+            <div style="max-width:600px;margin:0 auto;">
+            <h2 style="color:#2E7D32;">RenewSim</h2>
+            <p>Welcome to RenewSim!</p>
+            <p>Click the button below to activate your account:</p>
+            <a href="%s" style="display:inline-block;background:#2E7D32;color:white;padding:15px 30px;text-decoration:none;border-radius:5px;">Activate Account</a>
+            <p style="color:#666;margin-top:20px;">Or copy and paste this link:<br><span style="color:#1976D2;">%s</span></p>
+            <p style="color:#999;font-size:12px;">If you didn't create an account, please ignore this email.</p>
+            </div></body></html>""", link, link);
+    }
+
+    private String maskEmail(String email) {
+        if (email == null || !email.contains("@")) return "***";
+        int at = email.indexOf("@");
+        return at <= 2 ? "***" + email.substring(at) : email.substring(0, 2) + "***" + email.substring(at);
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -117,3 +117,12 @@ role-service:
 
 technology-service:
   url: http://renewsim-backend:8080
+
+# =============================
+# BREVO EMAIL (docker)
+# =============================
+email:
+  brevo:
+    api-key: ${BREVO_API_KEY:}
+    sender-email: ${BREVO_SENDER_EMAIL:}
+    sender-name: ${BREVO_SENDER_NAME:RenewSim}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -112,10 +112,19 @@ cors:
   max-age-seconds: 3600
 
 # =============================
-# ACTUATOR (completo en local)
-# =============================
-management:
-  endpoints:
-    web:
-      exposure:
-        include: "health,info,flyway,metrics"
+  # ACTUATOR (completo en local)
+  # =============================
+  management:
+    endpoints:
+      web:
+        exposure:
+          include: "health,info,flyway,metrics"
+
+  # =============================
+  # BREVO EMAIL (local)
+  # =============================
+  email:
+    brevo:
+      api-key: ${BREVO_API_KEY:}
+      sender-email: ${BREVO_SENDER_EMAIL:notifications@renewsim.com}
+      sender-name: ${BREVO_SENDER_NAME:RenewSim}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -122,6 +122,15 @@ technology-service:
   url: ${TECHNOLOGY_SERVICE_URL:http://localhost:8080}
 
 # =============================
+# BREVO EMAIL (prod)
+# =============================
+email:
+  brevo:
+    api-key: ${BREVO_API_KEY:}
+    sender-email: ${BREVO_SENDER_EMAIL:}
+    sender-name: ${BREVO_SENDER_NAME:RenewSim}
+
+# =============================
 # OPENAPI/SWAGGER (DISABLED IN PROD)
 # =============================
 springdoc:


### PR DESCRIPTION
This pull request introduces a new email adapter for sending OTP and activation emails using the Brevo (formerly Sendinblue) service, and adds configuration settings for this integration across local, Docker, and production environments. The main focus is on enabling the backend to send transactional emails via Brevo with customizable sender details.

**Email Integration:**

* Added a new `BrevoEmailAdapter` class implementing the `EmailPort` interface, which handles sending OTP and activation emails using the Brevo API. This includes error handling, email content formatting, and sender masking for logs. (`src/main/java/com/renewsim/backend/auth_service/infrastructure/email/BrevoEmailAdapter.java`)

**Configuration Updates:**

* Added Brevo email configuration sections (`email.brevo`) to the local, Docker, and production configuration files, enabling environment-specific API keys and sender details. (`src/main/resources/application-local.yml`, `src/main/resources/application-docker.yml`, `src/main/resources/application-prod.yml`) [[1]](diffhunk://#diff-43a78ff616f196d58ca4ff339d581c4c183d5872bf6b85a877a4bc14f7c240c1R122-R130) [[2]](diffhunk://#diff-8c2ffb0d9d8127baf51f1b7f9042c3cda875be10d0451b7e29a744ad68cbd550R120-R128) [[3]](diffhunk://#diff-272166538026361b7bdb5379430d7e416752e07cb68d0b1a5ff26d1899427308R124-R132)