### PR TITLE
Stabilize AuthRateLimitingIT configuration

### DIFF
--- a/src/test/java/com/renewsim/backend/auth_service/web/AuthRateLimitingIT.java
+++ b/src/test/java/com/renewsim/backend/auth_service/web/AuthRateLimitingIT.java
@@ -2,17 +2,24 @@ package com.renewsim.backend.auth_service.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.auth_service.infrastructure.config.SecurityRateLimitProperties;
-import com.renewsim.backend.config.TestSecurityConfig;
+import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimiter;
+import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimitingFilter;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -21,8 +28,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Import(TestSecurityConfig.class)
-class AuthRateLimitingITTest {
+@Import(AuthRateLimitingIT.RateLimitingTestConfig.class)
+@TestPropertySource(properties = {
+    "security.rate-limiting.enabled=true",
+    "security.rate-limiting.strategy=IP",
+    "security.rate-limiting.max-attempts=2",
+    "security.rate-limiting.window=30s",
+    "security.rate-limiting.retry-after=30s",
+    "security.rate-limiting.login-path=/api/v1/auth/login"
+})
+class AuthRateLimitingIT {
+
+    @TestConfiguration
+    static class RateLimitingTestConfig {
+        @Bean(name = "authRateLimitingFilter")
+        @Primary
+        LoginRateLimitingFilter authRateLimitingFilter(ObjectMapper objectMapper, SecurityRateLimitProperties p) {
+            LoginRateLimiter.Strategy strategy = (p.getStrategy() == SecurityRateLimitProperties.Strategy.IP_USER)
+                    ? LoginRateLimiter.Strategy.IP_USER
+                    : LoginRateLimiter.Strategy.IP;
+            return new LoginRateLimitingFilter(
+                    new LoginRateLimiter(p.getWindowSeconds(), p.getMaxAttempts(), strategy),
+                    objectMapper,
+                    p);
+        }
+    }
 
     @Autowired
     MockMvc mvc;
@@ -32,11 +62,11 @@ class AuthRateLimitingITTest {
     SecurityRateLimitProperties rateProps;
 
     static class LoginDto {
-        public String username;
+        public String email;
         public String password;
 
-        LoginDto(String username, String password) {
-            this.username = username;
+        LoginDto(String email, String password) {
+            this.email = email;
             this.password = password;
         }
     }
@@ -44,9 +74,10 @@ class AuthRateLimitingITTest {
     @Test
     @DisplayName("Exceed attempts -> 429 with Retry-After")
     void exceedAttemptsShouldReturn429AndRetryAfter() throws Exception {
-        final String loginPath = rateProps.getLoginPath(); 
+        final String loginPath = rateProps.getLoginPath();
+        final String randomEmail = "rate_" + UUID.randomUUID().toString().substring(0, 8) + "@mail.com";
         final String body = objectMapper.writeValueAsString(
-            new LoginDto("user@example.com", "WrongPassword123")
+            new LoginDto(randomEmail, "WrongPassword123")
         );
 
         for (int i = 0; i < rateProps.getMaxAttempts() - 1; i++) {


### PR DESCRIPTION
This pull request updates the authentication rate limiting integration test to improve test isolation and configuration clarity. The test class is renamed, a custom test configuration is added for rate limiting, and the login test now uses a unique email per run to avoid interference from previous tests.

**Test configuration improvements:**

* Renamed the test class from `AuthRateLimitingITTest` to `AuthRateLimitingIT` for consistency and clarity.
* Added an inner `RateLimitingTestConfig` class with a custom `LoginRateLimitingFilter` bean to explicitly configure rate limiting for tests, using `@TestConfiguration` and `@Primary`.
* Applied `@TestPropertySource` to set rate limiting properties directly in the test, ensuring predictable and isolated test behavior.

**Test data isolation:**

* Updated the login test to generate a unique email address for each test run, preventing rate limiting from being triggered by previous test executions.

**Code consistency:**

* Changed the `LoginDto` field from `username` to `email` to match the expected login payload.