### PR TITLE
Feat/technology soft delete admin

### DIFF
--- a/platform/implementation/IMPLEMENTATION_PLAN.md
+++ b/platform/implementation/IMPLEMENTATION_PLAN.md
@@ -296,13 +296,13 @@ Stack: Java 21 + Spring Boot 3.2.1 (backend hexagonal) · React 18 + TypeScript 
     - `@CacheEvict(value="technologies", allEntries=true)` en `createTechnology()` y `updateTechnology()`
     - _Requirements: 5.6_
 
-  - [ ] 3.5 Implementar `GET /api/v1/technologies` (paginado, filtro por energyType) + `GET /api/v1/technologies/{id}`
+  - [x] 3.5 Implementar `GET /api/v1/technologies` (paginado, filtro por energyType) + `GET /api/v1/technologies/{id}`
     - `TechnologyResponseDTO` con todos los campos de Technology
     - `GET /technologies?page=0&size=20&energyType=SOLAR` → `Page<TechnologyResponseDTO>`
     - `GET /technologies/{id}` → `TechnologyResponseDTO`; HTTP 404 si no existe
     - _Requirements: 5.1, 5.2, 5.3_
 
-  - [ ] 3.6 Implementar `POST`, `PUT` y `DELETE` (soft delete) en `/api/v1/technologies` — solo ADMIN
+  - [x ] 3.6 Implementar `POST`, `PUT` y `DELETE` (soft delete) en `/api/v1/technologies` — solo ADMIN
     - `TechnologyRequestDTO` con validaciones `@NotBlank`, `@DecimalMin`, `@DecimalMax`
     - `POST /technologies` → HTTP 201 + invalidar caché
     - `PUT /technologies/{id}` → HTTP 200 + invalidar caché

--- a/src/main/java/com/renewsim/backend/technology_service/application/port/out/TechnologyRepositoryPort.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/port/out/TechnologyRepositoryPort.java
@@ -14,6 +14,8 @@ public interface TechnologyRepositoryPort {
 
     Optional<Technology> findById(Long id);
 
+    Optional<Technology> findActiveById(Long id);
+
     Optional<Technology> findByName(String name);
 
     List<Technology> findAll();

--- a/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyCommandService.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyCommandService.java
@@ -60,7 +60,7 @@ public class TechnologyCommandService {
     }
 
     public TechnologyUpdateResultDTO handleUpdate(UpdateTechnologyCommand command) {
-        var existing = validator.getExisting(command.id());
+        var existing = validator.getExistingActive(command.id());
 
         var updated = new Technology(
                 existing.getId(),
@@ -68,18 +68,23 @@ public class TechnologyCommandService {
                 EnergyType.fromString(command.energyType()),
                 new Efficiency(command.efficiency()),
                 new InstallationCost(BigDecimal.valueOf(command.installationCost())),
+                existing.getLifespanYears(),
                 new MaintenanceCost(BigDecimal.valueOf(command.maintenanceCost())),
+                existing.getDescription(),
+                existing.isActive(),
+                existing.getCreatedAt(),
+                existing.getUpdatedAt(),
                 new EnvironmentalImpact(command.environmentalImpact()),
                 new Co2Reduction(BigDecimal.valueOf(command.co2Reduction())),
                 new CapacityFactor(command.capacityFactor()));
 
-        repository.save(updated);
-        return dtoMapper.toUpdateResult(updated);
+        var saved = repository.save(updated);
+        return dtoMapper.toUpdateResult(saved);
     }
 
     public void handleDelete(DeleteTechnologyCommand command) {
-        validator.ensureExists(command.id());
-        repository.deleteById(command.id());
+        var existing = validator.getExistingActive(command.id());
+        repository.save(existing.deactivate());
     }
 
     // ============================================================

--- a/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyEstimationService.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyEstimationService.java
@@ -1,5 +1,6 @@
 package com.renewsim.backend.technology_service.application.service;
 
+import com.renewsim.backend.shared.exception.BadRequestException;
 import com.renewsim.backend.technology_service.application.dto.TechnologyEstimateDTO;
 import com.renewsim.backend.technology_service.application.port.in.EstimateTechnologyUseCase;
 import com.renewsim.backend.technology_service.domain.model.vo.EnergyType;
@@ -21,7 +22,7 @@ public class TechnologyEstimationService implements EstimateTechnologyUseCase {
 
     @Override
     public TechnologyEstimateDTO estimate(String energyType, Double installedCapacityKw) {
-        String normalized = EnergyType.fromString(energyType).name();
+        String normalized = normalizeEnergyType(energyType);
         CapacityFactorRange range = DEFAULT_CAPACITY_FACTORS.getOrDefault(normalized,
                 new CapacityFactorRange(10.0, 50.0, 25.0));
 
@@ -40,6 +41,14 @@ public class TechnologyEstimationService implements EstimateTechnologyUseCase {
                 range.min(),
                 range.max(),
                 confidence);
+    }
+
+    private String normalizeEnergyType(String energyType) {
+        try {
+            return EnergyType.fromString(energyType).name();
+        } catch (IllegalArgumentException ex) {
+            throw new BadRequestException("Invalid energy type: " + energyType);
+        }
     }
 
     private record CapacityFactorRange(double min, double max, double defaultFactor) {

--- a/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyValidator.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyValidator.java
@@ -30,5 +30,10 @@ public class TechnologyValidator {
         return repository.findById(id)
                 .orElseThrow(() -> new TechnologyNotFoundException(id));
     }
+
+    public Technology getExistingActive(Long id) {
+        return repository.findActiveById(id)
+                .orElseThrow(() -> new TechnologyNotFoundException(id));
+    }
 }
 

--- a/src/main/java/com/renewsim/backend/technology_service/infrastructure/mapper/TechnologyMapper.java
+++ b/src/main/java/com/renewsim/backend/technology_service/infrastructure/mapper/TechnologyMapper.java
@@ -62,13 +62,13 @@ public interface TechnologyMapper {
     @Mapping(target = "maintenanceCost", expression = "java(domain.getMaintenanceCost().value())")
     @Mapping(target = "co2ReductionFactor", expression = "java(domain.getCo2Reduction().value())")
     @Mapping(target = "capacityFactor", expression = "java(java.math.BigDecimal.valueOf(domain.getCapacityFactor().value()))")
-    @Mapping(target = "description", ignore = true)
-    @Mapping(target = "lifespanYears", constant = "25")
+    @Mapping(target = "description", expression = "java(domain.getDescription())")
+    @Mapping(target = "lifespanYears", expression = "java(domain.getLifespanYears())")
     @Mapping(target = "minCapacityKw", constant = "0.00")
     @Mapping(target = "maxCapacityKw", ignore = true)
-    @Mapping(target = "isActive", constant = "true")
-    @Mapping(target = "createdAt", ignore = true)
-    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "isActive", expression = "java(domain.isActive())")
+    @Mapping(target = "createdAt", expression = "java(domain.getCreatedAt())")
+    @Mapping(target = "updatedAt", expression = "java(domain.getUpdatedAt())")
     TechnologyEntity toEntity(Technology domain);
 
     // ============================================================

--- a/src/main/java/com/renewsim/backend/technology_service/infrastructure/persistence/adapter/TechnologyRepositoryAdapter.java
+++ b/src/main/java/com/renewsim/backend/technology_service/infrastructure/persistence/adapter/TechnologyRepositoryAdapter.java
@@ -24,6 +24,14 @@ public class TechnologyRepositoryAdapter implements TechnologyRepositoryPort {
     @Override
     public Technology save(Technology technology) {
         var entity = mapper.toEntity(technology);
+
+        if (technology.getId() != null) {
+            jpaRepository.findById(technology.getId()).ifPresent(existing -> {
+                entity.setMinCapacityKw(existing.getMinCapacityKw());
+                entity.setMaxCapacityKw(existing.getMaxCapacityKw());
+            });
+        }
+
         var saved = jpaRepository.save(entity);
         return mapper.toDomain(saved);
     }
@@ -31,6 +39,11 @@ public class TechnologyRepositoryAdapter implements TechnologyRepositoryPort {
     @Override
     public Optional<Technology> findById(Long id) {
         return jpaRepository.findById(id).map(mapper::toDomain);
+    }
+
+    @Override
+    public Optional<Technology> findActiveById(Long id) {
+        return jpaRepository.findByIdAndIsActiveTrue(id).map(mapper::toDomain);
     }
      @Override
     public Optional<Technology> findByName(String name) { 

--- a/src/main/java/com/renewsim/backend/technology_service/infrastructure/persistence/repository/JpaTechnologyRepository.java
+++ b/src/main/java/com/renewsim/backend/technology_service/infrastructure/persistence/repository/JpaTechnologyRepository.java
@@ -16,6 +16,8 @@ public interface JpaTechnologyRepository extends JpaRepository<TechnologyEntity,
     
     Optional<TechnologyEntity> findByName(String name);
 
+    Optional<TechnologyEntity> findByIdAndIsActiveTrue(Long id);
+
     Page<TechnologyEntity> findByEnergyType(TechnologyEntity.EnergyType energyType, Pageable pageable);
 
     Page<TechnologyEntity> findByEnergyTypeAndIsActiveTrue(TechnologyEntity.EnergyType energyType, Pageable pageable);

--- a/src/main/java/com/renewsim/backend/technology_service/web/controller/TechnologyController.java
+++ b/src/main/java/com/renewsim/backend/technology_service/web/controller/TechnologyController.java
@@ -6,6 +6,7 @@ import com.renewsim.backend.technology_service.application.command.*;
 import com.renewsim.backend.technology_service.application.dto.TechnologyEstimateDTO;
 import com.renewsim.backend.technology_service.application.port.in.*;
 import com.renewsim.backend.technology_service.application.result.*;
+import com.renewsim.backend.technology_service.web.dto.TechnologyRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -66,9 +67,9 @@ public class TechnologyController {
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
     })
     public ResponseEntity<OperationResponse<TechnologyCreationResultDTO>> create(
-            @Valid @RequestBody CreateTechnologyCommand command) {
+            @Valid @RequestBody TechnologyRequestDTO request) {
 
-        var result = createUseCase.createTechnology(command);
+        var result = createUseCase.createTechnology(toCreateCommand(request));
         return ResponseEntity
                 .status(201)
                 .body(ApiResponseFactory.created(result, "Technology created successfully"));
@@ -121,11 +122,9 @@ public class TechnologyController {
     })
     public ResponseEntity<OperationResponse<TechnologyUpdateResultDTO>> update(
             @Parameter(description = "Technology unique identifier", required = true) @PathVariable Long id,
-            @Valid @RequestBody UpdateTechnologyCommand command) {
+            @Valid @RequestBody TechnologyRequestDTO request) {
 
-        // Crear un nuevo record con el id del path
-        var commandWithId = UpdateTechnologyCommand.withId(id, command);
-        var result = updateUseCase.updateTechnology(commandWithId);
+        var result = updateUseCase.updateTechnology(toUpdateCommand(id, request));
 
         return ResponseEntity.ok(ApiResponseFactory.ok(result, "Technology updated successfully"));
     }
@@ -133,16 +132,41 @@ public class TechnologyController {
     // DELETE
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('SCOPE_admin:delete') or hasRole('ADMIN')")
-    @Operation(summary = "Delete technology", description = "Permanently removes a technology from the catalog. Requires ADMIN role or scope admin:delete.", security = @SecurityRequirement(name = "bearerAuth"))
+    @Operation(summary = "Delete technology", description = "Soft-deletes a technology from the catalog. Requires ADMIN role or scope admin:delete.", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Technology deleted successfully", content = @Content),
+            @ApiResponse(responseCode = "204", description = "Technology deleted successfully", content = @Content),
             @ApiResponse(responseCode = "404", description = "Technology not found", content = @Content),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden - insufficient permissions", content = @Content)
     })
-    public ResponseEntity<OperationResponse<Void>> delete(
+    public ResponseEntity<Void> delete(
             @Parameter(description = "Technology unique identifier", required = true) @PathVariable Long id) {
         deleteUseCase.deleteTechnology(new DeleteTechnologyCommand(id));
-        return ResponseEntity.ok(ApiResponseFactory.noContent("Technology deleted successfully"));
+        return ResponseEntity.noContent().build();
+    }
+
+    private CreateTechnologyCommand toCreateCommand(TechnologyRequestDTO request) {
+        return new CreateTechnologyCommand(
+                request.name(),
+                request.efficiency(),
+                request.installationCost(),
+                request.maintenanceCost(),
+                request.environmentalImpact(),
+                request.co2Reduction(),
+                request.capacityFactor(),
+                request.energyType());
+    }
+
+    private UpdateTechnologyCommand toUpdateCommand(Long id, TechnologyRequestDTO request) {
+        return new UpdateTechnologyCommand(
+                id,
+                request.name(),
+                request.efficiency(),
+                request.installationCost(),
+                request.maintenanceCost(),
+                request.environmentalImpact(),
+                request.co2Reduction(),
+                request.capacityFactor(),
+                request.energyType());
     }
 }

--- a/src/main/java/com/renewsim/backend/technology_service/web/dto/TechnologyRequestDTO.java
+++ b/src/main/java/com/renewsim/backend/technology_service/web/dto/TechnologyRequestDTO.java
@@ -1,0 +1,30 @@
+package com.renewsim.backend.technology_service.web.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record TechnologyRequestDTO(
+        @NotBlank(message = "Technology name is required") String name,
+        @DecimalMin(value = "0.0", message = "Efficiency must be >= 0")
+        @DecimalMax(value = "1.0", message = "Efficiency must be <= 1")
+        double efficiency,
+        @Positive(message = "Installation cost must be positive")
+        double installationCost,
+        @Positive(message = "Maintenance cost must be positive")
+        double maintenanceCost,
+        @Min(value = 0, message = "Environmental impact must be >= 0")
+        @Max(value = 100, message = "Environmental impact must be <= 100")
+        double environmentalImpact,
+        @PositiveOrZero(message = "CO2 reduction cannot be negative")
+        double co2Reduction,
+        @Positive(message = "Capacity factor must be positive")
+        @DecimalMax(value = "100", message = "Capacity factor must be <= 100")
+        double capacityFactor,
+        @NotBlank(message = "Energy type is required")
+        String energyType) {
+}

--- a/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCommandServiceTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCommandServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Sort;
 import com.renewsim.backend.shared.exception.BadRequestException;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -107,7 +108,12 @@ class TechnologyCommandServiceTest {
                 EnergyType.SOLAR,
                 new Efficiency(0.85),
                 new InstallationCost(BigDecimal.valueOf(1200)),
+                30,
                 new MaintenanceCost(BigDecimal.valueOf(100)),
+                "Existing description",
+                false,
+                Instant.parse("2026-05-01T10:15:30Z"),
+                Instant.parse("2026-05-02T11:15:30Z"),
                 new EnvironmentalImpact(10.0),
                 new Co2Reduction(BigDecimal.valueOf(250)),
                 new CapacityFactor(18.0));
@@ -115,7 +121,7 @@ class TechnologyCommandServiceTest {
         TechnologyUpdateResultDTO expectedDTO = new TechnologyUpdateResultDTO(
                 1L, "Solar Panel", "SOLAR", 0.90, 1400, 120, 8, 300, 6000, true, "Updated successfully");
 
-        when(validator.getExisting(1L)).thenReturn(existing);
+        when(validator.getExistingActive(1L)).thenReturn(existing);
         when(repository.save(any(Technology.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(dtoMapper.toUpdateResult(any(Technology.class))).thenReturn(expectedDTO);
 
@@ -125,9 +131,16 @@ class TechnologyCommandServiceTest {
         assertEquals("Solar Panel", result.name());
         assertEquals(0.90, result.efficiency());
         assertEquals(1400, result.installationCost());
-        verify(validator, times(1)).getExisting(1L);
-        verify(repository, times(1)).save(any(Technology.class));
+        var technologyCaptor = org.mockito.ArgumentCaptor.forClass(Technology.class);
+        verify(validator, times(1)).getExistingActive(1L);
+        verify(repository, times(1)).save(technologyCaptor.capture());
         verify(dtoMapper, times(1)).toUpdateResult(any(Technology.class));
+
+        var savedTechnology = technologyCaptor.getValue();
+        assertEquals(30, savedTechnology.getLifespanYears());
+        assertEquals("Existing description", savedTechnology.getDescription());
+        assertFalse(savedTechnology.isActive());
+        assertEquals(Instant.parse("2026-05-01T10:15:30Z"), savedTechnology.getCreatedAt());
     }
 
     // ============================================================
@@ -136,13 +149,31 @@ class TechnologyCommandServiceTest {
     @Test
     @DisplayName("Should delete an existing technology successfully")
     void shouldDeleteTechnology() {
-        doNothing().when(validator).ensureExists(1L);
-        doNothing().when(repository).deleteById(1L);
+        var existing = new Technology(
+                1L,
+                "Solar Panel",
+                EnergyType.SOLAR,
+                new Efficiency(0.85),
+                new InstallationCost(BigDecimal.valueOf(1200)),
+                25,
+                new MaintenanceCost(BigDecimal.valueOf(100)),
+                "Existing description",
+                true,
+                Instant.parse("2026-05-01T10:15:30Z"),
+                Instant.parse("2026-05-02T11:15:30Z"),
+                new EnvironmentalImpact(10.0),
+                new Co2Reduction(BigDecimal.valueOf(250)),
+                new CapacityFactor(18.0));
+
+        when(validator.getExistingActive(1L)).thenReturn(existing);
+        when(repository.save(any(Technology.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         service.handleDelete(deleteCommand);
 
-        verify(validator, times(1)).ensureExists(1L);
-        verify(repository, times(1)).deleteById(1L);
+        var technologyCaptor = org.mockito.ArgumentCaptor.forClass(Technology.class);
+        verify(validator, times(1)).getExistingActive(1L);
+        verify(repository, times(1)).save(technologyCaptor.capture());
+        assertFalse(technologyCaptor.getValue().isActive());
     }
 
     // ============================================================
@@ -164,6 +195,40 @@ class TechnologyCommandServiceTest {
         assertEquals("Solar Panel", result.name());
         verify(validator, times(1)).getExisting(1L);
         verify(dtoMapper, times(1)).toResponse(domain);
+    }
+
+    @Test
+    @DisplayName("Should get an inactive technology by ID for historical reads")
+    void shouldGetInactiveTechnologyByIdForHistoricalReads() {
+        Technology inactiveTechnology = new Technology(
+                1L,
+                "Solar Panel",
+                EnergyType.SOLAR,
+                new Efficiency(0.85),
+                new InstallationCost(BigDecimal.valueOf(1200)),
+                25,
+                new MaintenanceCost(BigDecimal.valueOf(100)),
+                "Retired technology",
+                false,
+                Instant.parse("2026-05-01T10:15:30Z"),
+                Instant.parse("2026-05-02T11:15:30Z"),
+                new EnvironmentalImpact(10.0),
+                new Co2Reduction(BigDecimal.valueOf(250)),
+                new CapacityFactor(18.0));
+        TechnologyResponseDTO response = new TechnologyResponseDTO(
+                1L, "Solar Panel", "SOLAR", 0.85, 1200, 25, 100,
+                "Retired technology", false, Instant.parse("2026-05-01T10:15:30Z"),
+                Instant.parse("2026-05-02T11:15:30Z"), 10, 250, 18);
+
+        when(validator.getExisting(1L)).thenReturn(inactiveTechnology);
+        when(dtoMapper.toResponse(inactiveTechnology)).thenReturn(response);
+
+        var result = service.handleGetById(getByIdCommand);
+
+        assertNotNull(result);
+        assertFalse(result.isActive());
+        verify(validator, times(1)).getExisting(1L);
+        verify(dtoMapper, times(1)).toResponse(inactiveTechnology);
     }
 
     // ============================================================

--- a/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyEstimationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyEstimationServiceTest.java
@@ -1,0 +1,32 @@
+package com.renewsim.backend.technology_service.application.service;
+
+import com.renewsim.backend.shared.exception.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TechnologyEstimationServiceTest {
+
+    private final TechnologyEstimationService service = new TechnologyEstimationService();
+
+    @Test
+    @DisplayName("estimate should return defaults for a valid energy type")
+    void estimateShouldReturnDefaultsForValidEnergyType() {
+        var result = service.estimate("solar", null);
+
+        assertThat(result.energyType()).isEqualTo("SOLAR");
+        assertThat(result.suggestedCapacityFactor()).isEqualTo(18.0);
+        assertThat(result.confidence()).isEqualTo("medium");
+    }
+
+    @Test
+    @DisplayName("estimate should reject invalid energy type with bad request")
+    void estimateShouldRejectInvalidEnergyTypeWithBadRequest() {
+        var exception = assertThrows(BadRequestException.class,
+                () -> service.estimate("foo", null));
+
+        assertThat(exception.getMessage()).isEqualTo("Invalid energy type: foo");
+    }
+}

--- a/src/test/java/com/renewsim/backend/technology_service/infrastructure/mapper/TechnologyMapperTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/infrastructure/mapper/TechnologyMapperTest.java
@@ -1,0 +1,53 @@
+package com.renewsim.backend.technology_service.infrastructure.mapper;
+
+import com.renewsim.backend.technology_service.domain.model.Technology;
+import com.renewsim.backend.technology_service.domain.model.vo.CapacityFactor;
+import com.renewsim.backend.technology_service.domain.model.vo.Co2Reduction;
+import com.renewsim.backend.technology_service.domain.model.vo.Efficiency;
+import com.renewsim.backend.technology_service.domain.model.vo.EnergyType;
+import com.renewsim.backend.technology_service.domain.model.vo.EnvironmentalImpact;
+import com.renewsim.backend.technology_service.domain.model.vo.InstallationCost;
+import com.renewsim.backend.technology_service.domain.model.vo.MaintenanceCost;
+import com.renewsim.backend.technology_service.infrastructure.persistence.entity.TechnologyEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TechnologyMapperTest {
+
+    private final TechnologyMapper mapper = Mappers.getMapper(TechnologyMapper.class);
+
+    @Test
+    @DisplayName("toEntity should preserve persisted metadata needed by update and soft delete")
+    void toEntityShouldPreservePersistedMetadataNeededByUpdateAndSoftDelete() {
+        Technology technology = new Technology(
+                7L,
+                "Wind Turbine",
+                EnergyType.WIND,
+                new Efficiency(0.35),
+                new InstallationCost(BigDecimal.valueOf(2000)),
+                30,
+                new MaintenanceCost(BigDecimal.valueOf(120)),
+                "Seeded description",
+                false,
+                Instant.parse("2026-05-10T08:00:00Z"),
+                Instant.parse("2026-05-11T09:30:00Z"),
+                new EnvironmentalImpact(8.0),
+                new Co2Reduction(BigDecimal.valueOf(300)),
+                new CapacityFactor(35.0));
+
+        TechnologyEntity entity = mapper.toEntity(technology);
+
+        assertThat(entity.getId()).isEqualTo(7L);
+        assertThat(entity.getLifespanYears()).isEqualTo(30);
+        assertThat(entity.getDescription()).isEqualTo("Seeded description");
+        assertThat(entity.getIsActive()).isFalse();
+        assertThat(entity.getCreatedAt()).isEqualTo(Instant.parse("2026-05-10T08:00:00Z"));
+        assertThat(entity.getUpdatedAt()).isEqualTo(Instant.parse("2026-05-11T09:30:00Z"));
+    }
+}

--- a/src/test/java/com/renewsim/backend/technology_service/infrastructure/persistence/adapter/TechnologyRepositoryAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/infrastructure/persistence/adapter/TechnologyRepositoryAdapterTest.java
@@ -1,0 +1,124 @@
+package com.renewsim.backend.technology_service.infrastructure.persistence.adapter;
+
+import com.renewsim.backend.technology_service.domain.model.Technology;
+import com.renewsim.backend.technology_service.domain.model.vo.CapacityFactor;
+import com.renewsim.backend.technology_service.domain.model.vo.Co2Reduction;
+import com.renewsim.backend.technology_service.domain.model.vo.Efficiency;
+import com.renewsim.backend.technology_service.domain.model.vo.EnergyType;
+import com.renewsim.backend.technology_service.domain.model.vo.EnvironmentalImpact;
+import com.renewsim.backend.technology_service.domain.model.vo.InstallationCost;
+import com.renewsim.backend.technology_service.domain.model.vo.MaintenanceCost;
+import com.renewsim.backend.technology_service.infrastructure.mapper.TechnologyMapper;
+import com.renewsim.backend.technology_service.infrastructure.persistence.entity.TechnologyEntity;
+import com.renewsim.backend.technology_service.infrastructure.persistence.repository.JpaTechnologyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TechnologyRepositoryAdapterTest {
+
+    @Mock
+    private JpaTechnologyRepository jpaRepository;
+
+    @Mock
+    private TechnologyMapper mapper;
+
+    @InjectMocks
+    private TechnologyRepositoryAdapter adapter;
+
+    @Test
+    @DisplayName("save should preserve persistence-only min and max capacity fields on update")
+    void saveShouldPreservePersistenceOnlyMinAndMaxCapacityFieldsOnUpdate() {
+        Technology technology = new Technology(
+                7L,
+                "Wind Turbine",
+                EnergyType.WIND,
+                new Efficiency(0.35),
+                new InstallationCost(BigDecimal.valueOf(2000)),
+                30,
+                new MaintenanceCost(BigDecimal.valueOf(120)),
+                "Seeded description",
+                true,
+                Instant.parse("2026-05-10T08:00:00Z"),
+                Instant.parse("2026-05-11T09:30:00Z"),
+                new EnvironmentalImpact(8.0),
+                new Co2Reduction(BigDecimal.valueOf(300)),
+                new CapacityFactor(35.0));
+
+        TechnologyEntity mappedEntity = TechnologyEntity.builder()
+                .id(7L)
+                .name("Wind Turbine")
+                .energyType(TechnologyEntity.EnergyType.WIND)
+                .unitCost(BigDecimal.valueOf(2000))
+                .maintenanceCost(BigDecimal.valueOf(120))
+                .lifespanYears(30)
+                .description("Seeded description")
+                .efficiency(BigDecimal.valueOf(0.35))
+                .capacityFactor(BigDecimal.valueOf(35.0))
+                .co2ReductionFactor(BigDecimal.valueOf(300))
+                .isActive(true)
+                .createdAt(Instant.parse("2026-05-10T08:00:00Z"))
+                .updatedAt(Instant.parse("2026-05-11T09:30:00Z"))
+                .build();
+
+        TechnologyEntity existingEntity = TechnologyEntity.builder()
+                .id(7L)
+                .minCapacityKw(BigDecimal.valueOf(5.50))
+                .maxCapacityKw(BigDecimal.valueOf(55.50))
+                .build();
+
+        when(mapper.toEntity(technology)).thenReturn(mappedEntity);
+        when(jpaRepository.findById(7L)).thenReturn(Optional.of(existingEntity));
+        when(jpaRepository.save(mappedEntity)).thenReturn(mappedEntity);
+        when(mapper.toDomain(mappedEntity)).thenReturn(technology);
+
+        adapter.save(technology);
+
+        ArgumentCaptor<TechnologyEntity> captor = ArgumentCaptor.forClass(TechnologyEntity.class);
+        verify(jpaRepository).save(captor.capture());
+        assertThat(captor.getValue().getMinCapacityKw()).isEqualByComparingTo("5.50");
+        assertThat(captor.getValue().getMaxCapacityKw()).isEqualByComparingTo("55.50");
+    }
+
+    @Test
+    @DisplayName("findActiveById should query only active technologies")
+    void findActiveByIdShouldQueryOnlyActiveTechnologies() {
+        TechnologyEntity entity = TechnologyEntity.builder().id(9L).build();
+        Technology technology = new Technology(
+                9L,
+                "Solar Panel",
+                EnergyType.SOLAR,
+                new Efficiency(0.85),
+                new InstallationCost(BigDecimal.valueOf(1200)),
+                25,
+                new MaintenanceCost(BigDecimal.valueOf(100)),
+                null,
+                true,
+                null,
+                null,
+                new EnvironmentalImpact(10.0),
+                new Co2Reduction(BigDecimal.valueOf(250)),
+                new CapacityFactor(18.0));
+
+        when(jpaRepository.findByIdAndIsActiveTrue(9L)).thenReturn(Optional.of(entity));
+        when(mapper.toDomain(entity)).thenReturn(technology);
+
+        var result = adapter.findActiveById(9L);
+
+        assertThat(result).contains(technology);
+        verify(jpaRepository).findByIdAndIsActiveTrue(9L);
+    }
+}

--- a/src/test/java/com/renewsim/backend/technology_service/web/controller/TechnologyControllerTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/web/controller/TechnologyControllerTest.java
@@ -1,0 +1,78 @@
+package com.renewsim.backend.technology_service.web.controller;
+
+import com.renewsim.backend.technology_service.application.command.CreateTechnologyCommand;
+import com.renewsim.backend.technology_service.application.command.DeleteTechnologyCommand;
+import com.renewsim.backend.technology_service.application.command.UpdateTechnologyCommand;
+import com.renewsim.backend.technology_service.application.port.in.CreateTechnologyUseCase;
+import com.renewsim.backend.technology_service.application.port.in.DeleteTechnologyUseCase;
+import com.renewsim.backend.technology_service.application.port.in.EstimateTechnologyUseCase;
+import com.renewsim.backend.technology_service.application.port.in.GetTechnologyUseCase;
+import com.renewsim.backend.technology_service.application.port.in.UpdateTechnologyUseCase;
+import com.renewsim.backend.technology_service.web.dto.TechnologyRequestDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TechnologyControllerTest {
+
+    @Mock
+    private CreateTechnologyUseCase createUseCase;
+    @Mock
+    private UpdateTechnologyUseCase updateUseCase;
+    @Mock
+    private DeleteTechnologyUseCase deleteUseCase;
+    @Mock
+    private GetTechnologyUseCase getUseCase;
+    @Mock
+    private EstimateTechnologyUseCase estimateUseCase;
+
+    @InjectMocks
+    private TechnologyController controller;
+
+    @Test
+    @DisplayName("create should map request DTO to create command")
+    void createShouldMapRequestDtoToCreateCommand() {
+        TechnologyRequestDTO request = new TechnologyRequestDTO(
+                "Solar Panel", 0.85, 1200, 100, 10, 250, 18, "SOLAR");
+
+        controller.create(request);
+
+        ArgumentCaptor<CreateTechnologyCommand> captor = ArgumentCaptor.forClass(CreateTechnologyCommand.class);
+        verify(createUseCase).createTechnology(captor.capture());
+        assertThat(captor.getValue().name()).isEqualTo("Solar Panel");
+        assertThat(captor.getValue().energyType()).isEqualTo("SOLAR");
+    }
+
+    @Test
+    @DisplayName("update should map request DTO and path id to update command")
+    void updateShouldMapRequestDtoAndPathIdToUpdateCommand() {
+        TechnologyRequestDTO request = new TechnologyRequestDTO(
+                "Wind Turbine", 0.35, 2000, 120, 8, 300, 35, "WIND");
+
+        controller.update(7L, request);
+
+        ArgumentCaptor<UpdateTechnologyCommand> captor = ArgumentCaptor.forClass(UpdateTechnologyCommand.class);
+        verify(updateUseCase).updateTechnology(captor.capture());
+        assertThat(captor.getValue().id()).isEqualTo(7L);
+        assertThat(captor.getValue().name()).isEqualTo("Wind Turbine");
+    }
+
+    @Test
+    @DisplayName("delete should return HTTP 204")
+    void deleteShouldReturnHttp204() {
+        var response = controller.delete(9L);
+
+        verify(deleteUseCase).deleteTechnology(new DeleteTechnologyCommand(9L));
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(response.getBody()).isNull();
+    }
+}


### PR DESCRIPTION
This pull request introduces several important improvements and refactorings to the Technology Service, focusing on stricter validation, improved update and delete operations (including soft delete), and enhanced test coverage. The main changes are grouped as follows:

### API and Controller Improvements
* Refactored the `TechnologyController` to use a new `TechnologyRequestDTO` for both create and update operations, centralizing validation and simplifying parameter handling. Also, the delete operation now returns HTTP 204 and performs a soft delete instead of a hard delete. [[1]](diffhunk://#diff-3b56ba02903ac2c3c86969a72e146764ee71ed1402ce3c42d536757e1f194b6dL69-R72) [[2]](diffhunk://#diff-3b56ba02903ac2c3c86969a72e146764ee71ed1402ce3c42d536757e1f194b6dL124-R170) [[3]](diffhunk://#diff-4704b02b8ce0425f87a56f76b2d05a34b9bded26a2c237f650a5919790ee147cR1-R30)

### Domain and Persistence Enhancements
* Added support for soft delete by introducing `findActiveById` in the repository and validator, and updating the delete logic to deactivate the entity instead of removing it. Update operations now preserve important fields such as `lifespanYears`, `description`, `isActive`, `createdAt`, and `updatedAt`. [[1]](diffhunk://#diff-4d42af25aec6db02f3e0982521c05caec6e4506d80746664a8e4d92669701e5dR33-R37) [[2]](diffhunk://#diff-ddc97210af81cdc3982b029381aeaecdadc5e7be4c7ea080999bc255adb9b2cbR27-R34) [[3]](diffhunk://#diff-ddc97210af81cdc3982b029381aeaecdadc5e7be4c7ea080999bc255adb9b2cbR43-R47) [[4]](diffhunk://#diff-bf1e17666b721eb22de6a80d3f925b644679e3afcdee28ede6027f9a1d64afbfR19-R20) [[5]](diffhunk://#diff-b1b888968cc0de825108b788cb1cba1c8bf1fed6066c0dc7effd2bb053d75c6dL63-R87)

* Improved the `TechnologyMapper` to map all relevant fields (including `description`, `lifespanYears`, `isActive`, `createdAt`, and `updatedAt`), ensuring complete and accurate persistence of domain objects.

### Validation and Error Handling
* Enhanced validation in the estimation service: invalid energy types now result in a `BadRequestException`, providing clearer error messages for clients. [[1]](diffhunk://#diff-c275057660c0085945cc98eb7649abd2a23b97c50498e9b85cb34004df80073eR3) [[2]](diffhunk://#diff-c275057660c0085945cc98eb7649abd2a23b97c50498e9b85cb34004df80073eL24-R25) [[3]](diffhunk://#diff-c275057660c0085945cc98eb7649abd2a23b97c50498e9b85cb34004df80073eR46-R53)

### Testing and Documentation Updates
* Updated tests to cover the new soft delete behavior and to verify that all relevant fields are preserved during update operations. [[1]](diffhunk://#diff-a78e1d07699767525e14838f11bb82f07b084a4b9c3cc9832d591ebaa69adef0R111-R124) [[2]](diffhunk://#diff-a78e1d07699767525e14838f11bb82f07b084a4b9c3cc9832d591ebaa69adef0L128-R143) [[3]](diffhunk://#diff-a78e1d07699767525e14838f11bb82f07b084a4b9c3cc9832d591ebaa69adef0L139-R176)
* Updated the implementation plan to reflect the completion of the technology API endpoints.

These changes collectively improve the robustness, maintainability, and correctness of the Technology Service API.