### PR TITLE
feat(simulation): unify lifecycle and complete technologies contract

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/application/port/in/CreateSimulationUseCase.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/port/in/CreateSimulationUseCase.java
@@ -2,8 +2,11 @@ package com.renewsim.backend.simulation_service.application.port.in;
 
 import com.renewsim.backend.simulation_service.application.command.CreateSimulationCommand;
 import com.renewsim.backend.simulation_service.application.result.SimulationCreationResultDTO;
+import com.renewsim.backend.simulation_service.web.dto.SimulationRecommendationResultDTO;
 
 public interface CreateSimulationUseCase {
     SimulationCreationResultDTO createSimulation(CreateSimulationCommand command);
+
+    SimulationRecommendationResultDTO createSimulationWithRecommendation(CreateSimulationCommand command);
 }
 

--- a/src/main/java/com/renewsim/backend/simulation_service/application/result/SimulationDetailResultDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/result/SimulationDetailResultDTO.java
@@ -1,6 +1,7 @@
 package com.renewsim.backend.simulation_service.application.result;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record SimulationDetailResultDTO(
     Long id,
@@ -12,7 +13,8 @@ public record SimulationDetailResultDTO(
     double estimatedSavings,
     Double returnOnInvestment,
     LocalDateTime timestamp,
-    String createdBy
+    String createdBy,
+    List<Long> technologyIds
 ) {}
 
 

--- a/src/main/java/com/renewsim/backend/simulation_service/application/service/SimulationApplicationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/service/SimulationApplicationService.java
@@ -18,6 +18,8 @@ import com.renewsim.backend.simulation_service.domain.model.vo.CO2Reduction;
 import com.renewsim.backend.simulation_service.domain.model.vo.ClimateData;
 import com.renewsim.backend.simulation_service.domain.model.vo.EnergyOutput;
 import com.renewsim.backend.simulation_service.domain.model.vo.ProjectSize;
+import com.renewsim.backend.simulation_service.web.dto.SimulationRecommendationResultDTO;
+import com.renewsim.backend.technology_service.application.service.TechnologyRecommenderService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -36,6 +38,7 @@ public class SimulationApplicationService implements
         private final SimulationValidator validator;
         private final SimulationCalculator calculator;
         private final ClimateDataProviderPort climateProvider;
+        private final TechnologyRecommenderService recommender;
 
         // --------------------------------------------------
         // CREATE
@@ -66,6 +69,15 @@ public class SimulationApplicationService implements
                 Simulation completed = base.withCalculatedResults(energyOutput, co2Reduction);
                 Simulation saved = repository.save(completed);
 
+                List<Long> desiredTechnologies = (command.technologyIds() != null && !command.technologyIds().isEmpty())
+                                ? command.technologyIds()
+                                : recommender.recommendFor(saved);
+
+                if (desiredTechnologies != null && !desiredTechnologies.isEmpty()) {
+                        Simulation withTechnologies = saved.assignTechnologies(desiredTechnologies);
+                        saved = repository.save(withTechnologies);
+                }
+
                 return new SimulationCreationResultDTO(
                                 saved.id(),
                                 saved.location(),
@@ -73,6 +85,20 @@ public class SimulationApplicationService implements
                                 saved.projectSize().value(),
                                 saved.budget().value(),
                                 saved.createdAt());
+        }
+
+        @Override
+        public SimulationRecommendationResultDTO createSimulationWithRecommendation(CreateSimulationCommand command) {
+
+                SimulationCreationResultDTO created = createSimulation(command);
+
+                Simulation saved = repository.findById(created.id())
+                                .orElseThrow(() -> new SimulationNotFoundException(created.id()));
+
+                return new SimulationRecommendationResultDTO(
+                                saved.id(),
+                                saved.energyType().name(),
+                                saved.technologyIds());
         }
 
         // --------------------------------------------------
@@ -169,7 +195,8 @@ public class SimulationApplicationService implements
                                 savings,
                                 roiYears,
                                 simulation.createdAt(),
-                                simulation.createdBy()
+                                simulation.createdBy(),
+                                simulation.technologyIds()
 
                 );
         }

--- a/src/main/java/com/renewsim/backend/simulation_service/application/service/SimulationOrchestratorService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/service/SimulationOrchestratorService.java
@@ -1,22 +1,11 @@
 package com.renewsim.backend.simulation_service.application.service;
 
 import com.renewsim.backend.simulation_service.application.command.CreateSimulationCommand;
-import com.renewsim.backend.simulation_service.application.port.out.ClimateDataProviderPort;
-import com.renewsim.backend.simulation_service.application.port.out.SimulationRepositoryPort;
-import com.renewsim.backend.simulation_service.domain.factory.SimulationFactory;
-import com.renewsim.backend.simulation_service.domain.model.Simulation;
-import com.renewsim.backend.simulation_service.domain.model.vo.CO2Reduction;
-import com.renewsim.backend.simulation_service.domain.model.vo.ClimateData;
-import com.renewsim.backend.simulation_service.domain.model.vo.EnergyOutput;
 import com.renewsim.backend.simulation_service.web.dto.SimulationRecommendationResultDTO;
-import com.renewsim.backend.technology_service.application.service.TechnologyRecommenderService;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 /**
  * SimulationOrchestratorService
@@ -26,17 +15,12 @@ import java.util.List;
  * Garantiza persistencia coherente y consistencia transaccional siguiendo
  * principios DDD.
  */
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class SimulationOrchestratorService {
 
-        private final SimulationRepositoryPort repository;
-        private final SimulationValidator validator;
-        private final SimulationCalculator calculator;
-        private final TechnologyRecommenderService recommender;
-        private final ClimateDataProviderPort climateProvider;
+        private final SimulationApplicationService simulationApplicationService;
 
         /**
          * Crea una simulación y recomienda tecnologías según su tipo de energía.
@@ -47,44 +31,7 @@ public class SimulationOrchestratorService {
          * 4 Asignarlas y persistir la simulación actualizada.
          */
         public SimulationRecommendationResultDTO createSimulationWithRecommendation(CreateSimulationCommand command) {
-
-                validator.validateProjectSize(command.projectSize());
-                validator.validateBudget(command.budget());
-
-                ClimateData climateData = command.climateData() != null
-                                ? command.climateData()
-                                : climateProvider.fetchClimateData(command.location());
-
-                // 1️ Crear simulación base
-                Simulation base = SimulationFactory.create(
-                                command.location(),
-                                command.energyType(),
-                                command.projectSize(),
-                                command.budget(),
-                                climateData,
-                                List.of(),
-                                command.createdBy());
-
-                // 2️ Calcular resultados
-                EnergyOutput energyOutput = calculator.calculateEnergyOutput(base);
-                CO2Reduction co2Reduction = calculator.calculateCo2Reduction(energyOutput);
-
-                Simulation completed = base.withCalculatedResults(energyOutput, co2Reduction);
-
-                // 3️ Guardar simulación COMPLETA
-                Simulation saved = repository.save(completed);
-
-                // 4️ Recomendar tecnologías
-                List<Long> recommendedIds = recommender.recommendFor(saved);
-
-                Simulation finalSimulation = saved.assignTechnologies(recommendedIds);
-
-                repository.save(finalSimulation);
-
-                return new SimulationRecommendationResultDTO(
-                                finalSimulation.id(),
-                                finalSimulation.energyType().name(),
-                                finalSimulation.technologyIds());
+                return simulationApplicationService.createSimulationWithRecommendation(command);
         }
 
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/web/controller/SimulationTechnologyController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/controller/SimulationTechnologyController.java
@@ -3,7 +3,9 @@ package com.renewsim.backend.simulation_service.web.controller;
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
 import com.renewsim.backend.simulation_service.application.port.in.GetSimulationUseCase;
 import com.renewsim.backend.simulation_service.application.command.GetSimulationByIdCommand;
+import com.renewsim.backend.simulation_service.application.port.out.TechnologyClientPort;
 import com.renewsim.backend.simulation_service.application.result.SimulationDetailResultDTO;
+import com.renewsim.backend.simulation_service.web.dto.TechnologyResponseDTO;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,6 +20,7 @@ import java.util.List;
 public class SimulationTechnologyController {
 
     private final GetSimulationUseCase getSimulationUseCase;
+    private final TechnologyClientPort technologyClientPort;
 
     /**
      * Devuelve las tecnologías asociadas a una simulación específica
@@ -25,7 +28,7 @@ public class SimulationTechnologyController {
      */
     @PreAuthorize("hasAuthority('SCOPE_read:simulations')")
     @GetMapping("/{id}/technologies")
-    public List<String> getTechnologiesBySimulationId(@PathVariable Long id, Authentication auth) {
+    public List<TechnologyResponseDTO> getTechnologiesBySimulationId(@PathVariable Long id, Authentication auth) {
         AuthenticatedUser user = (AuthenticatedUser) auth.getPrincipal();
         boolean isAdmin = auth.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
@@ -34,6 +37,8 @@ public class SimulationTechnologyController {
             new GetSimulationByIdCommand(id, user.username(), isAdmin)
         );
 
-        return List.of(); // technologyIds not available in SimulationDetailResultDTO
+        return simulation.technologyIds().stream()
+                .map(technologyClientPort::getTechnologyById)
+                .toList();
     }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/application/service/SimulationApplicationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/application/service/SimulationApplicationServiceTest.java
@@ -1,0 +1,192 @@
+package com.renewsim.backend.simulation_service.application.service;
+
+import com.renewsim.backend.simulation_service.application.command.CreateSimulationCommand;
+import com.renewsim.backend.simulation_service.application.command.GetSimulationByIdCommand;
+import com.renewsim.backend.simulation_service.application.port.out.ClimateDataProviderPort;
+import com.renewsim.backend.simulation_service.application.port.out.SimulationRepositoryPort;
+import com.renewsim.backend.simulation_service.application.result.SimulationDetailResultDTO;
+import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import com.renewsim.backend.simulation_service.domain.model.vo.Budget;
+import com.renewsim.backend.simulation_service.domain.model.vo.CO2Reduction;
+import com.renewsim.backend.simulation_service.domain.model.vo.ClimateData;
+import com.renewsim.backend.simulation_service.domain.model.vo.EnergyOutput;
+import com.renewsim.backend.simulation_service.domain.model.vo.EnergyType;
+import com.renewsim.backend.simulation_service.domain.model.vo.ProjectSize;
+import com.renewsim.backend.technology_service.application.service.TechnologyRecommenderService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SimulationApplicationServiceTest {
+
+    @Mock
+    private SimulationRepositoryPort repository;
+    @Mock
+    private SimulationValidator validator;
+    @Mock
+    private SimulationCalculator calculator;
+    @Mock
+    private ClimateDataProviderPort climateProvider;
+    @Mock
+    private TechnologyRecommenderService recommender;
+
+    @Test
+    @DisplayName("RED->GREEN: createSimulation assigns recommendations when command has no technologies")
+    void createSimulationAssignsRecommendationsWhenCommandHasNoTechnologies() {
+        SimulationApplicationService service = new SimulationApplicationService(
+                repository,
+                validator,
+                calculator,
+                climateProvider,
+                recommender);
+
+        ClimateData climateData = new ClimateData(5, 7, 1);
+        CreateSimulationCommand command = new CreateSimulationCommand(
+                "Mendoza",
+                EnergyType.SOLAR,
+                100,
+                10000,
+                climateData,
+                List.of(),
+                "alice");
+
+        doNothing().when(validator).validateProjectSize(100);
+        doNothing().when(validator).validateBudget(10000);
+        when(calculator.calculateEnergyOutput(any(Simulation.class))).thenReturn(new EnergyOutput(120000));
+        when(calculator.calculateCo2Reduction(any(EnergyOutput.class))).thenReturn(new CO2Reduction(84));
+
+        Simulation afterCreateSave = new Simulation(
+                99L,
+                "Mendoza",
+                EnergyType.SOLAR,
+                new ProjectSize(100),
+                new Budget(10000),
+                new EnergyOutput(120000),
+                new CO2Reduction(84),
+                climateData,
+                List.of(),
+                "alice",
+                LocalDateTime.parse("2026-05-22T09:00:00"));
+
+        Simulation afterRecommendationSave = new Simulation(
+                99L,
+                "Mendoza",
+                EnergyType.SOLAR,
+                new ProjectSize(100),
+                new Budget(10000),
+                new EnergyOutput(120000),
+                new CO2Reduction(84),
+                climateData,
+                List.of(1L),
+                "alice",
+                LocalDateTime.parse("2026-05-22T09:00:00"));
+
+        when(repository.save(any(Simulation.class))).thenReturn(afterCreateSave, afterRecommendationSave);
+        when(recommender.recommendFor(afterCreateSave)).thenReturn(List.of(1L));
+
+        service.createSimulation(command);
+
+        verify(repository, times(2)).save(any(Simulation.class));
+        ArgumentCaptor<Simulation> saveCaptor = ArgumentCaptor.forClass(Simulation.class);
+        verify(repository, times(2)).save(saveCaptor.capture());
+        assertThat(saveCaptor.getAllValues().get(1).technologyIds()).containsExactly(1L);
+    }
+
+    @Test
+    @DisplayName("TRIANGULATE: createSimulation keeps explicit command technologies and skips recommender")
+    void createSimulationKeepsExplicitCommandTechnologies() {
+        SimulationApplicationService service = new SimulationApplicationService(
+                repository,
+                validator,
+                calculator,
+                climateProvider,
+                recommender);
+
+        ClimateData climateData = new ClimateData(5, 7, 1);
+        CreateSimulationCommand command = new CreateSimulationCommand(
+                "Mendoza",
+                EnergyType.SOLAR,
+                100,
+                10000,
+                climateData,
+                List.of(9L, 10L),
+                "alice");
+
+        doNothing().when(validator).validateProjectSize(100);
+        doNothing().when(validator).validateBudget(10000);
+        when(calculator.calculateEnergyOutput(any(Simulation.class))).thenReturn(new EnergyOutput(120000));
+        when(calculator.calculateCo2Reduction(any(EnergyOutput.class))).thenReturn(new CO2Reduction(84));
+
+        Simulation saved = new Simulation(
+                100L,
+                "Mendoza",
+                EnergyType.SOLAR,
+                new ProjectSize(100),
+                new Budget(10000),
+                new EnergyOutput(120000),
+                new CO2Reduction(84),
+                climateData,
+                List.of(),
+                "alice",
+                LocalDateTime.parse("2026-05-22T09:00:00"));
+
+        when(repository.save(any(Simulation.class))).thenReturn(saved, saved);
+
+        service.createSimulation(command);
+
+        verify(repository, times(2)).save(any(Simulation.class));
+        verify(recommender, never()).recommendFor(any(Simulation.class));
+
+        ArgumentCaptor<Simulation> saveCaptor = ArgumentCaptor.forClass(Simulation.class);
+        verify(repository, times(2)).save(saveCaptor.capture());
+        assertThat(saveCaptor.getAllValues().get(1).technologyIds()).containsExactly(9L, 10L);
+    }
+
+    @Test
+    @DisplayName("RED->GREEN: getSimulationById includes technologyIds in detail result")
+    void getSimulationByIdIncludesTechnologyIdsInDetailResult() {
+        SimulationApplicationService service = new SimulationApplicationService(
+                repository,
+                validator,
+                calculator,
+                climateProvider,
+                recommender);
+
+        Simulation simulation = new Simulation(
+                77L,
+                "Cordoba",
+                EnergyType.WIND,
+                new ProjectSize(80),
+                new Budget(20000),
+                new EnergyOutput(80000),
+                new CO2Reduction(40),
+                new ClimateData(4, 9, 0),
+                List.of(2L, 3L),
+                "alice",
+                LocalDateTime.parse("2026-05-22T12:00:00"));
+
+        when(repository.findById(77L)).thenReturn(Optional.of(simulation));
+        when(calculator.calculateSavings(simulation)).thenReturn(5000.0);
+        when(calculator.calculateRoiYears(simulation)).thenReturn(4.0);
+
+        SimulationDetailResultDTO detail = service.getSimulationById(new GetSimulationByIdCommand(77L, "alice", false));
+
+        assertThat(detail.technologyIds()).containsExactly(2L, 3L);
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/web/controller/SimulationTechnologyControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/web/controller/SimulationTechnologyControllerTest.java
@@ -1,0 +1,112 @@
+package com.renewsim.backend.simulation_service.web.controller;
+
+import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
+import com.renewsim.backend.simulation_service.application.command.GetSimulationByIdCommand;
+import com.renewsim.backend.simulation_service.application.port.in.GetSimulationUseCase;
+import com.renewsim.backend.simulation_service.application.port.out.TechnologyClientPort;
+import com.renewsim.backend.simulation_service.application.result.SimulationDetailResultDTO;
+import com.renewsim.backend.simulation_service.web.dto.TechnologyResponseDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SimulationTechnologyControllerTest {
+
+    @Mock
+    private GetSimulationUseCase getSimulationUseCase;
+    @Mock
+    private TechnologyClientPort technologyClientPort;
+
+    @InjectMocks
+    private SimulationTechnologyController controller;
+
+    @Test
+    @DisplayName("RED->GREEN: technologies endpoint returns concrete technology data for simulation IDs")
+    void getTechnologiesBySimulationIdReturnsMappedTechnologyPayload() {
+        AuthenticatedUser user = AuthenticatedUser.of(
+                "alice",
+                Set.of("USER"),
+                Set.of("read:simulations"));
+        Authentication authentication = new TestingAuthenticationToken(
+                user,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+        SimulationDetailResultDTO simulation = new SimulationDetailResultDTO(
+                55L,
+                "Mendoza",
+                "SOLAR",
+                100,
+                10000,
+                120000,
+                30000,
+                4.0,
+                LocalDateTime.parse("2026-05-22T11:00:00"),
+                "alice",
+                List.of(1L, 2L));
+
+        when(getSimulationUseCase.getSimulationById(any(GetSimulationByIdCommand.class))).thenReturn(simulation);
+        when(technologyClientPort.getTechnologyById(1L)).thenReturn(new TechnologyResponseDTO(1L, "Solar Panel", "SOLAR", 21, 20000, 30, 5000));
+        when(technologyClientPort.getTechnologyById(2L)).thenReturn(new TechnologyResponseDTO(2L, "Wind Turbine", "WIND", 35, 50000, 50, 12000));
+
+        List<TechnologyResponseDTO> response = controller.getTechnologiesBySimulationId(55L, authentication);
+
+        assertThat(response).hasSize(2);
+        assertThat(response.get(0).id()).isEqualTo(1L);
+        assertThat(response.get(1).id()).isEqualTo(2L);
+        verify(technologyClientPort, times(2)).getTechnologyById(any(Long.class));
+    }
+
+    @Test
+    @DisplayName("TRIANGULATE: technologies endpoint keeps ownership command context")
+    void getTechnologiesBySimulationIdUsesOwnerAndAdminFlags() {
+        AuthenticatedUser user = AuthenticatedUser.of(
+                "admin",
+                Set.of("ADMIN"),
+                Set.of("read:simulations"));
+        Authentication authentication = new TestingAuthenticationToken(
+                user,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+
+        SimulationDetailResultDTO simulation = new SimulationDetailResultDTO(
+                88L,
+                "Cordoba",
+                "WIND",
+                50,
+                7000,
+                60000,
+                11000,
+                2.0,
+                LocalDateTime.parse("2026-05-22T12:00:00"),
+                "alice",
+                List.of());
+
+        when(getSimulationUseCase.getSimulationById(any(GetSimulationByIdCommand.class))).thenReturn(simulation);
+
+        controller.getTechnologiesBySimulationId(88L, authentication);
+
+        ArgumentCaptor<GetSimulationByIdCommand> commandCaptor = ArgumentCaptor.forClass(GetSimulationByIdCommand.class);
+        verify(getSimulationUseCase).getSimulationById(commandCaptor.capture());
+        assertThat(commandCaptor.getValue().requesterUsername()).isEqualTo("admin");
+        assertThat(commandCaptor.getValue().isAdmin()).isTrue();
+    }
+}


### PR DESCRIPTION
This pull request introduces several enhancements to the simulation service, focusing on improved technology recommendation and assignment during simulation creation, better encapsulation of simulation details (including associated technology IDs), and improved test coverage. The main changes include updating core service logic to assign recommended technologies, exposing technology IDs in API responses, refactoring orchestration logic, and adding comprehensive unit tests.

**Simulation creation and recommendation logic:**
- The `SimulationApplicationService` now assigns technology recommendations during simulation creation if no explicit technologies are provided in the command, using the `TechnologyRecommenderService`. This ensures simulations always have associated technologies, either user-specified or recommended.
- Added a new method `createSimulationWithRecommendation` to the `CreateSimulationUseCase` interface and its implementation, which creates a simulation and returns recommended technologies in a single operation. [[1]](diffhunk://#diff-5933a986136beee9f5ff8d4c5a89125aa7457d3757639c04dd2db07b150a4533R5-R10) [[2]](diffhunk://#diff-2c7bfc906cb72b1044356ab1333996bfbbeab31bee67346d73ef8293972c669dR90-R103)

**Simulation detail and technology exposure:**
- The `SimulationDetailResultDTO` record and its population now include a `technologyIds` field, allowing clients to retrieve the list of associated technology IDs for a simulation. [[1]](diffhunk://#diff-7d1adff2d6b2afa021813fea31b07b171ad6ff80392f73fdb1a505816bc7becbR4) [[2]](diffhunk://#diff-7d1adff2d6b2afa021813fea31b07b171ad6ff80392f73fdb1a505816bc7becbL15-R17) [[3]](diffhunk://#diff-2c7bfc906cb72b1044356ab1333996bfbbeab31bee67346d73ef8293972c669dL172-R199)
- The `SimulationTechnologyController` endpoint `/simulation/{id}/technologies` now returns detailed technology DTOs by fetching them via the `TechnologyClientPort`, instead of just returning an empty list or IDs. [[1]](diffhunk://#diff-98ae5c0e447489adaafc69f989a7bdf2c5a842093564d9f4cbc98dbfd24a5f77R6-R8) [[2]](diffhunk://#diff-98ae5c0e447489adaafc69f989a7bdf2c5a842093564d9f4cbc98dbfd24a5f77R23-R31) [[3]](diffhunk://#diff-98ae5c0e447489adaafc69f989a7bdf2c5a842093564d9f4cbc98dbfd24a5f77L37-R42)

**Service refactoring and orchestration:**
- The `SimulationOrchestratorService` has been refactored to delegate simulation creation and recommendation logic to the `SimulationApplicationService`, removing redundant orchestration logic and ensuring a single point of business logic. [[1]](diffhunk://#diff-480e428103747078dccaf420e74a707f31c729ba4bac13a0089fd2b76f0a2dc4L4-L20) [[2]](diffhunk://#diff-480e428103747078dccaf420e74a707f31c729ba4bac13a0089fd2b76f0a2dc4L29-R23) [[3]](diffhunk://#diff-480e428103747078dccaf420e74a707f31c729ba4bac13a0089fd2b76f0a2dc4L50-R34)

**Testing improvements:**
- Added a new unit test class `SimulationApplicationServiceTest` that verifies:
  - Technology recommendations are assigned when not specified.
  - Explicit technology IDs are honored and recommendations skipped.
  - Technology IDs are included in simulation detail results.

These changes collectively improve the maintainability, correctness, and usability of the simulation service API, especially in how simulations and their associated technologies are managed and exposed to clients.