### PR TITLE
Add portfolio dashboard layer to simulation feature

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/GetPortfolioDashboardService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/GetPortfolioDashboardService.java
@@ -1,0 +1,57 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.simulation_service.application.port.out.SimulationRecordRepositoryPort;
+import com.renewsim.backend.simulation_service.application.port.out.TechnologyLookupPort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Application service that orchestrates dashboard retrieval and ranking.
+ */
+@Service
+@Transactional(readOnly = true)
+public class GetPortfolioDashboardService implements GetPortfolioDashboardUseCase {
+
+        private final SimulationRecordRepositoryPort repository;
+        private final ScenarioSnapshotAssembler snapshotAssembler;
+        private final PortfolioDashboardAggregator dashboardAggregator;
+
+        public GetPortfolioDashboardService(
+                        SimulationRecordRepositoryPort repository,
+                        TechnologyLookupPort technologyLookupPort,
+                        ObjectMapper objectMapper) {
+                this(repository, new ScenarioSnapshotAssembler(
+                                technologyLookupPort,
+                                objectMapper,
+                                new PortfolioScenarioScoringPolicy()),
+                                new PortfolioDashboardAggregator());
+        }
+
+        GetPortfolioDashboardService(
+                        SimulationRecordRepositoryPort repository,
+                        ScenarioSnapshotAssembler snapshotAssembler,
+                        PortfolioDashboardAggregator dashboardAggregator) {
+                this.repository = repository;
+                this.snapshotAssembler = snapshotAssembler;
+                this.dashboardAggregator = dashboardAggregator;
+        }
+
+        @Override
+        public PortfolioDashboardResult getDashboard(String username) {
+                List<ScenarioSnapshot> snapshots = repository.findByCreatedByOrderByCreatedAtDesc(username).stream()
+                                .map(snapshotAssembler::toSnapshot)
+                                .toList();
+
+                List<ScenarioSnapshot> ranked = snapshots.stream()
+                                .sorted(Comparator.comparingInt(ScenarioSnapshot::score).reversed()
+                                                .thenComparing(ScenarioSnapshot::createdAt,
+                                                                Comparator.nullsLast(Comparator.reverseOrder())))
+                                .toList();
+
+                return dashboardAggregator.buildDashboard(snapshots, ranked);
+        }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/GetPortfolioDashboardUseCase.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/GetPortfolioDashboardUseCase.java
@@ -1,0 +1,12 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+/**
+ * Produces the executive dashboard for a user's simulation portfolio.
+ */
+public interface GetPortfolioDashboardUseCase {
+
+    /**
+     * Builds the current dashboard snapshot for the given user.
+     */
+    PortfolioDashboardResult getDashboard(String username);
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardAggregator.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardAggregator.java
@@ -1,0 +1,169 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates ranked scenario snapshots into the portfolio dashboard view model.
+ */
+final class PortfolioDashboardAggregator {
+
+    PortfolioDashboardResult buildDashboard(List<ScenarioSnapshot> snapshots, List<ScenarioSnapshot> rankedSnapshots) {
+        return new PortfolioDashboardResult(
+                buildSummary(snapshots),
+                buildRecommendedScenario(rankedSnapshots),
+                rankedSnapshots.stream().map(this::toPrioritizedScenario).toList(),
+                buildRiskAlerts(snapshots),
+                buildDistribution(snapshots));
+    }
+
+    private PortfolioDashboardSummary buildSummary(List<ScenarioSnapshot> snapshots) {
+        List<Double> roiValues = snapshots.stream()
+                .map(ScenarioSnapshot::roiPercent)
+                .filter(value -> value != null)
+                .sorted()
+                .toList();
+        List<Double> paybackValues = snapshots.stream()
+                .map(ScenarioSnapshot::paybackYears)
+                .filter(value -> value != null)
+                .sorted()
+                .toList();
+
+        return new PortfolioDashboardSummary(
+                snapshots.size(),
+                snapshots.size(),
+                average(roiValues),
+                median(paybackValues),
+                round(snapshots.stream().mapToDouble(ScenarioSnapshot::annualGenerationKwh).sum()),
+                round(snapshots.stream().mapToDouble(ScenarioSnapshot::co2SavedKg).sum()),
+                snapshots.stream().filter(ScenarioSnapshot::requiresAttention).count());
+    }
+
+    private PortfolioDashboardRecommendedScenario buildRecommendedScenario(List<ScenarioSnapshot> rankedSnapshots) {
+        return rankedSnapshots.stream()
+                .filter(ScenarioSnapshot::hasFinancials)
+                .findFirst()
+                .map(snapshot -> new PortfolioDashboardRecommendedScenario(
+                        snapshot.id(),
+                        snapshot.name(),
+                        snapshot.technology(),
+                        snapshot.location(),
+                        snapshot.roiPercent(),
+                        snapshot.paybackYears(),
+                        snapshot.capex(),
+                        snapshot.estimatedAnnualSavings(),
+                        snapshot.priority(),
+                        snapshot.headline(),
+                        snapshot.drivers(),
+                        snapshot.mainRisk(),
+                        snapshot.nextStep()))
+                .orElse(null);
+    }
+
+    private List<PortfolioDashboardRiskAlert> buildRiskAlerts(List<ScenarioSnapshot> snapshots) {
+        List<PortfolioDashboardRiskAlert> alerts = new ArrayList<>();
+
+        long negativeRoi = snapshots.stream().filter(ScenarioSnapshot::hasNegativeRoi).count();
+        if (negativeRoi > 0) {
+            alerts.add(new PortfolioDashboardRiskAlert(
+                    "NEGATIVE_ROI",
+                    "HIGH",
+                    negativeRoi,
+                    negativeRoi + " escenarios presentan ROI negativo"));
+        }
+
+        long longPayback = snapshots.stream().filter(ScenarioSnapshot::hasLongPayback).count();
+        if (longPayback > 0) {
+            alerts.add(new PortfolioDashboardRiskAlert(
+                    "LONG_PAYBACK",
+                    "MEDIUM",
+                    longPayback,
+                    longPayback + " escenarios tienen un payback demasiado largo"));
+        }
+
+        long incompleteData = snapshots.stream().filter(ScenarioSnapshot::hasIncompleteData).count();
+        if (incompleteData > 0) {
+            alerts.add(new PortfolioDashboardRiskAlert(
+                    "INCOMPLETE_DATA",
+                    "MEDIUM",
+                    incompleteData,
+                    incompleteData + " simulaciones no tienen informacion suficiente para priorizar"));
+        }
+
+        long reviewRequired = snapshots.stream().filter(ScenarioSnapshot::needsReview).count();
+        if (reviewRequired > 0) {
+            alerts.add(new PortfolioDashboardRiskAlert(
+                    "REQUIRES_REVIEW",
+                    "LOW",
+                    reviewRequired,
+                    reviewRequired + " escenarios requieren revision ejecutiva antes de avanzar"));
+        }
+
+        return alerts;
+    }
+
+    private PortfolioDashboardDistribution buildDistribution(List<ScenarioSnapshot> snapshots) {
+        Map<String, List<ScenarioSnapshot>> byTechnology = new LinkedHashMap<>();
+        Map<String, Long> byStatus = new LinkedHashMap<>();
+
+        for (ScenarioSnapshot snapshot : snapshots) {
+            byTechnology.computeIfAbsent(snapshot.technology(), key -> new ArrayList<>()).add(snapshot);
+            byStatus.merge(snapshot.status(), 1L, Long::sum);
+        }
+
+        List<PortfolioDashboardDistributionByTechnology> byTechnologyItems = byTechnology.entrySet().stream()
+                .map(entry -> new PortfolioDashboardDistributionByTechnology(
+                        entry.getKey(),
+                        entry.getValue().size(),
+                        round(entry.getValue().stream().mapToDouble(ScenarioSnapshot::annualGenerationKwh).sum())))
+                .sorted(Comparator.comparingLong(PortfolioDashboardDistributionByTechnology::count).reversed())
+                .toList();
+
+        List<PortfolioDashboardDistributionByStatus> byStatusItems = byStatus.entrySet().stream()
+                .map(entry -> new PortfolioDashboardDistributionByStatus(entry.getKey(), entry.getValue()))
+                .sorted(Comparator.comparingLong(PortfolioDashboardDistributionByStatus::count).reversed())
+                .toList();
+
+        return new PortfolioDashboardDistribution(byTechnologyItems, byStatusItems);
+    }
+
+    private PortfolioDashboardPrioritizedScenario toPrioritizedScenario(ScenarioSnapshot snapshot) {
+        return new PortfolioDashboardPrioritizedScenario(
+                snapshot.id(),
+                snapshot.name(),
+                snapshot.technology(),
+                snapshot.status(),
+                snapshot.location(),
+                snapshot.roiPercent(),
+                snapshot.paybackYears(),
+                snapshot.capex(),
+                snapshot.estimatedAnnualSavings(),
+                snapshot.priority(),
+                snapshot.score());
+    }
+
+    private Double average(List<Double> values) {
+        if (values.isEmpty()) {
+            return null;
+        }
+        return round(values.stream().mapToDouble(Double::doubleValue).average().orElse(0.0));
+    }
+
+    private Double median(List<Double> values) {
+        if (values.isEmpty()) {
+            return null;
+        }
+        int middle = values.size() / 2;
+        if (values.size() % 2 == 0) {
+            return round((values.get(middle - 1) + values.get(middle)) / 2.0);
+        }
+        return round(values.get(middle));
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardDistribution.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardDistribution.java
@@ -1,0 +1,8 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import java.util.List;
+
+public record PortfolioDashboardDistribution(
+        List<PortfolioDashboardDistributionByTechnology> byTechnology,
+        List<PortfolioDashboardDistributionByStatus> byStatus) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardDistributionByStatus.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardDistributionByStatus.java
@@ -1,0 +1,6 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+public record PortfolioDashboardDistributionByStatus(
+        String label,
+        long count) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardDistributionByTechnology.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardDistributionByTechnology.java
@@ -1,0 +1,7 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+public record PortfolioDashboardDistributionByTechnology(
+        String label,
+        long count,
+        double energyKwh) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardPrioritizedScenario.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardPrioritizedScenario.java
@@ -1,0 +1,15 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+public record PortfolioDashboardPrioritizedScenario(
+        String id,
+        String name,
+        String technology,
+        String status,
+        String location,
+        Double roiPercent,
+        Double paybackYears,
+        Double capex,
+        Double estimatedAnnualSavings,
+        String priority,
+        Integer score) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardRecommendedScenario.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardRecommendedScenario.java
@@ -1,0 +1,19 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import java.util.List;
+
+public record PortfolioDashboardRecommendedScenario(
+        String id,
+        String name,
+        String technology,
+        String location,
+        Double roiPercent,
+        Double paybackYears,
+        Double capex,
+        Double estimatedAnnualSavings,
+        String priority,
+        String headline,
+        List<String> drivers,
+        String mainRisk,
+        String nextStep) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardResult.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardResult.java
@@ -1,0 +1,11 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import java.util.List;
+
+public record PortfolioDashboardResult(
+        PortfolioDashboardSummary summary,
+        PortfolioDashboardRecommendedScenario recommendedScenario,
+        List<PortfolioDashboardPrioritizedScenario> prioritizedScenarios,
+        List<PortfolioDashboardRiskAlert> riskAlerts,
+        PortfolioDashboardDistribution distribution) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardRiskAlert.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardRiskAlert.java
@@ -1,0 +1,8 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+public record PortfolioDashboardRiskAlert(
+        String type,
+        String severity,
+        long count,
+        String message) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardSummary.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardSummary.java
@@ -1,0 +1,11 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+public record PortfolioDashboardSummary(
+        long totalSimulations,
+        long activeSimulations,
+        Double averageRoiPercent,
+        Double medianPaybackYears,
+        double totalEnergyGeneratedKwh,
+        double totalCo2SavedKg,
+        long atRiskCount) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioScenarioScoringPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioScenarioScoringPolicy.java
@@ -1,0 +1,96 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import com.renewsim.backend.simulation_service.application.shared.SimulationDetailsResult;
+
+import java.util.List;
+
+/**
+ * Encapsulates portfolio prioritization and risk scoring rules.
+ */
+final class PortfolioScenarioScoringPolicy {
+
+    private static final double LONG_PAYBACK_YEARS = 10.0;
+    private static final double WEAK_ROI_PERCENT = 5.0;
+
+    int computeScore(SimulationDetailsResult details, Double roiPercent, Double paybackYears) {
+        if (details == null || details.summary() == null) {
+            return 20;
+        }
+
+        int score = switch (details.summary().recommendation()) {
+            case "recommended" -> 45;
+            case "viable_with_reservations" -> 30;
+            default -> 10;
+        };
+
+        if (roiPercent != null) {
+            score += Math.max(0, Math.min(30, (int) Math.round(roiPercent * 1.5)));
+        }
+        if (paybackYears != null) {
+            score += Math.max(0, Math.min(20, (int) Math.round(20.0 - paybackYears)));
+        }
+
+        long warnings = safeWarnings(details).stream()
+                .filter(warning -> "warning".equalsIgnoreCase(warning.severity()))
+                .count();
+        score -= (int) warnings * 5;
+
+        return Math.max(0, Math.min(100, score));
+    }
+
+    String resolveMainRisk(SimulationDetailsResult details, Double paybackYears, Double roiPercent) {
+        if (details == null) {
+            return "Informacion financiera incompleta";
+        }
+        String warningRisk = safeWarnings(details).stream()
+                .filter(warning -> "warning".equalsIgnoreCase(warning.severity()))
+                .map(SimulationDetailsResult.SimulationWarning::message)
+                .findFirst()
+                .orElse(null);
+        if (warningRisk != null) {
+            return warningRisk;
+        }
+        if (paybackYears != null && paybackYears > LONG_PAYBACK_YEARS) {
+            return "Payback por encima de la banda esperada";
+        }
+        if (roiPercent != null && roiPercent < WEAK_ROI_PERCENT) {
+            return "Retorno anual debil frente al CAPEX";
+        }
+        return "Sensibilidad moderada a supuestos economicos";
+    }
+
+    boolean needsReview(SimulationDetailsResult details, String recommendation) {
+        if (details == null) {
+            return true;
+        }
+        if (!"recommended".equalsIgnoreCase(recommendation)) {
+            return true;
+        }
+        return safeWarnings(details).stream().anyMatch(warning -> "warning".equalsIgnoreCase(warning.severity()));
+    }
+
+    String priorityFor(int score, boolean hasDetails) {
+        if (!hasDetails) {
+            return "REVIEW";
+        }
+        if (score >= 75) {
+            return "HIGH";
+        }
+        if (score >= 50) {
+            return "MEDIUM";
+        }
+        return "LOW";
+    }
+
+    boolean hasNegativeRoi(Double roiPercent) {
+        return roiPercent != null && roiPercent < 0.0;
+    }
+
+    boolean hasLongPayback(Double paybackYears) {
+        return paybackYears != null && paybackYears > LONG_PAYBACK_YEARS;
+    }
+
+    private List<SimulationDetailsResult.SimulationWarning> safeWarnings(SimulationDetailsResult details) {
+        return details.warnings() == null ? List.of() : details.warnings();
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/ScenarioSnapshot.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/ScenarioSnapshot.java
@@ -1,0 +1,37 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+record ScenarioSnapshot(
+        String id,
+        String name,
+        String technology,
+        String status,
+        String location,
+        Double roiPercent,
+        Double paybackYears,
+        Double capex,
+        Double estimatedAnnualSavings,
+        double annualGenerationKwh,
+        double co2SavedKg,
+        String headline,
+        List<String> drivers,
+        String mainRisk,
+        String nextStep,
+        String priority,
+        int score,
+        LocalDateTime createdAt,
+        boolean hasIncompleteData,
+        boolean needsReview,
+        boolean hasNegativeRoi,
+        boolean hasLongPayback) {
+
+    boolean hasFinancials() {
+        return roiPercent != null || paybackYears != null;
+    }
+
+    boolean requiresAttention() {
+        return hasIncompleteData || hasNegativeRoi || hasLongPayback || needsReview;
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/ScenarioSnapshotAssembler.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/application/dashboard/ScenarioSnapshotAssembler.java
@@ -1,0 +1,129 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.simulation_service.application.port.out.TechnologyLookupPort;
+import com.renewsim.backend.simulation_service.application.shared.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.domain.model.Simulation;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Translates stored simulations into normalized dashboard snapshots.
+ */
+final class ScenarioSnapshotAssembler {
+
+    private final TechnologyLookupPort technologyLookupPort;
+    private final ObjectMapper objectMapper;
+    private final PortfolioScenarioScoringPolicy scoringPolicy;
+
+    ScenarioSnapshotAssembler(
+            TechnologyLookupPort technologyLookupPort,
+            ObjectMapper objectMapper,
+            PortfolioScenarioScoringPolicy scoringPolicy) {
+        this.technologyLookupPort = technologyLookupPort;
+        this.objectMapper = objectMapper;
+        this.scoringPolicy = scoringPolicy;
+    }
+
+    ScenarioSnapshot toSnapshot(Simulation simulation) {
+        SimulationDetailsResult details = readDetails(simulation.getResultSnapshot());
+        SimulationDetailsResult.Financial financial = details != null ? details.financial() : null;
+        SimulationDetailsResult.Technical technical = details != null ? details.technical() : null;
+        SimulationDetailsResult.Summary summary = details != null ? details.summary() : null;
+        boolean hasCompleteDetails = financial != null && technical != null && summary != null;
+        Double capex = simulation.getEconomics() != null ? simulation.getEconomics().capexTotal() : null;
+        Double annualSavings = financial != null ? Double.valueOf(financial.annualSavings())
+                : simulation.getAnnualSavings();
+        Double annualBenefit = financial != null ? Double.valueOf(financial.netAnnualBenefit())
+                : simulation.getAnnualSavings();
+        Double paybackYears = financial != null ? financial.paybackYears() : null;
+        Double roiPercent = roiPercent(capex, annualBenefit);
+        double annualGeneration = technical != null ? technical.annualGenerationKwh()
+                : defaultNumber(simulation.getAnnualGenerationKwh());
+        double co2SavedKg = annualGeneration > 0.0 && simulation.getTechnology() != null
+                ? technologyLookupPort.findActiveCo2ReductionFactorByEnergyType(simulation.getTechnology().value())
+                        .map(factor -> annualGeneration * factor)
+                        .orElse(0.0)
+                : 0.0;
+        String recommendation = summary != null && summary.recommendation() != null
+                ? summary.recommendation()
+                : "review_required";
+        List<String> drivers = summary != null && summary.reasons() != null
+                ? summary.reasons().stream()
+                        .map(SimulationDetailsResult.RecommendationReason::message)
+                        .filter(message -> message != null && !message.isBlank())
+                        .limit(3)
+                        .toList()
+                : List.of("El escenario todavia no tiene salida financiera consolidada.");
+        if (drivers.isEmpty()) {
+            drivers = List.of("El escenario todavia no tiene salida financiera consolidada.");
+        }
+
+        int score = scoringPolicy.computeScore(details, roiPercent, paybackYears);
+
+        return new ScenarioSnapshot(
+                String.valueOf(simulation.getId().value()),
+                simulation.getName(),
+                normalizeLabel(simulation.getTechnology() != null ? simulation.getTechnology().value() : "unknown"),
+                normalizeLabel(simulation.getStatus() != null ? simulation.getStatus().name() : "draft"),
+                simulation.getLocation().label(),
+                roiPercent,
+                paybackYears,
+                capex,
+                annualSavings,
+                round(annualGeneration),
+                round(co2SavedKg),
+                summary != null && summary.headline() != null
+                        ? summary.headline()
+                        : "El escenario necesita completar datos antes de priorizarse.",
+                drivers,
+                scoringPolicy.resolveMainRisk(details, paybackYears, roiPercent),
+                nextStepFor(recommendation),
+                scoringPolicy.priorityFor(score, hasCompleteDetails),
+                score,
+                simulation.getCreatedAt(),
+                !hasCompleteDetails,
+                scoringPolicy.needsReview(details, recommendation),
+                scoringPolicy.hasNegativeRoi(roiPercent),
+                scoringPolicy.hasLongPayback(paybackYears));
+    }
+
+    private SimulationDetailsResult readDetails(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(raw, SimulationDetailsResult.class);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to deserialize simulation payload", ex);
+        }
+    }
+
+    private Double roiPercent(Double capex, Double annualBenefit) {
+        if (capex == null || annualBenefit == null || capex <= 0.0) {
+            return null;
+        }
+        return round((annualBenefit / capex) * 100.0);
+    }
+
+    private String nextStepFor(String recommendation) {
+        return switch (recommendation) {
+            case "recommended" -> "Validar sensibilidad y elevar a evaluacion ejecutiva";
+            case "viable_with_reservations" -> "Revisar supuestos criticos antes de priorizar inversion";
+            default -> "Completar datos y replantear supuestos antes de avanzar";
+        };
+    }
+
+    private String normalizeLabel(String value) {
+        return value == null ? "UNKNOWN" : value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    private double defaultNumber(Double value) {
+        return value == null ? 0.0 : value;
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/web/controller/SimulationController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/controller/SimulationController.java
@@ -1,6 +1,7 @@
 package com.renewsim.backend.simulation_service.web.controller;
 
 import com.renewsim.backend.simulation_service.application.createSimulation.CreateRealSimulationUseCase;
+import com.renewsim.backend.simulation_service.application.dashboard.GetPortfolioDashboardUseCase;
 import com.renewsim.backend.simulation_service.application.deleteSimulation.DeleteRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.application.detailSimulation.GetRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.application.historySimulation.ListUserRealSimulationsUseCase;
@@ -8,6 +9,7 @@ import com.renewsim.backend.simulation_service.application.port.out.ClimateDataP
 import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
 import com.renewsim.backend.simulation_service.web.dto.CreateSimulationRequestDTO;
 import com.renewsim.backend.simulation_service.web.dto.ListUserSimulationsResponseDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardResponseDTO;
 import com.renewsim.backend.simulation_service.web.dto.ResolvedLocationResponseDTO;
 import com.renewsim.backend.simulation_service.web.dto.SimulationDetailsResponseDTO;
 import com.renewsim.backend.shared.domain.vo.Location;
@@ -50,6 +52,7 @@ public class SimulationController {
     private final ClimateDataProviderPort climateDataProviderPort;
     private final CreateRealSimulationUseCase createRealSimulationUseCase;
     private final GetRealSimulationUseCase getRealSimulationUseCase;
+    private final GetPortfolioDashboardUseCase getPortfolioDashboardUseCase;
     private final ListUserRealSimulationsUseCase listUserRealSimulationsUseCase;
     private final DeleteRealSimulationUseCase deleteRealSimulationUseCase;
     private final SimulationWebMapper webMapper = new SimulationWebMapper();
@@ -125,6 +128,17 @@ public class SimulationController {
         log.info("User {} retrieved {} simulations", requestContext.username(), history.total());
 
         return ResponseEntity.ok(history);
+    }
+
+    @Operation(summary = "Get executive portfolio dashboard for authenticated user")
+    @PreAuthorize("hasAuthority('SCOPE_read:simulations') or hasRole('ADMIN')")
+    @GetMapping("/dashboard")
+    public ResponseEntity<PortfolioDashboardResponseDTO> getDashboard(Authentication auth) {
+
+        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+
+        return ResponseEntity
+                .ok(webMapper.toWebDashboard(getPortfolioDashboardUseCase.getDashboard(requestContext.username())));
     }
 
     @Operation(summary = "Resolve location from coordinates")

--- a/src/main/java/com/renewsim/backend/simulation_service/web/controller/SimulationWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/controller/SimulationWebMapper.java
@@ -1,6 +1,7 @@
 package com.renewsim.backend.simulation_service.web.controller;
 
 import com.renewsim.backend.simulation_service.application.createSimulation.CreateRealSimulationCommand;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardResult;
 import com.renewsim.backend.simulation_service.application.historySimulation.UserSimulationListResult;
 import com.renewsim.backend.simulation_service.application.shared.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
@@ -13,6 +14,14 @@ import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 import com.renewsim.backend.simulation_service.web.dto.CreateSimulationRequestDTO;
 import com.renewsim.backend.simulation_service.web.dto.ListUserSimulationsResponseDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardDistributionByStatusDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardDistributionByTechnologyDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardDistributionDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardPrioritizedScenarioDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardRecommendedScenarioDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardResponseDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardRiskAlertDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardSummaryDTO;
 import com.renewsim.backend.simulation_service.web.dto.SimulationDetailsResponseDTO;
 import com.renewsim.backend.simulation_service.web.dto.SimulationHistoryRowDTO;
 
@@ -201,4 +210,62 @@ final class SimulationWebMapper {
                 result.total());
     }
 
+    PortfolioDashboardResponseDTO toWebDashboard(PortfolioDashboardResult result) {
+        return new PortfolioDashboardResponseDTO(
+                new PortfolioDashboardSummaryDTO(
+                        result.summary().totalSimulations(),
+                        result.summary().activeSimulations(),
+                        result.summary().averageRoiPercent(),
+                        result.summary().medianPaybackYears(),
+                        result.summary().totalEnergyGeneratedKwh(),
+                        result.summary().totalCo2SavedKg(),
+                        result.summary().atRiskCount()),
+                result.recommendedScenario() == null ? null : new PortfolioDashboardRecommendedScenarioDTO(
+                        result.recommendedScenario().id(),
+                        result.recommendedScenario().name(),
+                        result.recommendedScenario().technology(),
+                        result.recommendedScenario().location(),
+                        result.recommendedScenario().roiPercent(),
+                        result.recommendedScenario().paybackYears(),
+                        result.recommendedScenario().capex(),
+                        result.recommendedScenario().estimatedAnnualSavings(),
+                        result.recommendedScenario().priority(),
+                        result.recommendedScenario().headline(),
+                        result.recommendedScenario().drivers(),
+                        result.recommendedScenario().mainRisk(),
+                        result.recommendedScenario().nextStep()),
+                result.prioritizedScenarios().stream()
+                        .map(item -> new PortfolioDashboardPrioritizedScenarioDTO(
+                                item.id(),
+                                item.name(),
+                                item.technology(),
+                                item.status(),
+                                item.location(),
+                                item.roiPercent(),
+                                item.paybackYears(),
+                                item.capex(),
+                                item.estimatedAnnualSavings(),
+                                item.priority(),
+                                item.score()))
+                        .toList(),
+                result.riskAlerts().stream()
+                        .map(alert -> new PortfolioDashboardRiskAlertDTO(
+                                alert.type(),
+                                alert.severity(),
+                                alert.count(),
+                                alert.message()))
+                        .toList(),
+                new PortfolioDashboardDistributionDTO(
+                        result.distribution().byTechnology().stream()
+                                .map(item -> new PortfolioDashboardDistributionByTechnologyDTO(
+                                        item.label(),
+                                        item.count(),
+                                        item.energyKwh()))
+                                .toList(),
+                        result.distribution().byStatus().stream()
+                                .map(item -> new PortfolioDashboardDistributionByStatusDTO(
+                                        item.label(),
+                                        item.count()))
+                                .toList()));
+    }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardDistributionByStatusDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardDistributionByStatusDTO.java
@@ -1,0 +1,6 @@
+package com.renewsim.backend.simulation_service.web.dto;
+
+public record PortfolioDashboardDistributionByStatusDTO(
+                String label,
+                long count) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardDistributionByTechnologyDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardDistributionByTechnologyDTO.java
@@ -1,0 +1,7 @@
+package com.renewsim.backend.simulation_service.web.dto;
+
+public record PortfolioDashboardDistributionByTechnologyDTO(
+                String label,
+                long count,
+                double energyKwh) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardDistributionDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardDistributionDTO.java
@@ -1,0 +1,8 @@
+package com.renewsim.backend.simulation_service.web.dto;
+
+import java.util.List;
+
+public record PortfolioDashboardDistributionDTO(
+                List<PortfolioDashboardDistributionByTechnologyDTO> byTechnology,
+                List<PortfolioDashboardDistributionByStatusDTO> byStatus) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardPrioritizedScenarioDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardPrioritizedScenarioDTO.java
@@ -1,0 +1,15 @@
+package com.renewsim.backend.simulation_service.web.dto;
+
+public record PortfolioDashboardPrioritizedScenarioDTO(
+                String id,
+                String name,
+                String technology,
+                String status,
+                String location,
+                Double roiPercent,
+                Double paybackYears,
+                Double capex,
+                Double estimatedAnnualSavings,
+                String priority,
+                Integer score) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardRecommendedScenarioDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardRecommendedScenarioDTO.java
@@ -1,0 +1,19 @@
+package com.renewsim.backend.simulation_service.web.dto;
+
+import java.util.List;
+
+public record PortfolioDashboardRecommendedScenarioDTO(
+                String id,
+                String name,
+                String technology,
+                String location,
+                Double roiPercent,
+                Double paybackYears,
+                Double capex,
+                Double estimatedAnnualSavings,
+                String priority,
+                String headline,
+                List<String> drivers,
+                String mainRisk,
+                String nextStep) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardResponseDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardResponseDTO.java
@@ -1,0 +1,11 @@
+package com.renewsim.backend.simulation_service.web.dto;
+
+import java.util.List;
+
+public record PortfolioDashboardResponseDTO(
+                PortfolioDashboardSummaryDTO summary,
+                PortfolioDashboardRecommendedScenarioDTO recommendedScenario,
+                List<PortfolioDashboardPrioritizedScenarioDTO> prioritizedScenarios,
+                List<PortfolioDashboardRiskAlertDTO> riskAlerts,
+                PortfolioDashboardDistributionDTO distribution) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardRiskAlertDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardRiskAlertDTO.java
@@ -1,0 +1,8 @@
+package com.renewsim.backend.simulation_service.web.dto;
+
+public record PortfolioDashboardRiskAlertDTO(
+                String type,
+                String severity,
+                long count,
+                String message) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardSummaryDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/web/dto/PortfolioDashboardSummaryDTO.java
@@ -1,0 +1,11 @@
+package com.renewsim.backend.simulation_service.web.dto;
+
+public record PortfolioDashboardSummaryDTO(
+                long totalSimulations,
+                long activeSimulations,
+                Double averageRoiPercent,
+                Double medianPaybackYears,
+                double totalEnergyGeneratedKwh,
+                double totalCo2SavedKg,
+                long atRiskCount) {
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardAggregatorTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioDashboardAggregatorTest.java
@@ -1,0 +1,113 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PortfolioDashboardAggregatorTest {
+
+        private final PortfolioDashboardAggregator aggregator = new PortfolioDashboardAggregator();
+
+        @Test
+        @DisplayName("buildDashboard aggregates summary, recommendation, alerts and distribution")
+        void buildDashboardAggregatesSummaryRecommendationAlertsAndDistribution() {
+                ScenarioSnapshot best = snapshot(
+                                "55", "SOLAR", "COMPLETED", 22.5, 6.2, 315000.0, 82000.0,
+                                457200.0, 205740.0, "HIGH", 82,
+                                false, false, false, false);
+                ScenarioSnapshot risky = snapshot(
+                                "56", "SOLAR", "COMPLETED", -1.59, 12.4, 315000.0, 12000.0,
+                                350000.0, 157500.0, "LOW", 18,
+                                false, true, true, true);
+                ScenarioSnapshot draft = snapshot(
+                                "57", "WIND", "DRAFT", null, null, 110000.0, null,
+                                0.0, 0.0, "REVIEW", 20,
+                                true, true, false, false);
+
+                PortfolioDashboardResult result = aggregator.buildDashboard(
+                                List.of(best, risky, draft),
+                                List.of(best, draft, risky));
+
+                assertThat(result.summary().totalSimulations()).isEqualTo(3);
+                assertThat(result.summary().averageRoiPercent()).isEqualTo(10.46);
+                assertThat(result.summary().medianPaybackYears()).isEqualTo(9.3);
+                assertThat(result.summary().totalEnergyGeneratedKwh()).isEqualTo(807200.0);
+                assertThat(result.summary().totalCo2SavedKg()).isEqualTo(363240.0);
+                assertThat(result.summary().atRiskCount()).isEqualTo(2);
+
+                assertThat(result.recommendedScenario()).isNotNull();
+                assertThat(result.recommendedScenario().id()).isEqualTo("55");
+                assertThat(result.prioritizedScenarios()).extracting(PortfolioDashboardPrioritizedScenario::id)
+                                .containsExactly("55", "57", "56");
+
+                assertThat(result.riskAlerts()).extracting(PortfolioDashboardRiskAlert::type)
+                                .containsExactly("NEGATIVE_ROI", "LONG_PAYBACK", "INCOMPLETE_DATA", "REQUIRES_REVIEW");
+
+                assertThat(result.distribution().byTechnology())
+                                .extracting(PortfolioDashboardDistributionByTechnology::label)
+                                .containsExactly("SOLAR", "WIND");
+                assertThat(result.distribution().byTechnology().getFirst().energyKwh()).isEqualTo(807200.0);
+                assertThat(result.distribution().byStatus()).extracting(PortfolioDashboardDistributionByStatus::label)
+                                .containsExactly("COMPLETED", "DRAFT");
+        }
+
+        @Test
+        @DisplayName("buildDashboard leaves recommended scenario null when ranked snapshots have no financials")
+        void buildDashboardLeavesRecommendedScenarioNullWhenNoFinancialsExist() {
+                ScenarioSnapshot review = snapshot(
+                                "57", "SOLAR", "DRAFT", null, null, 110000.0, null,
+                                0.0, 0.0, "REVIEW", 20,
+                                true, true, false, false);
+
+                PortfolioDashboardResult result = aggregator.buildDashboard(List.of(review), List.of(review));
+
+                assertThat(result.recommendedScenario()).isNull();
+                assertThat(result.riskAlerts()).extracting(PortfolioDashboardRiskAlert::type)
+                                .containsExactly("INCOMPLETE_DATA", "REQUIRES_REVIEW");
+        }
+
+        private ScenarioSnapshot snapshot(
+                        String id,
+                        String technology,
+                        String status,
+                        Double roiPercent,
+                        Double paybackYears,
+                        Double capex,
+                        Double annualSavings,
+                        double annualGenerationKwh,
+                        double co2SavedKg,
+                        String priority,
+                        int score,
+                        boolean hasIncompleteData,
+                        boolean needsReview,
+                        boolean hasNegativeRoi,
+                        boolean hasLongPayback) {
+                return new ScenarioSnapshot(
+                                id,
+                                "Scenario " + id,
+                                technology,
+                                status,
+                                "Sevilla, ES",
+                                roiPercent,
+                                paybackYears,
+                                capex,
+                                annualSavings,
+                                annualGenerationKwh,
+                                co2SavedKg,
+                                "headline",
+                                List.of("driver"),
+                                "risk",
+                                "next step",
+                                priority,
+                                score,
+                                LocalDateTime.parse("2026-06-30T14:00:00"),
+                                hasIncompleteData,
+                                needsReview,
+                                hasNegativeRoi,
+                                hasLongPayback);
+        }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioScenarioScoringPolicyTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/application/dashboard/PortfolioScenarioScoringPolicyTest.java
@@ -1,0 +1,98 @@
+package com.renewsim.backend.simulation_service.application.dashboard;
+
+import com.renewsim.backend.simulation_service.application.shared.SimulationDetailsResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PortfolioScenarioScoringPolicyTest {
+
+    private final PortfolioScenarioScoringPolicy policy = new PortfolioScenarioScoringPolicy();
+
+    @Test
+    @DisplayName("computeScore combines recommendation, roi, payback and warnings")
+    void computeScoreCombinesRecommendationRoiPaybackAndWarnings() {
+        SimulationDetailsResult details = details(
+                "recommended",
+                List.of(new SimulationDetailsResult.SimulationWarning("warning", "LOW_AVAILABILITY",
+                        "warning message")));
+
+        int score = policy.computeScore(details, 20.0, 5.0);
+
+        assertThat(score).isEqualTo(85);
+    }
+
+    @Test
+    @DisplayName("computeScore falls back to baseline when summary is unavailable")
+    void computeScoreFallsBackToBaselineWhenSummaryIsUnavailable() {
+        assertThat(policy.computeScore(null, 20.0, 5.0)).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("resolveMainRisk prefers warning messages over generic thresholds")
+    void resolveMainRiskPrefersWarningMessagesOverGenericThresholds() {
+        SimulationDetailsResult details = details(
+                "viable_with_reservations",
+                List.of(new SimulationDetailsResult.SimulationWarning("warning", "LOW_AVAILABILITY",
+                        "Availability too low")));
+
+        String mainRisk = policy.resolveMainRisk(details, 12.0, 2.0);
+
+        assertThat(mainRisk).isEqualTo("Availability too low");
+    }
+
+    @Test
+    @DisplayName("priorityFor maps review and score bands explicitly")
+    void priorityForMapsReviewAndScoreBandsExplicitly() {
+        assertThat(policy.priorityFor(80, true)).isEqualTo("HIGH");
+        assertThat(policy.priorityFor(60, true)).isEqualTo("MEDIUM");
+        assertThat(policy.priorityFor(20, true)).isEqualTo("LOW");
+        assertThat(policy.priorityFor(80, false)).isEqualTo("REVIEW");
+    }
+
+    @Test
+    @DisplayName("needsReview only clears recommended scenarios without warnings")
+    void needsReviewOnlyClearsRecommendedScenariosWithoutWarnings() {
+        SimulationDetailsResult cleanRecommended = details("recommended", List.of());
+        SimulationDetailsResult warnedRecommended = details(
+                "recommended",
+                List.of(new SimulationDetailsResult.SimulationWarning("warning", "LOW_AVAILABILITY",
+                        "Availability too low")));
+
+        assertThat(policy.needsReview(cleanRecommended, "recommended")).isFalse();
+        assertThat(policy.needsReview(warnedRecommended, "recommended")).isTrue();
+        assertThat(policy.needsReview(cleanRecommended, "viable_with_reservations")).isTrue();
+        assertThat(policy.needsReview(null, "recommended")).isTrue();
+    }
+
+    @Test
+    @DisplayName("negative roi and long payback flags follow threshold rules")
+    void negativeRoiAndLongPaybackFlagsFollowThresholdRules() {
+        assertThat(policy.hasNegativeRoi(-0.1)).isTrue();
+        assertThat(policy.hasNegativeRoi(0.0)).isFalse();
+        assertThat(policy.hasLongPayback(10.1)).isTrue();
+        assertThat(policy.hasLongPayback(10.0)).isFalse();
+    }
+
+    private SimulationDetailsResult details(
+            String recommendation,
+            List<SimulationDetailsResult.SimulationWarning> warnings) {
+        return new SimulationDetailsResult(
+                "55",
+                "completed",
+                "2026-06-30T14:00:00Z",
+                "2026-06-30T14:00:00Z",
+                "solar-spain-v1",
+                "solar",
+                null,
+                new SimulationDetailsResult.Summary(recommendation, "headline", "summary", List.of()),
+                null,
+                null,
+                null,
+                null,
+                warnings);
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/application/service/RealSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/application/service/RealSimulationServiceTest.java
@@ -3,8 +3,12 @@ package com.renewsim.backend.simulation_service.application.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.shared.exception.BadRequestException;
 import com.renewsim.backend.simulation_service.application.createSimulation.CreateRealSimulationCommand;
-import com.renewsim.backend.simulation_service.application.createSimulation.CreateSimulationService;
 import com.renewsim.backend.simulation_service.application.createSimulation.SimulationCompletionMapper;
+import com.renewsim.backend.simulation_service.application.createSimulation.CreateSimulationService;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardDistributionByTechnology;
+import com.renewsim.backend.simulation_service.application.dashboard.GetPortfolioDashboardService;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardRiskAlert;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardResult;
 import com.renewsim.backend.simulation_service.application.detailSimulation.GetSimulationService;
 import com.renewsim.backend.simulation_service.application.historySimulation.ListSimulationsService;
 import com.renewsim.backend.simulation_service.application.historySimulation.UserSimulationListResult;
@@ -106,6 +110,83 @@ class RealSimulationServiceTest {
         }
 
         @Test
+        @DisplayName("getDashboard aggregates portfolio KPIs, recommendation and alerts")
+        void getDashboardAggregatesPortfolioData() throws Exception {
+                GetPortfolioDashboardService service = new GetPortfolioDashboardService(
+                                repository,
+                                technologyLookupPort,
+                                new ObjectMapper().findAndRegisterModules());
+
+                Simulation best = completedSimulation(55L, "alice",
+                                new ObjectMapper().writeValueAsString(resultWithMetrics(
+                                                "55", "recommended", 82000, 9100, 6.2, 1820, List.of())));
+                Simulation risky = completedSimulation(56L, "alice",
+                                new ObjectMapper().writeValueAsString(resultWithMetrics(
+                                                "56", "not_recommended", 12000, -5000, 12.4, 980,
+                                                List.of(new SimulationDetailsResult.SimulationWarning("warning",
+                                                                "LOW_AVAILABILITY_ASSUMPTION",
+                                                                "Availability assumption is below 95% and may materially reduce annual output.")))));
+                Simulation draft = Simulation.create(
+                                "Solar - Draft",
+                                Technology.solar(),
+                                SimulationLocation.of("Cordoba, Andalucia, ES", 37.8882, -4.7794, "Spain",
+                                                CountryCode.of("ES")),
+                                new SimulationSystem(120, 0.81, 0.5, 99.0,
+                                                new SimulationSystem.LossesPct(2, 6, 1, 3, 1)),
+                                ConsumptionProfile.of(48000,
+                                                List.of(4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d,
+                                                                4000d, 4000d, 4000d)),
+                                new SimulationEconomics(Currency.of("EUR"), 110000.0, 3000.0, 0.18, 0.07, 8,
+                                                ProjectLifetime.of(20)),
+                                "alice");
+                draft.assignId(SimulationId.of(57L));
+
+                when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(best, risky, draft));
+                when(technologyLookupPort.findActiveCo2ReductionFactorByEnergyType("solar"))
+                                .thenReturn(Optional.of(0.45));
+
+                PortfolioDashboardResult response = service.getDashboard("alice");
+
+                assertThat(response.summary().totalSimulations()).isEqualTo(3);
+                assertThat(response.summary().atRiskCount()).isEqualTo(2);
+                assertThat(response.recommendedScenario()).isNotNull();
+                assertThat(response.recommendedScenario().id()).isEqualTo("55");
+                assertThat(response.prioritizedScenarios()).hasSize(3);
+                assertThat(response.riskAlerts()).extracting(PortfolioDashboardRiskAlert::type)
+                                .contains("NEGATIVE_ROI", "LONG_PAYBACK", "INCOMPLETE_DATA", "REQUIRES_REVIEW");
+                assertThat(response.distribution().byTechnology().getFirst().label()).isEqualTo("SOLAR");
+        }
+
+        @Test
+        @DisplayName("getDashboard tolerates partial historical snapshots")
+        void getDashboardToleratesPartialHistoricalSnapshots() throws Exception {
+                GetPortfolioDashboardService service = new GetPortfolioDashboardService(
+                                repository,
+                                technologyLookupPort,
+                                new ObjectMapper().findAndRegisterModules());
+
+                Simulation partial = completedSimulation(58L, "alice", """
+                                {
+                                  "id": "58",
+                                  "status": "completed",
+                                  "summary": null,
+                                  "technical": null,
+                                  "financial": null,
+                                  "warnings": null
+                                }
+                                """);
+
+                when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(partial));
+
+                PortfolioDashboardResult response = service.getDashboard("alice");
+
+                assertThat(response.summary().totalSimulations()).isEqualTo(1);
+                assertThat(response.summary().atRiskCount()).isEqualTo(1);
+                assertThat(response.prioritizedScenarios()).hasSize(1);
+                assertThat(response.prioritizedScenarios().getFirst().priority()).isEqualTo("REVIEW");
+        }
+
+        @Test
         @DisplayName("ConsumptionProfile rejects annual demand mismatches at domain level")
         void consumptionProfileRejectsAnnualDemandMismatch() {
                 assertThatThrownBy(() -> ConsumptionProfile.of(999999,
@@ -200,4 +281,43 @@ class RealSimulationServiceTest {
                                 List.of());
         }
 
+        private SimulationDetailsResult resultWithMetrics(
+                        String id,
+                        String recommendation,
+                        double annualSavings,
+                        double netAnnualBenefit,
+                        double paybackYears,
+                        double specificYield,
+                        List<SimulationDetailsResult.SimulationWarning> warnings) {
+                return new SimulationDetailsResult(
+                                id,
+                                "completed",
+                                "2026-06-30T14:00:00Z",
+                                "2026-06-30T14:00:00Z",
+                                "solar-spain-v1",
+                                "solar",
+                                new SimulationDetailsResult.ResolvedLocation("Sevilla, Andalucia, ES", "Sevilla",
+                                                "Andalucia", "Spain", "ES", 37.3891, -5.9845, "Europe/Madrid"),
+                                new SimulationDetailsResult.Summary(recommendation, "headline", "summary",
+                                                List.of(new SimulationDetailsResult.RecommendationReason("economics",
+                                                                "positive", "Driver"))),
+                                new SimulationDetailsResult.Input("Solar - Sevilla", "solar",
+                                                new SimulationDetailsResult.Location("Sevilla, Andalucia, ES", 37.3891,
+                                                                -5.9845, "Spain", "ES"),
+                                                new SimulationDetailsResult.SystemSpec(300, 0.81, 0.5, 99,
+                                                                new SimulationDetailsResult.LossesPct(2, 6, 1, 3, 1)),
+                                                new SimulationDetailsResult.Demand(120000, List.of()),
+                                                new SimulationDetailsResult.Economics("EUR", 315000, 7200, 0.18, 0.07,
+                                                                8, 20)),
+                                new SimulationDetailsResult.Technical(457200, List.of(), specificYield, 0.81, 17.4,
+                                                72.3, 31.5,
+                                                new SimulationDetailsResult.ResourceSeries("PVGIS", "2005-2020",
+                                                                List.of(), List.of()),
+                                                new SimulationDetailsResult.LossesSummary(2, 6, 1, 3, 1, 13),
+                                                List.of()),
+                                new SimulationDetailsResult.Financial("EUR", annualSavings, 8800, netAnnualBenefit,
+                                                paybackYears, 8.7, 121500, 11.4, 0.071, List.of()),
+                                new SimulationDetailsResult.Assumptions(8, 20, 0.5, 0.18, 0.07, "PVGIS", "2005-2020"),
+                                warnings);
+        }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/web/controller/SimulationControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/web/controller/SimulationControllerTest.java
@@ -2,6 +2,15 @@ package com.renewsim.backend.simulation_service.web.controller;
 
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
 import com.renewsim.backend.simulation_service.application.createSimulation.CreateRealSimulationUseCase;
+import com.renewsim.backend.simulation_service.application.dashboard.GetPortfolioDashboardUseCase;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardResult;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardDistribution;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardDistributionByStatus;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardDistributionByTechnology;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardPrioritizedScenario;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardRecommendedScenario;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardRiskAlert;
+import com.renewsim.backend.simulation_service.application.dashboard.PortfolioDashboardSummary;
 import com.renewsim.backend.simulation_service.application.deleteSimulation.DeleteRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.application.detailSimulation.GetRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.application.historySimulation.ListUserRealSimulationsUseCase;
@@ -12,6 +21,7 @@ import com.renewsim.backend.simulation_service.application.shared.SimulationDeta
 import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
 import com.renewsim.backend.simulation_service.web.dto.CreateSimulationRequestDTO;
 import com.renewsim.backend.simulation_service.web.dto.ListUserSimulationsResponseDTO;
+import com.renewsim.backend.simulation_service.web.dto.PortfolioDashboardResponseDTO;
 import com.renewsim.backend.simulation_service.web.dto.ResolvedLocationResponseDTO;
 import com.renewsim.backend.simulation_service.web.dto.SimulationDetailsResponseDTO;
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +57,8 @@ class SimulationControllerTest {
     private CreateRealSimulationUseCase createRealSimulationUseCase;
     @Mock
     private GetRealSimulationUseCase getRealSimulationUseCase;
+    @Mock
+    private GetPortfolioDashboardUseCase getPortfolioDashboardUseCase;
     @Mock
     private ListUserRealSimulationsUseCase listUserRealSimulationsUseCase;
     @Mock
@@ -100,6 +112,35 @@ class SimulationControllerTest {
         assertThat(body).isNotNull();
         assertThat(body.total()).isEqualTo(1);
         assertThat(body.items().getFirst().recommendation()).isEqualTo("viable_with_reservations");
+    }
+
+    @Test
+    @DisplayName("getDashboard returns executive portfolio contract")
+    void getDashboardReturnsExecutivePortfolioContract() {
+        Authentication auth = authentication("alice", "ROLE_USER");
+        when(getPortfolioDashboardUseCase.getDashboard("alice")).thenReturn(
+                new PortfolioDashboardResult(
+                        new PortfolioDashboardSummary(3, 3, 14.2, 6.2, 912300, 410535, 2),
+                        new PortfolioDashboardRecommendedScenario(
+                                "55", "Solar - Sevilla", "SOLAR", "Sevilla, ES", 22.5, 6.2, 315000.0, 82000.0,
+                                "HIGH", "headline", List.of("driver 1"), "main risk", "next step"),
+                        List.of(new PortfolioDashboardPrioritizedScenario(
+                                "55", "Solar - Sevilla", "SOLAR", "COMPLETED", "Sevilla, ES", 22.5, 6.2,
+                                315000.0, 82000.0, "HIGH", 82)),
+                        List.of(new PortfolioDashboardRiskAlert("INCOMPLETE_DATA", "MEDIUM", 1,
+                                "1 simulaciones no tienen información suficiente para priorizar")),
+                        new PortfolioDashboardDistribution(
+                                List.of(new PortfolioDashboardDistributionByTechnology("SOLAR", 3, 912300)),
+                                List.of(new PortfolioDashboardDistributionByStatus("COMPLETED", 2),
+                                        new PortfolioDashboardDistributionByStatus("DRAFT", 1)))));
+
+        PortfolioDashboardResponseDTO body = controller.getDashboard(auth).getBody();
+
+        assertThat(body).isNotNull();
+        assertThat(body.summary().totalSimulations()).isEqualTo(3);
+        assertThat(body.recommendedScenario()).isNotNull();
+        assertThat(body.recommendedScenario().name()).isEqualTo("Solar - Sevilla");
+        assertThat(body.riskAlerts().getFirst().type()).isEqualTo("INCOMPLETE_DATA");
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces a new application service and supporting classes to produce an executive dashboard for a user's simulation portfolio. The main logic centers around aggregating, scoring, and prioritizing simulation scenarios to create a comprehensive dashboard view, including summary statistics, risk alerts, and scenario recommendations.

**Dashboard Service Implementation:**

- Added `GetPortfolioDashboardService`, which orchestrates retrieval, transformation, ranking, and aggregation of simulation scenarios into a dashboard result for a given user. It leverages a scoring policy and an aggregator to produce the final dashboard output.

**Dashboard Aggregation and Scoring:**

- Introduced `PortfolioDashboardAggregator` to assemble the dashboard view model, including summary statistics, recommended scenario, prioritized scenario list, risk alerts, and technology/status distributions.
- Added `PortfolioScenarioScoringPolicy`, encapsulating logic for scenario prioritization, risk assessment, and priority assignment based on simulation results.
- Created `ScenarioSnapshot` as a record to represent normalized scenario data with computed attributes for scoring and risk evaluation.

**Dashboard Data Models:**

- Added dashboard result and supporting view model records, including:
  - [`PortfolioDashboardResult`](diffhunk://#diff-7d832c6d3e7032a98437b39e8fab228bc7688af4246bc67b87f62a04ffaeafb2R1-R11): The main dashboard output structure.
  - [`PortfolioDashboardSummary`](diffhunk://#diff-fe658079d62fa8b3962088fdf96ae1844cb7c79fa8e2600e18f2be5e47a402cdR1-R11): Portfolio-level summary metrics.
  - `PortfolioDashboardRecommendedScenario`, `PortfolioDashboardPrioritizedScenario`: Scenario-level details for recommendations and prioritization. [[1]](diffhunk://#diff-9f7b77a675c78e11176cdcae0fcfe04195bc9c304491dddee7013f94eec575d0R1-R19) [[2]](diffhunk://#diff-c2eeffbbe51def54e6b2e21215925ec395090e00796020e0fc115a73e4fef63aR1-R15)
  - [`PortfolioDashboardRiskAlert`](diffhunk://#diff-84e774c3c1ec0d5c6f59d6cea1ce06575f1e1a018320b9ace94116c24127dcfdR1-R8): Risk alert structure for scenarios needing attention.
  - `PortfolioDashboardDistribution`, `PortfolioDashboardDistributionByTechnology`, `PortfolioDashboardDistributionByStatus`: Structures for technology and status breakdowns. [[1]](diffhunk://#diff-6ae7a14d7199fc5edf54792064a66167dedc6fd25794d265b2254066abcc3278R1-R8) [[2]](diffhunk://#diff-92c7a3a956dd0790901aa83af545bc49ed543e4b9f8315c6696920b40d528240R1-R7) [[3]](diffhunk://#diff-e7257023aec485f87f25f4fb0d256c209c07b5fae4688567251cdc6ab4a5f3f6R1-R6)

**Use Case Interface:**

- Defined `GetPortfolioDashboardUseCase`, specifying the contract for dashboard generation.