### PR TITLE
Add DELETE /api/v1/users/{id} endpoint for ADMIN with error handling

### DIFF
--- a/src/main/java/com/renewsim/backend/user_service/application/port/in/DeleteUserUseCase.java
+++ b/src/main/java/com/renewsim/backend/user_service/application/port/in/DeleteUserUseCase.java
@@ -1,0 +1,5 @@
+package com.renewsim.backend.user_service.application.port.in;
+
+public interface DeleteUserUseCase {
+    void deleteUser(Long userId);
+}

--- a/src/main/java/com/renewsim/backend/user_service/application/service/DeleteUserService.java
+++ b/src/main/java/com/renewsim/backend/user_service/application/service/DeleteUserService.java
@@ -1,0 +1,27 @@
+package com.renewsim.backend.user_service.application.service;
+
+import com.renewsim.backend.shared.exception.UserNotFoundException;
+import com.renewsim.backend.user_service.application.port.in.DeleteUserUseCase;
+import com.renewsim.backend.user_service.application.port.out.UserRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteUserService implements DeleteUserUseCase {
+
+    private final UserRepositoryPort userRepositoryPort;
+
+    @Override
+    public void deleteUser(Long userId) {
+        if (!userRepositoryPort.existsById(userId)) {
+            throw new UserNotFoundException("User with id " + userId + " not found");
+        }
+        userRepositoryPort.deleteById(userId);
+        log.info("User deleted userId={}", userId);
+    }
+}

--- a/src/main/java/com/renewsim/backend/user_service/web/controller/UserController.java
+++ b/src/main/java/com/renewsim/backend/user_service/web/controller/UserController.java
@@ -33,6 +33,7 @@ public class UserController {
         private final UpdateMyProfileUseCase updateMyProfileUseCase;
         private final ChangeMyPasswordUseCase changeMyPasswordUseCase;
         private final ActivateUserUseCase activateUserUseCase;
+        private final DeleteUserUseCase deleteUserUseCase;
 
         // ----------------------------------------------------
         // POST /users → Create
@@ -220,5 +221,16 @@ public class UserController {
         public ResponseEntity<OperationResponse<Void>> activate(@PathVariable Long id) {
                 activateUserUseCase.activate(id);
                 return ResponseEntity.ok(ApiResponseFactory.noContent("User activated successfully"));
+        }
+
+        // ----------------------------------------------------
+        // DELETE /users/{id} → Delete user (ADMIN only)
+        // ----------------------------------------------------
+        @Operation(summary = "Delete user", description = "Requires role ADMIN", security = @SecurityRequirement(name = "bearerAuth"))
+        @DeleteMapping("/{id}")
+        @PreAuthorize("hasRole('ADMIN')")
+        public ResponseEntity<OperationResponse<Void>> delete(@PathVariable Long id) {
+                deleteUserUseCase.deleteUser(id);
+                return ResponseEntity.ok(ApiResponseFactory.noContent("User deleted successfully"));
         }
 }

--- a/src/test/java/com/renewsim/backend/user_service/application/service/DeleteUserServiceTest.java
+++ b/src/test/java/com/renewsim/backend/user_service/application/service/DeleteUserServiceTest.java
@@ -1,0 +1,68 @@
+package com.renewsim.backend.user_service.application.service;
+
+import com.renewsim.backend.shared.exception.UserNotFoundException;
+import com.renewsim.backend.user_service.application.port.out.UserRepositoryPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.*;
+
+@DisplayName("DeleteUserService")
+class DeleteUserServiceTest {
+
+    private UserRepositoryPort userRepositoryPort;
+    private DeleteUserService service;
+
+    @BeforeEach
+    void setUp() {
+        userRepositoryPort = mock(UserRepositoryPort.class);
+        service = new DeleteUserService(userRepositoryPort);
+    }
+
+    @Nested
+    @DisplayName("Given user exists")
+    class UserExists {
+
+        @BeforeEach
+        void setup() {
+            when(userRepositoryPort.existsById(1L)).thenReturn(true);
+        }
+
+        @Test
+        @DisplayName("should delete user successfully")
+        void shouldDeleteUser() {
+            assertThatNoException().isThrownBy(() -> service.deleteUser(1L));
+            verify(userRepositoryPort).deleteById(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("Given user does not exist")
+    class UserNotFound {
+
+        @BeforeEach
+        void setup() {
+            when(userRepositoryPort.existsById(99L)).thenReturn(false);
+        }
+
+        @Test
+        @DisplayName("should throw UserNotFoundException")
+        void shouldThrow() {
+            assertThatThrownBy(() -> service.deleteUser(99L))
+                    .isInstanceOf(UserNotFoundException.class)
+                    .hasMessageContaining("99");
+        }
+
+        @Test
+        @DisplayName("should never call deleteById")
+        void shouldNeverDelete() {
+            assertThatThrownBy(() -> service.deleteUser(99L))
+                    .isInstanceOf(UserNotFoundException.class);
+            verify(userRepositoryPort, never()).deleteById(any());
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces the ability for administrators to delete users from the system. It adds the necessary service, controller endpoint, and tests to ensure proper functionality and error handling.

**User Deletion Feature:**

* Added the `DeleteUserUseCase` interface to define the contract for deleting a user by ID.
* Implemented the `DeleteUserService` class, which checks for user existence, deletes the user if found, and throws a `UserNotFoundException` otherwise.
* Updated the `UserController` to inject `DeleteUserUseCase` and added a new `DELETE /users/{id}` endpoint, secured for ADMIN role, to handle user deletion requests. [[1]](diffhunk://#diff-5b548cb89f601ab75c3f3adb769ea1da31960953fb3a8d7de23e403707e19820R36) [[2]](diffhunk://#diff-5b548cb89f601ab75c3f3adb769ea1da31960953fb3a8d7de23e403707e19820R225-R235)

**Testing:**

* Added `DeleteUserServiceTest` to verify that users are deleted when they exist, and that the appropriate exception is thrown and no deletion occurs when the user does not exist.… UserNotFoundException on missing user