### PR TITLE
fix(fase2): production gaps — security, architecture & unit tests

### DIFF
--- a/src/main/java/com/renewsim/backend/auth_service/application/service/ResendVerificationEmailUseCase.java
+++ b/src/main/java/com/renewsim/backend/auth_service/application/service/ResendVerificationEmailUseCase.java
@@ -1,10 +1,10 @@
 package com.renewsim.backend.auth_service.application.service;
 
+import com.renewsim.backend.auth_service.application.dto.UserSnapshot;
 import com.renewsim.backend.auth_service.application.port.out.EmailPort;
 import com.renewsim.backend.auth_service.application.port.out.EmailVerificationTokenRepository;
+import com.renewsim.backend.auth_service.application.port.out.UserAccountGateway;
 import com.renewsim.backend.auth_service.domain.model.EmailVerificationToken;
-import com.renewsim.backend.user_service.application.port.out.UserRepositoryPort;
-import com.renewsim.backend.user_service.domain.model.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,11 +17,11 @@ import java.util.Base64;
 
 /**
  * Use case for resending email verification link.
- * 
+ *
  * Business rules:
  * - User must exist
- * - User must not already be verified
- * - Generates new token (invalidates previous)
+ * - User must not already be verified (enabled)
+ * - Generates new token
  * - Sends verification email
  */
 @Slf4j
@@ -29,7 +29,7 @@ import java.util.Base64;
 @RequiredArgsConstructor
 public class ResendVerificationEmailUseCase {
 
-    private final UserRepositoryPort userRepository;
+    private final UserAccountGateway userAccountGateway;
     private final EmailVerificationTokenRepository tokenRepository;
     private final EmailPort emailPort;
     private final SecureRandom secureRandom = new SecureRandom();
@@ -41,31 +41,24 @@ public class ResendVerificationEmailUseCase {
     public void execute(String email) {
         log.debug("Resending verification email to={}", maskEmail(email));
 
-        // Find user by email
-        User user = userRepository.findByEmail(email)
-            .orElseThrow(() -> new ResendVerificationException("User not found"));
+        UserSnapshot user = userAccountGateway.findByEmail(email)
+                .orElseThrow(() -> new ResendVerificationException("User not found"));
 
-        // Check if already verified
-        if (user.isEmailVerified()) {
+        if (user.enabled()) {
             throw new ResendVerificationException("Email already verified");
         }
 
-        // Generate new token
         String token = generateSecureToken();
         LocalDateTime expiresAt = LocalDateTime.now().plusHours(expirationHours);
 
         EmailVerificationToken verificationToken = new EmailVerificationToken(
-            user.getId(),
-            token,
-            expiresAt
-        );
+                user.id(), token, expiresAt);
 
         tokenRepository.save(verificationToken);
 
-        // Send email
-        emailPort.sendVerificationEmail(user.getEmail(), user.getFullName(), token);
+        emailPort.sendVerificationEmail(user.email(), user.fullName(), token);
 
-        log.info("Verification email resent to user={}", user.getId());
+        log.info("Verification email resent to userId={}", user.id());
     }
 
     private String generateSecureToken() {
@@ -75,14 +68,12 @@ public class ResendVerificationEmailUseCase {
     }
 
     private String maskEmail(String email) {
-        if (email == null || !email.contains("@")) return "***";
+        if (email == null || !email.contains("@"))
+            return "***";
         int at = email.indexOf("@");
         return at <= 2 ? "***" + email.substring(at) : email.substring(0, 2) + "***" + email.substring(at);
     }
 
-    /**
-     * Exception thrown when resend verification fails.
-     */
     public static class ResendVerificationException extends RuntimeException {
         public ResendVerificationException(String message) {
             super(message);

--- a/src/main/java/com/renewsim/backend/auth_service/application/service/VerifyEmailUseCase.java
+++ b/src/main/java/com/renewsim/backend/auth_service/application/service/VerifyEmailUseCase.java
@@ -1,9 +1,8 @@
 package com.renewsim.backend.auth_service.application.service;
 
 import com.renewsim.backend.auth_service.application.port.out.EmailVerificationTokenRepository;
+import com.renewsim.backend.auth_service.application.port.out.UserAccountGateway;
 import com.renewsim.backend.auth_service.domain.model.EmailVerificationToken;
-import com.renewsim.backend.user_service.application.port.out.UserRepositoryPort;
-import com.renewsim.backend.user_service.domain.model.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,13 +10,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Use case for verifying user email addresses.
- * 
+ *
  * Business rules:
  * - Token must exist
  * - Token must not be expired
  * - Token must not have been used already
- * - User must exist
- * - Sets user.emailVerified = true
+ * - Activates the user account via UserAccountGateway (auth → user_service
+ * boundary)
  * - Marks token as verified
  */
 @Slf4j
@@ -26,41 +25,29 @@ import org.springframework.transaction.annotation.Transactional;
 public class VerifyEmailUseCase {
 
     private final EmailVerificationTokenRepository tokenRepository;
-    private final UserRepositoryPort userRepository;
+    private final UserAccountGateway userAccountGateway;
 
     @Transactional
     public void execute(String token) {
         log.debug("Attempting to verify email with token");
 
-        // Find token
         EmailVerificationToken verificationToken = tokenRepository.findByToken(token)
-            .orElseThrow(() -> new EmailVerificationException("Invalid or expired verification token"));
+                .orElseThrow(() -> new EmailVerificationException("Invalid or expired verification token"));
 
-        // Validate token can be used
         try {
             verificationToken.validateCanBeUsed();
         } catch (IllegalStateException e) {
             throw new EmailVerificationException(e.getMessage());
         }
 
-        // Find user
-        User user = userRepository.findById(verificationToken.getUserId())
-            .orElseThrow(() -> new EmailVerificationException("User not found"));
+        userAccountGateway.activateUser(verificationToken.getUserId());
 
-        // Verify email (idempotent)
-        user.verifyEmail();
-        userRepository.save(user);
-
-        // Mark token as verified
         verificationToken.markAsVerified();
         tokenRepository.save(verificationToken);
 
-        log.info("Email verified successfully for user={}", user.getId());
+        log.info("Email verified successfully for userId={}", verificationToken.getUserId());
     }
 
-    /**
-     * Exception thrown when email verification fails.
-     */
     public static class EmailVerificationException extends RuntimeException {
         public EmailVerificationException(String message) {
             super(message);

--- a/src/main/java/com/renewsim/backend/auth_service/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/renewsim/backend/auth_service/infrastructure/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh").permitAll()
+                        .requestMatchers("/api/v1/auth/email-verification/**").permitAll()
                         // User service internal endpoints
                         .requestMatchers("/api/v1/users/exists").permitAll()
                         .requestMatchers("/api/v1/users/by-username").permitAll()

--- a/src/main/java/com/renewsim/backend/role_service/web/controller/RoleController.java
+++ b/src/main/java/com/renewsim/backend/role_service/web/controller/RoleController.java
@@ -11,6 +11,8 @@ import com.renewsim.backend.role_service.web.dto.RoleCreateRequestDTO;
 import com.renewsim.backend.role_service.web.dto.RoleDTO;
 import com.renewsim.backend.shared.dto.ApiResponseFactory;
 import com.renewsim.backend.shared.dto.OperationResponse;
+import com.renewsim.backend.shared.exception.ResourceNotFoundException;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -44,14 +46,11 @@ public class RoleController {
     // --------------------------
     @PostMapping
     @PreAuthorize("hasAuthority('SCOPE_roles:write') or hasRole('ADMIN')")
-    @Operation(summary = "Create a new role", description = "Requires role ADMIN or scope roles:write", 
-        security = @SecurityRequirement(name = "bearerAuth"),
-        responses = {
-            @ApiResponse(responseCode = "201", description = "Role created successfully", 
-                         content = @Content(schema = @Schema(implementation = RoleCreationResultDTO.class))),
+    @Operation(summary = "Create a new role", description = "Requires role ADMIN or scope roles:write", security = @SecurityRequirement(name = "bearerAuth"), responses = {
+            @ApiResponse(responseCode = "201", description = "Role created successfully", content = @Content(schema = @Schema(implementation = RoleCreationResultDTO.class))),
             @ApiResponse(responseCode = "400", description = "Validation error", content = @Content),
             @ApiResponse(responseCode = "409", description = "Role already exists", content = @Content)
-        })
+    })
     public ResponseEntity<OperationResponse<RoleCreationResultDTO>> createRole(
             @Valid @RequestBody RoleCreateRequestDTO request) {
 
@@ -68,14 +67,11 @@ public class RoleController {
     // --------------------------
     @PostMapping("/manage")
     @PreAuthorize("hasAuthority('SCOPE_roles:write') or hasRole('ADMIN')")
-    @Operation(summary = "Batch manage user roles", description = "Assign and revoke multiple roles in a single request",
-        security = @SecurityRequirement(name = "bearerAuth"),
-        responses = {
-            @ApiResponse(responseCode = "200", description = "Roles updated successfully",
-                         content = @Content(schema = @Schema(implementation = ManageUserRolesResultDTO.class))),
+    @Operation(summary = "Batch manage user roles", description = "Assign and revoke multiple roles in a single request", security = @SecurityRequirement(name = "bearerAuth"), responses = {
+            @ApiResponse(responseCode = "200", description = "Roles updated successfully", content = @Content(schema = @Schema(implementation = ManageUserRolesResultDTO.class))),
             @ApiResponse(responseCode = "400", description = "Validation error", content = @Content),
             @ApiResponse(responseCode = "404", description = "User or role not found", content = @Content)
-        })
+    })
     public ResponseEntity<OperationResponse<ManageUserRolesResultDTO>> manageRoles(
             @Valid @RequestBody ManageUserRolesRequestDTO request) {
 
@@ -94,8 +90,7 @@ public class RoleController {
     // --------------------------
     @GetMapping
     @PreAuthorize("hasAuthority('SCOPE_roles:read') or hasAnyRole('ADMIN','USER')")
-    @Operation(summary = "List all roles", description = "Requires ADMIN, USER, or scope roles:read",
-        security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "List all roles", description = "Requires ADMIN, USER, or scope roles:read", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<OperationResponse<List<RoleDTO>>> getAllRoles() {
         var result = getRolesUseCase.getAll();
         return ResponseEntity.ok(ApiResponseFactory.ok(result, "Roles retrieved successfully"));
@@ -106,8 +101,7 @@ public class RoleController {
     // --------------------------
     @GetMapping("/exists/{name}")
     @PreAuthorize("hasAuthority('SCOPE_roles:read') or hasAnyRole('ADMIN','SERVICE_AUTH')")
-    @Operation(summary = "Check if role exists", description = "Requires ADMIN, SERVICE_AUTH, or scope roles:read",
-        security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Check if role exists", description = "Requires ADMIN, SERVICE_AUTH, or scope roles:read", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<OperationResponse<Boolean>> existsRole(
             @PathVariable @NotBlank String name) {
         boolean exists;
@@ -124,23 +118,18 @@ public class RoleController {
     // --------------------------
     // GET /roles/by-name/{name}
     // --------------------------
+
     @GetMapping("/by-name/{name}")
     @PreAuthorize("hasAuthority('SCOPE_roles:read') or hasAnyRole('ADMIN','SERVICE_AUTH')")
-    @Operation(summary = "Get role by name", description = "Requires ADMIN, SERVICE_AUTH, or scope roles:read",
-        security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Get role by name", description = "Requires ADMIN, SERVICE_AUTH, or scope roles:read", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<OperationResponse<RoleDTO>> getRoleByName(
             @PathVariable @NotBlank String name) {
 
-        var role = getRolesUseCase.getAll().stream()
+        return getRolesUseCase.getAll().stream()
                 .filter(r -> r.name().equalsIgnoreCase(name))
                 .findFirst()
-                .orElse(null);
-
-        if (role == null) {
-            return ResponseEntity.ok(ApiResponseFactory.ok(null, "Role not found"));
-        }
-
-        return ResponseEntity.ok(ApiResponseFactory.ok(role, "Role retrieved successfully"));
+                .map(role -> ResponseEntity.ok(ApiResponseFactory.ok(role, "Role retrieved successfully")))
+                .orElseThrow(() -> new ResourceNotFoundException("Role not found: " + name));
     }
 
     // --------------------------
@@ -148,8 +137,7 @@ public class RoleController {
     // --------------------------
     @PutMapping("/{roleId}/assign/{userId}")
     @PreAuthorize("hasAuthority('SCOPE_roles:write') or hasRole('ADMIN')")
-    @Operation(summary = "Assign role to user", description = "Requires ADMIN or scope roles:write",
-        security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Assign role to user", description = "Requires ADMIN or scope roles:write", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<OperationResponse<RoleAssignmentResultDTO>> assignRoleToUser(
             @PathVariable @NotNull Long roleId,
             @PathVariable @NotNull Long userId) {
@@ -164,11 +152,9 @@ public class RoleController {
     // --------------------------
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('SCOPE_roles:delete') or hasRole('ADMIN')")
-    @Operation(summary = "Delete a role", description = "Requires ADMIN or scope roles:delete",
-        security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Delete a role", description = "Requires ADMIN or scope roles:delete", security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<OperationResponse<Void>> deleteRole(@PathVariable @NotNull Long id) {
         deleteRoleUseCase.delete(id);
         return ResponseEntity.ok(ApiResponseFactory.noContent("Role deleted successfully"));
     }
 }
-

--- a/src/main/java/com/renewsim/backend/user_service/application/port/in/GetMyProfileUseCase.java
+++ b/src/main/java/com/renewsim/backend/user_service/application/port/in/GetMyProfileUseCase.java
@@ -4,4 +4,5 @@ import com.renewsim.backend.user_service.web.dto.UserResponse;
 
 public interface GetMyProfileUseCase {
     UserResponse getMyProfile(Long userId);
+    UserResponse getMyProfileByEmail(String email);
 }

--- a/src/main/java/com/renewsim/backend/user_service/application/service/GetMyProfileService.java
+++ b/src/main/java/com/renewsim/backend/user_service/application/service/GetMyProfileService.java
@@ -25,4 +25,11 @@ public class GetMyProfileService implements GetMyProfileUseCase {
                 .map(mapper::toResponse)
                 .orElseThrow(() -> new UserNotFoundException("User with id " + userId + " not found"));
     }
+
+    @Override
+    public UserResponse getMyProfileByEmail(String email) {
+        return userRepositoryPort.findByEmail(email)
+                .map(mapper::toResponse)
+                .orElseThrow(() -> new UserNotFoundException("User with email " + email + " not found"));
+    }
 }

--- a/src/main/java/com/renewsim/backend/user_service/web/controller/UserController.java
+++ b/src/main/java/com/renewsim/backend/user_service/web/controller/UserController.java
@@ -53,8 +53,7 @@ public class UserController {
         @GetMapping("/me")
         public ResponseEntity<OperationResponse<UserResponse>> getMe(
                         @AuthenticationPrincipal AuthenticatedUser principal) {
-                var user = getUserUseCase.getDomainUserByUsernameOrEmail(null, principal.username());
-                var response = getMyProfileUseCase.getMyProfile(user.getId());
+                var response = getMyProfileUseCase.getMyProfileByEmail(principal.username());
                 return ResponseEntity.ok(ApiResponseFactory.ok(response, "Profile retrieved successfully"));
         }
 
@@ -107,14 +106,13 @@ public class UserController {
                 var user = getUserUseCase.getDomainUserById(id);
                 var credentials = new UserCredentialsDTO(
                                 user.getId(),
-                                user.getEmail(), 
+                                user.getEmail(),
                                 user.getEmail(),
                                 user.getPasswordHash(),
                                 user.getRoles(),
-                                user.getStatus().name(), 
-                                user.isEmailVerified(), 
-                                user.getStatus().name().equals("ACTIVE") && user.isEmailVerified()
-                );
+                                user.getStatus().name(),
+                                user.isEmailVerified(),
+                                user.getStatus().name().equals("ACTIVE") && user.isEmailVerified());
                 return ResponseEntity.ok(ApiResponseFactory.ok(credentials, "Snapshot retrieved successfully"));
         }
 
@@ -161,14 +159,13 @@ public class UserController {
                 var user = getUserUseCase.getDomainUserByUsernameOrEmail(username, email);
                 var credentials = new UserCredentialsDTO(
                                 user.getId(),
-                                user.getEmail(), 
+                                user.getEmail(),
                                 user.getEmail(),
                                 user.getPasswordHash(),
                                 user.getRoles(),
-                                user.getStatus().name(), 
+                                user.getStatus().name(),
                                 user.isEmailVerified(),
-                                user.getStatus().name().equals("ACTIVE") && user.isEmailVerified() 
-                );
+                                user.getStatus().name().equals("ACTIVE") && user.isEmailVerified());
                 return ResponseEntity.ok(ApiResponseFactory.ok(credentials, "Credentials retrieved successfully"));
         }
 

--- a/src/test/java/com/renewsim/backend/auth_service/application/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/application/service/RefreshTokenServiceTest.java
@@ -1,0 +1,288 @@
+package com.renewsim.backend.auth_service.application.service;
+
+import com.renewsim.backend.auth_service.application.command.RefreshTokenCommand;
+import com.renewsim.backend.auth_service.application.dto.UserSnapshot;
+import com.renewsim.backend.auth_service.application.port.out.RefreshTokenRepositoryPort;
+import com.renewsim.backend.auth_service.application.port.out.TokenProvider;
+import com.renewsim.backend.auth_service.application.port.out.TransactionalPort;
+import com.renewsim.backend.auth_service.application.port.out.UserAccountGateway;
+import com.renewsim.backend.auth_service.application.result.RefreshTokenResult;
+import com.renewsim.backend.auth_service.application.validator.UserAccountValidator;
+import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
+import com.renewsim.backend.auth_service.domain.model.RefreshToken;
+import com.renewsim.backend.auth_service.domain.service.TokenHasher;
+import com.renewsim.backend.shared.domain.vo.RoleName;
+import com.renewsim.backend.shared.exception.AuthenticationException;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("RefreshTokenService")
+class RefreshTokenServiceTest {
+
+    private RefreshTokenRepositoryPort refreshTokenRepositoryPort;
+    private UserAccountGateway userAccountGateway;
+    private TokenProvider tokenProvider;
+    private TransactionalPort transactionalPort;
+    private UserAccountValidator userAccountValidator;
+    private Clock clock;
+    private RefreshTokenService service;
+
+    // Fixed clock for deterministic tests
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-01-01T10:00:00Z"), ZoneId.of("UTC"));
+
+    // A raw token and its hash
+    private static final String RAW_TOKEN = "raw-refresh-token-value";
+    private static final String TOKEN_HASH = TokenHasher.hash(RAW_TOKEN);
+
+    private static final UserSnapshot ACTIVE_USER = UserSnapshot.active(
+            1L, "user@renewsim.com", "Test User", "hash",
+            "user@renewsim.com", Set.of(RoleName.USER));
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenRepositoryPort = mock(RefreshTokenRepositoryPort.class);
+        userAccountGateway = mock(UserAccountGateway.class);
+        tokenProvider = mock(TokenProvider.class);
+        transactionalPort = mock(TransactionalPort.class);
+        userAccountValidator = new UserAccountValidator();
+        clock = FIXED_CLOCK;
+
+        when(transactionalPort.execute(any())).thenAnswer(inv ->
+                inv.getArgument(0, Supplier.class).get());
+
+        service = new RefreshTokenService(
+                refreshTokenRepositoryPort,
+                userAccountGateway,
+                tokenProvider,
+                transactionalPort,
+                clock,
+                userAccountValidator);
+    }
+
+    // ─────────────────────────────────────────────
+    // Happy path — valid token rotation
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given a valid refresh token")
+    class ValidToken {
+
+        private RefreshToken validToken;
+
+        @BeforeEach
+        void setup() {
+            validToken = RefreshToken.issue(1L, TOKEN_HASH, clock, 7 * 24 * 3600L);
+            when(refreshTokenRepositoryPort.findByTokenHash(TOKEN_HASH))
+                    .thenReturn(Optional.of(validToken));
+            when(userAccountGateway.findById(1L)).thenReturn(Optional.of(ACTIVE_USER));
+            when(tokenProvider.generate(any(AuthenticatedUser.class))).thenReturn("new-access-token");
+            when(tokenProvider.expiresInSeconds()).thenReturn(3600L);
+        }
+
+        @Test
+        @DisplayName("should return new access token")
+        void shouldReturnNewAccessToken() {
+            RefreshTokenResult result = service.execute(new RefreshTokenCommand(RAW_TOKEN));
+
+            assertThat(result.accessToken()).isEqualTo("new-access-token");
+            assertThat(result.tokenType()).isEqualTo("Bearer");
+            assertThat(result.expiresIn()).isEqualTo(3600L);
+        }
+
+        @Test
+        @DisplayName("should return raw refresh token in result")
+        void shouldReturnRawRefreshToken() {
+            RefreshTokenResult result = service.execute(new RefreshTokenCommand(RAW_TOKEN));
+
+            assertThat(result.rawRefreshToken()).isNotNull().isNotBlank();
+        }
+
+        @Test
+        @DisplayName("should revoke old token")
+        void shouldRevokeOldToken() {
+            service.execute(new RefreshTokenCommand(RAW_TOKEN));
+
+            ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+            verify(refreshTokenRepositoryPort, times(2)).save(captor.capture());
+
+            RefreshToken revokedToken = captor.getAllValues().get(0);
+            assertThat(revokedToken.isRevoked()).isTrue();
+            assertThat(revokedToken.getRevokedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("should save new refresh token")
+        void shouldSaveNewRefreshToken() {
+            service.execute(new RefreshTokenCommand(RAW_TOKEN));
+
+            ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+            verify(refreshTokenRepositoryPort, times(2)).save(captor.capture());
+
+            RefreshToken newToken = captor.getAllValues().get(1);
+            assertThat(newToken.isRevoked()).isFalse();
+            assertThat(newToken.getUserId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("should include user roles in result")
+        void shouldIncludeRolesInResult() {
+            RefreshTokenResult result = service.execute(new RefreshTokenCommand(RAW_TOKEN));
+
+            assertThat(result.roles()).contains("USER");
+            assertThat(result.username()).isEqualTo("user@renewsim.com");
+        }
+
+        @Test
+        @DisplayName("new refresh token hash should differ from old one")
+        void newTokenHashShouldDifferFromOld() {
+            service.execute(new RefreshTokenCommand(RAW_TOKEN));
+
+            ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+            verify(refreshTokenRepositoryPort, times(2)).save(captor.capture());
+
+            String oldHash = captor.getAllValues().get(0).getTokenHash();
+            String newHash = captor.getAllValues().get(1).getTokenHash();
+            assertThat(newHash).isNotEqualTo(oldHash);
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Token not found
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given token not found in repository")
+    class TokenNotFound {
+
+        @BeforeEach
+        void setup() {
+            when(refreshTokenRepositoryPort.findByTokenHash(any()))
+                    .thenReturn(Optional.empty());
+        }
+
+        @Test
+        @DisplayName("should throw AuthenticationException")
+        void shouldThrowAuthenticationException() {
+            assertThatThrownBy(() -> service.execute(new RefreshTokenCommand(RAW_TOKEN)))
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("Invalid or expired");
+        }
+
+        @Test
+        @DisplayName("should never generate access token")
+        void shouldNeverGenerateAccessToken() {
+            assertThatThrownBy(() -> service.execute(new RefreshTokenCommand(RAW_TOKEN)))
+                    .isInstanceOf(AuthenticationException.class);
+
+            verify(tokenProvider, never()).generate(any());
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Token expired or revoked
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given token is expired or revoked")
+    class InvalidToken {
+
+        @Test
+        @DisplayName("should throw AuthenticationException when token is revoked")
+        void shouldThrowWhenRevoked() {
+            RefreshToken revokedToken = RefreshToken.issue(1L, TOKEN_HASH, clock, 7 * 24 * 3600L)
+                    .revoked(clock);
+            when(refreshTokenRepositoryPort.findByTokenHash(TOKEN_HASH))
+                    .thenReturn(Optional.of(revokedToken));
+
+            assertThatThrownBy(() -> service.execute(new RefreshTokenCommand(RAW_TOKEN)))
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("Invalid or expired");
+        }
+
+        @Test
+        @DisplayName("should throw AuthenticationException when token is expired")
+        void shouldThrowWhenExpired() {
+            // Issue token in the past — already expired
+            Clock pastClock = Clock.fixed(
+                    Instant.parse("2025-01-01T00:00:00Z"), ZoneId.of("UTC"));
+            RefreshToken expiredToken = RefreshToken.issue(1L, TOKEN_HASH, pastClock, 1L);
+
+            when(refreshTokenRepositoryPort.findByTokenHash(TOKEN_HASH))
+                    .thenReturn(Optional.of(expiredToken));
+
+            assertThatThrownBy(() -> service.execute(new RefreshTokenCommand(RAW_TOKEN)))
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("Invalid or expired");
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // User not found after valid token
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given user not found after token lookup")
+    class UserNotFound {
+
+        @BeforeEach
+        void setup() {
+            RefreshToken validToken = RefreshToken.issue(1L, TOKEN_HASH, clock, 7 * 24 * 3600L);
+            when(refreshTokenRepositoryPort.findByTokenHash(TOKEN_HASH))
+                    .thenReturn(Optional.of(validToken));
+            when(userAccountGateway.findById(1L)).thenReturn(Optional.empty());
+        }
+
+        @Test
+        @DisplayName("should throw AuthenticationException")
+        void shouldThrow() {
+            assertThatThrownBy(() -> service.execute(new RefreshTokenCommand(RAW_TOKEN)))
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("User not found");
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // User account disabled
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given user account is disabled")
+    class DisabledUser {
+
+        @BeforeEach
+        void setup() {
+            UserSnapshot disabledUser = UserSnapshot.disabled(
+                    1L, "user@renewsim.com", "Test User", "hash",
+                    "user@renewsim.com", Set.of(RoleName.USER));
+
+            RefreshToken validToken = RefreshToken.issue(1L, TOKEN_HASH, clock, 7 * 24 * 3600L);
+            when(refreshTokenRepositoryPort.findByTokenHash(TOKEN_HASH))
+                    .thenReturn(Optional.of(validToken));
+            when(userAccountGateway.findById(1L)).thenReturn(Optional.of(disabledUser));
+        }
+
+        @Test
+        @DisplayName("should throw AuthenticationException")
+        void shouldThrow() {
+            assertThatThrownBy(() -> service.execute(new RefreshTokenCommand(RAW_TOKEN)))
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("not active");
+        }
+
+        @Test
+        @DisplayName("should never generate access token")
+        void shouldNeverGenerateToken() {
+            assertThatThrownBy(() -> service.execute(new RefreshTokenCommand(RAW_TOKEN)))
+                    .isInstanceOf(AuthenticationException.class);
+
+            verify(tokenProvider, never()).generate(any());
+        }
+    }
+}

--- a/src/test/java/com/renewsim/backend/auth_service/application/service/RegisterUserServiceTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/application/service/RegisterUserServiceTest.java
@@ -1,0 +1,312 @@
+package com.renewsim.backend.auth_service.application.service;
+
+import com.renewsim.backend.auth_service.application.command.RegisterCommand;
+import com.renewsim.backend.auth_service.application.dto.UserSnapshot;
+import com.renewsim.backend.auth_service.application.port.out.EmailPort;
+import com.renewsim.backend.auth_service.application.port.out.EmailVerificationTokenRepository;
+import com.renewsim.backend.auth_service.application.port.out.TransactionalPort;
+import com.renewsim.backend.auth_service.application.port.out.UserAccountGateway;
+import com.renewsim.backend.auth_service.application.result.RegisterResult;
+import com.renewsim.backend.auth_service.domain.model.AuthUserStatus;
+import com.renewsim.backend.shared.domain.vo.RoleName;
+import com.renewsim.backend.shared.exception.ConflictException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.core.env.Environment;
+import java.util.function.Supplier;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("RegisterUserService")
+class RegisterUserServiceTest {
+
+    private UserAccountGateway userAccountGateway;
+    private EmailVerificationTokenRepository emailVerificationTokenRepository;
+    private EmailPort emailPort;
+    private TransactionalPort transactionalPort;
+    private Environment environment;
+    private RegisterUserService service;
+
+    private static final RegisterCommand VALID_COMMAND = new RegisterCommand(
+            "Test User", "SecurePass123!", "user@renewsim.com");
+
+    private static final UserSnapshot INACTIVE_SNAPSHOT = UserSnapshot.disabled(
+            1L, "user", "Test User", "hash", "user@renewsim.com", Set.of(RoleName.USER));
+
+    private static final UserSnapshot ACTIVE_SNAPSHOT = UserSnapshot.active(
+            1L, "user", "Test User", "hash", "user@renewsim.com", Set.of(RoleName.USER));
+
+    @BeforeEach
+    void setUp() {
+        userAccountGateway = mock(UserAccountGateway.class);
+        emailVerificationTokenRepository = mock(EmailVerificationTokenRepository.class);
+        emailPort = mock(EmailPort.class);
+        environment = mock(Environment.class);
+        transactionalPort = mock(TransactionalPort.class);
+
+        // TransactionalPort executes the supplier directly
+        when(transactionalPort.execute(any())).thenAnswer(inv -> inv.getArgument(0, Supplier.class).get());
+
+        service = new RegisterUserService(
+                userAccountGateway,
+                emailVerificationTokenRepository,
+                emailPort,
+                transactionalPort,
+                environment,
+                48);
+    }
+
+    // ─────────────────────────────────────────────
+    // Happy path — non-local profile
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given non-local profile")
+    class NonLocalProfile {
+
+        @BeforeEach
+        void nonLocal() {
+            when(environment.getActiveProfiles()).thenReturn(new String[] { "prod" });
+            when(userAccountGateway.existsByEmail(any())).thenReturn(false);
+            when(userAccountGateway.createUser(any(), any(), any(), any(), any()))
+                    .thenReturn(INACTIVE_SNAPSHOT);
+        }
+
+        @Test
+        @DisplayName("should return INACTIVE result with verification message")
+        void shouldReturnInactiveResult() {
+            RegisterResult result = service.execute(VALID_COMMAND);
+
+            assertThat(result.status()).isEqualTo(AuthUserStatus.INACTIVE);
+            assertThat(result.email()).isEqualTo("user@renewsim.com");
+            assertThat(result.message()).containsIgnoringCase("email");
+        }
+
+        @Test
+        @DisplayName("should save email verification token")
+        void shouldSaveVerificationToken() {
+            service.execute(VALID_COMMAND);
+
+            verify(emailVerificationTokenRepository).save(
+                    argThat(token -> token.getUserId().equals(1L)
+                            && token.getToken() != null
+                            && !token.getToken().isBlank()));
+        }
+
+        @Test
+        @DisplayName("should send verification email")
+        void shouldSendVerificationEmail() {
+            service.execute(VALID_COMMAND);
+
+            verify(emailPort).sendVerificationEmail(
+                    eq("user@renewsim.com"),
+                    eq("Test User"),
+                    anyString());
+        }
+
+        @Test
+        @DisplayName("should never activate user")
+        void shouldNeverActivateUser() {
+            service.execute(VALID_COMMAND);
+
+            verify(userAccountGateway, never()).activateUser(any());
+        }
+
+        @Test
+        @DisplayName("should extract username from email")
+        void shouldExtractUsernameFromEmail() {
+            service.execute(VALID_COMMAND);
+
+            verify(userAccountGateway).createUser(
+                    eq("user"), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("should generate unique tokens on each registration")
+        void shouldGenerateUniqueTokens() {
+            when(userAccountGateway.createUser(any(), any(), any(), any(), any()))
+                    .thenReturn(INACTIVE_SNAPSHOT);
+
+            ArgumentCaptor<com.renewsim.backend.auth_service.domain.model.EmailVerificationToken> captor = ArgumentCaptor
+                    .forClass(
+                            com.renewsim.backend.auth_service.domain.model.EmailVerificationToken.class);
+
+            service.execute(VALID_COMMAND);
+            service.execute(new RegisterCommand("Other User", "Pass123!", "other@renewsim.com"));
+
+            verify(emailVerificationTokenRepository, times(2)).save(captor.capture());
+            var tokens = captor.getAllValues();
+            assertThat(tokens.get(0).getToken()).isNotEqualTo(tokens.get(1).getToken());
+        }
+
+        @Test
+        @DisplayName("should assign default USER role on creation")
+        void shouldAssignDefaultUserRole() {
+            service.execute(VALID_COMMAND);
+
+            verify(userAccountGateway).createUser(
+                    any(), any(), any(), any(),
+                    argThat(roles -> roles.contains(RoleName.USER) && roles.size() == 1));
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Happy path — local profile
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given local profile")
+    class LocalProfile {
+
+        @BeforeEach
+        void localProfile() {
+            when(environment.getActiveProfiles()).thenReturn(new String[] { "local" });
+            when(userAccountGateway.existsByEmail(any())).thenReturn(false);
+            when(userAccountGateway.createUser(any(), any(), any(), any(), any()))
+                    .thenReturn(ACTIVE_SNAPSHOT);
+        }
+
+        @Test
+        @DisplayName("should return ACTIVE result immediately")
+        void shouldReturnActiveResult() {
+            RegisterResult result = service.execute(VALID_COMMAND);
+
+            assertThat(result.status()).isEqualTo(AuthUserStatus.ACTIVE);
+            assertThat(result.message()).containsIgnoringCase("local");
+        }
+
+        @Test
+        @DisplayName("should auto-activate user")
+        void shouldAutoActivateUser() {
+            service.execute(VALID_COMMAND);
+
+            verify(userAccountGateway).activateUser(1L);
+        }
+
+        @Test
+        @DisplayName("should not send verification email")
+        void shouldNotSendVerificationEmail() {
+            service.execute(VALID_COMMAND);
+
+            verifyNoInteractions(emailPort);
+        }
+
+        @Test
+        @DisplayName("should not save verification token")
+        void shouldNotSaveVerificationToken() {
+            service.execute(VALID_COMMAND);
+
+            verifyNoInteractions(emailVerificationTokenRepository);
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Conflict — email already registered
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given email already exists")
+    class EmailConflict {
+
+        @BeforeEach
+        void emailExists() {
+            when(userAccountGateway.existsByEmail(any())).thenReturn(true);
+        }
+
+        @Test
+        @DisplayName("should throw ConflictException")
+        void shouldThrowConflictException() {
+            assertThatThrownBy(() -> service.execute(VALID_COMMAND))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("already registered");
+        }
+
+        @Test
+        @DisplayName("should never create user")
+        void shouldNeverCreateUser() {
+            assertThatThrownBy(() -> service.execute(VALID_COMMAND))
+                    .isInstanceOf(ConflictException.class);
+
+            verify(userAccountGateway, never()).createUser(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("should never send email")
+        void shouldNeverSendEmail() {
+            assertThatThrownBy(() -> service.execute(VALID_COMMAND))
+                    .isInstanceOf(ConflictException.class);
+
+            verifyNoInteractions(emailPort);
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Profile detection
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Profile detection")
+    class ProfileDetection {
+
+        @ParameterizedTest(name = "profile ''{0}'' should NOT auto-activate")
+        @ValueSource(strings = { "prod", "docker", "staging", "test" })
+        @DisplayName("non-local profiles should require email verification")
+        void nonLocalProfilesShouldRequireVerification(String profile) {
+            when(environment.getActiveProfiles()).thenReturn(new String[] { profile });
+            when(userAccountGateway.existsByEmail(any())).thenReturn(false);
+            when(userAccountGateway.createUser(any(), any(), any(), any(), any()))
+                    .thenReturn(INACTIVE_SNAPSHOT);
+
+            RegisterResult result = service.execute(VALID_COMMAND);
+
+            assertThat(result.status()).isEqualTo(AuthUserStatus.INACTIVE);
+            verify(userAccountGateway, never()).activateUser(any());
+        }
+
+        @Test
+        @DisplayName("multiple active profiles including local should auto-activate")
+        void multipleProfilesWithLocalShouldAutoActivate() {
+            when(environment.getActiveProfiles()).thenReturn(new String[] { "local", "debug" });
+            when(userAccountGateway.existsByEmail(any())).thenReturn(false);
+            when(userAccountGateway.createUser(any(), any(), any(), any(), any()))
+                    .thenReturn(ACTIVE_SNAPSHOT);
+
+            RegisterResult result = service.execute(VALID_COMMAND);
+
+            assertThat(result.status()).isEqualTo(AuthUserStatus.ACTIVE);
+            verify(userAccountGateway).activateUser(1L);
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Token expiration
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Token expiration")
+    class TokenExpiration {
+
+        @Test
+        @DisplayName("token should expire after configured hours")
+        void tokenShouldExpireAfterConfiguredHours() {
+            when(environment.getActiveProfiles()).thenReturn(new String[] { "prod" });
+            when(userAccountGateway.existsByEmail(any())).thenReturn(false);
+            when(userAccountGateway.createUser(any(), any(), any(), any(), any()))
+                    .thenReturn(INACTIVE_SNAPSHOT);
+
+            ArgumentCaptor<com.renewsim.backend.auth_service.domain.model.EmailVerificationToken> captor = ArgumentCaptor
+                    .forClass(
+                            com.renewsim.backend.auth_service.domain.model.EmailVerificationToken.class);
+
+            service.execute(VALID_COMMAND);
+
+            verify(emailVerificationTokenRepository).save(captor.capture());
+            var token = captor.getValue();
+
+            assertThat(token.getExpiresAt())
+                    .isAfter(java.time.LocalDateTime.now().plusHours(47))
+                    .isBefore(java.time.LocalDateTime.now().plusHours(49));
+        }
+    }
+}

--- a/src/test/java/com/renewsim/backend/auth_service/application/service/ResendVerificationEmailUseCaseTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/application/service/ResendVerificationEmailUseCaseTest.java
@@ -1,0 +1,213 @@
+package com.renewsim.backend.auth_service.application.service;
+
+import com.renewsim.backend.auth_service.application.dto.UserSnapshot;
+import com.renewsim.backend.auth_service.application.port.out.EmailPort;
+import com.renewsim.backend.auth_service.application.port.out.EmailVerificationTokenRepository;
+import com.renewsim.backend.auth_service.application.port.out.UserAccountGateway;
+import com.renewsim.backend.auth_service.application.service.ResendVerificationEmailUseCase.ResendVerificationException;
+import com.renewsim.backend.auth_service.domain.model.EmailVerificationToken;
+import com.renewsim.backend.shared.domain.vo.RoleName;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("ResendVerificationEmailUseCase")
+class ResendVerificationEmailUseCaseTest {
+
+    private UserAccountGateway userAccountGateway;
+    private EmailVerificationTokenRepository tokenRepository;
+    private EmailPort emailPort;
+    private ResendVerificationEmailUseCase useCase;
+
+    private static final String EMAIL = "user@renewsim.com";
+
+    private static final UserSnapshot UNVERIFIED_USER = UserSnapshot.disabled(
+            1L, "user", "Test User", "hash", EMAIL, Set.of(RoleName.USER));
+
+    private static final UserSnapshot VERIFIED_USER = UserSnapshot.active(
+            1L, "user", "Test User", "hash", EMAIL, Set.of(RoleName.USER));
+
+    @BeforeEach
+    void setUp() {
+        userAccountGateway = mock(UserAccountGateway.class);
+        tokenRepository = mock(EmailVerificationTokenRepository.class);
+        emailPort = mock(EmailPort.class);
+        useCase = new ResendVerificationEmailUseCase(userAccountGateway, tokenRepository, emailPort);
+    }
+
+    // ─────────────────────────────────────────────
+    // Happy path
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given an unverified user")
+    class UnverifiedUser {
+
+        @BeforeEach
+        void setup() {
+            when(userAccountGateway.findByEmail(EMAIL)).thenReturn(Optional.of(UNVERIFIED_USER));
+        }
+
+        @Test
+        @DisplayName("should save new verification token")
+        void shouldSaveNewToken() {
+            useCase.execute(EMAIL);
+
+            ArgumentCaptor<EmailVerificationToken> captor = ArgumentCaptor.forClass(EmailVerificationToken.class);
+            verify(tokenRepository).save(captor.capture());
+
+            EmailVerificationToken saved = captor.getValue();
+            assertThat(saved.getUserId()).isEqualTo(1L);
+            assertThat(saved.getToken()).isNotNull().isNotBlank();
+            assertThat(saved.getExpiresAt()).isAfter(java.time.LocalDateTime.now().minusMinutes(1));
+        }
+
+        @Test
+        @DisplayName("should send verification email")
+        void shouldSendVerificationEmail() {
+            useCase.execute(EMAIL);
+
+            verify(emailPort).sendVerificationEmail(
+                    eq(EMAIL),
+                    eq("Test User"),
+                    anyString());
+        }
+
+        @Test
+        @DisplayName("should generate unique tokens on each resend")
+        void shouldGenerateUniqueTokens() {
+            when(userAccountGateway.findByEmail(EMAIL)).thenReturn(Optional.of(UNVERIFIED_USER));
+
+            useCase.execute(EMAIL);
+            useCase.execute(EMAIL);
+
+            ArgumentCaptor<EmailVerificationToken> captor = ArgumentCaptor.forClass(EmailVerificationToken.class);
+            verify(tokenRepository, times(2)).save(captor.capture());
+
+            String token1 = captor.getAllValues().get(0).getToken();
+            String token2 = captor.getAllValues().get(1).getToken();
+            assertThat(token1).isNotEqualTo(token2);
+        }
+
+        @Test
+        @DisplayName("should complete without exception")
+        void shouldCompleteWithoutException() {
+            assertThatNoException().isThrownBy(() -> useCase.execute(EMAIL));
+        }
+
+        @Test
+        @DisplayName("token should be associated with correct userId")
+        void tokenShouldBelongToCorrectUser() {
+            useCase.execute(EMAIL);
+
+            ArgumentCaptor<EmailVerificationToken> captor = ArgumentCaptor.forClass(EmailVerificationToken.class);
+            verify(tokenRepository).save(captor.capture());
+
+            assertThat(captor.getValue().getUserId()).isEqualTo(UNVERIFIED_USER.id());
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // User not found
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given user does not exist")
+    class UserNotFound {
+
+        @BeforeEach
+        void setup() {
+            when(userAccountGateway.findByEmail(any())).thenReturn(Optional.empty());
+        }
+
+        @Test
+        @DisplayName("should throw ResendVerificationException")
+        void shouldThrow() {
+            assertThatThrownBy(() -> useCase.execute(EMAIL))
+                    .isInstanceOf(ResendVerificationException.class)
+                    .hasMessageContaining("User not found");
+        }
+
+        @Test
+        @DisplayName("should never send email")
+        void shouldNeverSendEmail() {
+            assertThatThrownBy(() -> useCase.execute(EMAIL))
+                    .isInstanceOf(ResendVerificationException.class);
+
+            verifyNoInteractions(emailPort);
+        }
+
+        @Test
+        @DisplayName("should never save token")
+        void shouldNeverSaveToken() {
+            assertThatThrownBy(() -> useCase.execute(EMAIL))
+                    .isInstanceOf(ResendVerificationException.class);
+
+            verifyNoInteractions(tokenRepository);
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Already verified
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given user is already verified")
+    class AlreadyVerified {
+
+        @BeforeEach
+        void setup() {
+            when(userAccountGateway.findByEmail(EMAIL)).thenReturn(Optional.of(VERIFIED_USER));
+        }
+
+        @Test
+        @DisplayName("should throw ResendVerificationException")
+        void shouldThrow() {
+            assertThatThrownBy(() -> useCase.execute(EMAIL))
+                    .isInstanceOf(ResendVerificationException.class)
+                    .hasMessageContaining("already verified");
+        }
+
+        @Test
+        @DisplayName("should never send email")
+        void shouldNeverSendEmail() {
+            assertThatThrownBy(() -> useCase.execute(EMAIL))
+                    .isInstanceOf(ResendVerificationException.class);
+
+            verifyNoInteractions(emailPort);
+        }
+
+        @Test
+        @DisplayName("should never save token")
+        void shouldNeverSaveToken() {
+            assertThatThrownBy(() -> useCase.execute(EMAIL))
+                    .isInstanceOf(ResendVerificationException.class);
+
+            verifyNoInteractions(tokenRepository);
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Various emails
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given various unknown emails")
+    class UnknownEmails {
+
+        @ParameterizedTest(name = "email ''{0}'' should not be found")
+        @ValueSource(strings = { "unknown@test.com", "ghost@renewsim.com", "nobody@mail.com" })
+        @DisplayName("should throw for any unknown email")
+        void shouldThrowForUnknownEmail(String email) {
+            when(userAccountGateway.findByEmail(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.execute(email))
+                    .isInstanceOf(ResendVerificationException.class)
+                    .hasMessageContaining("User not found");
+        }
+    }
+}

--- a/src/test/java/com/renewsim/backend/auth_service/application/service/VerifyEmailUseCaseTest.java
+++ b/src/test/java/com/renewsim/backend/auth_service/application/service/VerifyEmailUseCaseTest.java
@@ -1,0 +1,194 @@
+package com.renewsim.backend.auth_service.application.service;
+
+import com.renewsim.backend.auth_service.application.port.out.EmailVerificationTokenRepository;
+import com.renewsim.backend.auth_service.application.port.out.UserAccountGateway;
+import com.renewsim.backend.auth_service.application.service.VerifyEmailUseCase.EmailVerificationException;
+import com.renewsim.backend.auth_service.domain.model.EmailVerificationToken;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("VerifyEmailUseCase")
+class VerifyEmailUseCaseTest {
+
+    private EmailVerificationTokenRepository tokenRepository;
+    private UserAccountGateway userAccountGateway;
+    private VerifyEmailUseCase useCase;
+
+    private static final String VALID_TOKEN = "valid-token-abc123";
+    private static final Long USER_ID = 42L;
+
+    @BeforeEach
+    void setUp() {
+        tokenRepository = mock(EmailVerificationTokenRepository.class);
+        userAccountGateway = mock(UserAccountGateway.class);
+        useCase = new VerifyEmailUseCase(tokenRepository, userAccountGateway);
+    }
+
+    // ─────────────────────────────────────────────
+    // Happy path
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given a valid unused non-expired token")
+    class ValidToken {
+
+        private EmailVerificationToken token;
+
+        @BeforeEach
+        void setup() {
+            token = new EmailVerificationToken(
+                    USER_ID, VALID_TOKEN, LocalDateTime.now().plusHours(24));
+            when(tokenRepository.findByToken(VALID_TOKEN)).thenReturn(Optional.of(token));
+        }
+
+        @Test
+        @DisplayName("should activate user via gateway")
+        void shouldActivateUser() {
+            useCase.execute(VALID_TOKEN);
+
+            verify(userAccountGateway).activateUser(USER_ID);
+        }
+
+        @Test
+        @DisplayName("should mark token as verified")
+        void shouldMarkTokenAsVerified() {
+            useCase.execute(VALID_TOKEN);
+
+            assertThat(token.isVerified()).isTrue();
+            assertThat(token.getVerifiedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("should save verified token")
+        void shouldSaveVerifiedToken() {
+            useCase.execute(VALID_TOKEN);
+
+            verify(tokenRepository).save(token);
+        }
+
+        @Test
+        @DisplayName("should complete without exception")
+        void shouldCompleteWithoutException() {
+            assertThatNoException().isThrownBy(() -> useCase.execute(VALID_TOKEN));
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Token not found
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given token does not exist")
+    class TokenNotFound {
+
+        @BeforeEach
+        void setup() {
+            when(tokenRepository.findByToken(any())).thenReturn(Optional.empty());
+        }
+
+        @Test
+        @DisplayName("should throw EmailVerificationException")
+        void shouldThrow() {
+            assertThatThrownBy(() -> useCase.execute("non-existent-token"))
+                    .isInstanceOf(EmailVerificationException.class)
+                    .hasMessageContaining("Invalid or expired");
+        }
+
+        @Test
+        @DisplayName("should never activate user")
+        void shouldNeverActivateUser() {
+            assertThatThrownBy(() -> useCase.execute("non-existent-token"))
+                    .isInstanceOf(EmailVerificationException.class);
+
+            verify(userAccountGateway, never()).activateUser(any());
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Token already used
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given token already verified")
+    class AlreadyVerified {
+
+        @BeforeEach
+        void setup() {
+            EmailVerificationToken usedToken = new EmailVerificationToken(
+                    USER_ID, VALID_TOKEN, LocalDateTime.now().plusHours(24));
+            usedToken.markAsVerified();
+            when(tokenRepository.findByToken(VALID_TOKEN)).thenReturn(Optional.of(usedToken));
+        }
+
+        @Test
+        @DisplayName("should throw EmailVerificationException")
+        void shouldThrow() {
+            assertThatThrownBy(() -> useCase.execute(VALID_TOKEN))
+                    .isInstanceOf(EmailVerificationException.class)
+                    .hasMessageContaining("already been used");
+        }
+
+        @Test
+        @DisplayName("should never activate user")
+        void shouldNeverActivateUser() {
+            assertThatThrownBy(() -> useCase.execute(VALID_TOKEN))
+                    .isInstanceOf(EmailVerificationException.class);
+
+            verify(userAccountGateway, never()).activateUser(any());
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Token expired
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given token is expired")
+    class ExpiredToken {
+
+        @BeforeEach
+        void setup() {
+            EmailVerificationToken expiredToken = new EmailVerificationToken(
+                    USER_ID, VALID_TOKEN, LocalDateTime.now().minusSeconds(1));
+            when(tokenRepository.findByToken(VALID_TOKEN)).thenReturn(Optional.of(expiredToken));
+        }
+
+        @Test
+        @DisplayName("should throw EmailVerificationException")
+        void shouldThrow() {
+            assertThatThrownBy(() -> useCase.execute(VALID_TOKEN))
+                    .isInstanceOf(EmailVerificationException.class)
+                    .hasMessageContaining("expired");
+        }
+
+        @Test
+        @DisplayName("should never activate user")
+        void shouldNeverActivateUser() {
+            assertThatThrownBy(() -> useCase.execute(VALID_TOKEN))
+                    .isInstanceOf(EmailVerificationException.class);
+
+            verify(userAccountGateway, never()).activateUser(any());
+        }
+    }
+
+    // ─────────────────────────────────────────────
+    // Token format variation
+    // ─────────────────────────────────────────────
+    @Nested
+    @DisplayName("Given various invalid token strings")
+    class InvalidTokenStrings {
+
+        @ParameterizedTest(name = "token ''{0}'' should not be found")
+        @ValueSource(strings = { "", " ", "wrong-token", "abc" })
+        @DisplayName("should throw for unrecognized tokens")
+        void shouldThrowForUnrecognizedTokens(String token) {
+            when(tokenRepository.findByToken(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.execute(token))
+                    .isInstanceOf(EmailVerificationException.class);
+        }
+    }
+}


### PR DESCRIPTION

## What
Closes production gaps identified during Phase 2 audit of auth_service, user_service and role_service.

## Changes

### Security fixes
- `SecurityConfig`: add `permitAll` for `/api/v1/auth/email-verification/**` — users cannot verify email without being authenticated
- `RoleController`: fix `GET /roles/by-name/{name}` returning HTTP 200 + null body when role not found → now throws `ResourceNotFoundException` (404)

### Architecture fixes (layer leak removal)
- `VerifyEmailUseCase`: remove direct import of `UserRepositoryPort` and `User` from `user_service` — replaced with `UserAccountGateway.activateUser()` (correct auth→user_service boundary)
- `ResendVerificationEmailUseCase`: same fix — replaced `UserRepositoryPort` with `UserAccountGateway.findByEmail()`

### Performance fix
- `UserController.getMe()`: remove double query (getUserUseCase + getMyProfileUseCase) — replaced with single `getMyProfileUseCase.getMyProfileByEmail(principal.username())`
- `GetMyProfileUseCase`: add `getMyProfileByEmail(String email)` method
- `GetMyProfileService`: implement `getMyProfileByEmail` using `UserRepositoryPort.findByEmail()`

## Tests added (61 new tests)
- `RegisterUserServiceTest`: local/prod profile, conflict, token expiration, unique token generation
- `RefreshTokenServiceTest`: token rotation, expired token, revoked token, disabled user, user not found
- `VerifyEmailUseCaseTest`: valid token, expired, already used, not found
- `ResendVerificationEmailUseCaseTest`: unverified user, already verified, user not found

## Stats
- Before: 397 tests
- After: 458 tests
- Failures: 0
- Build: SUCCESS

## Checklist
- [x] All tests green
- [x] No cross-bounded-context layer leaks in auth_service
- [x] Security endpoints correctly public
- [x] Role endpoint returns correct HTTP status
- [x] Single query on GET /users/me