### PR TITLE
test(build): stabilize Mockito and Spring test runtime setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <mapstruct.version>1.6.2</mapstruct.version>
         <caffeine.version>3.1.8</caffeine.version>
         <lombok.version>1.18.30</lombok.version>
+        <mockito.version>5.17.0</mockito.version>
         <argLine></argLine>
     </properties>
 
@@ -305,26 +306,13 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>properties</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- Surefire config - exclude tests requiring Docker or needing refactor -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.4</version>
                 <configuration>
-                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
                     <skipTests>false</skipTests>
                     <includes>
                         <include>**/*Test.class</include>
@@ -351,7 +339,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.5.4</version>
                 <configuration>
-                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
                     <includes>
                         <include>**/*IT.java</include>
                     </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <mapstruct.version>1.6.2</mapstruct.version>
         <caffeine.version>3.1.8</caffeine.version>
         <lombok.version>1.18.30</lombok.version>
+        <argLine></argLine>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -304,12 +304,26 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- Surefire config - exclude tests requiring Docker or needing refactor -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.4</version>
                 <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                     <skipTests>false</skipTests>
                     <includes>
                         <include>**/*Test.class</include>
@@ -336,6 +350,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.5.4</version>
                 <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                     <includes>
                         <include>**/*IT.java</include>
                     </includes>

--- a/src/test/java/com/renewsim/backend/config/TestSecurityConfig.java
+++ b/src/test/java/com/renewsim/backend/config/TestSecurityConfig.java
@@ -1,8 +1,5 @@
 package com.renewsim.backend.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.renewsim.backend.auth_service.infrastructure.config.SecurityRateLimitProperties;
-import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimiter;
 import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimitingFilter;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -11,37 +8,15 @@ import org.springframework.context.annotation.Primary;
 import static org.mockito.Mockito.mock;
 
 /**
- * Test configuration to provide mock beans for missing dependencies.
- * 
- * TECHNICAL DEBT: LoginRateLimiter implementation is missing in production code.
- * This mock allows tests to pass while the proper implementation is pending.
- * 
- * TODO Task 1.2/1.3: Implement proper LoginRateLimiter with:
- * - Interface definition
- * - Production implementation (e.g., Redis-based or in-memory)
- * - Conditional configuration (@ConditionalOnProperty)
- * - Unit tests
- * 
- * @see com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimitingFilter
+ * Test configuration that neutralizes login rate-limiting infrastructure for
+ * Spring Boot tests that focus on web/controller behavior.
  */
 @TestConfiguration
 public class TestSecurityConfig {
 
-    /**
-     * Provides a mock LoginRateLimiter bean for tests.
-     * Uses @Primary to ensure this bean is selected over any other candidates.
-     */
-    @Bean(name = "testLoginRateLimiter")
-    @Primary
-    public LoginRateLimiter loginRateLimiter() {
-        return mock(LoginRateLimiter.class);
-    }
-
     @Bean
     @Primary
-    public LoginRateLimitingFilter loginRateLimitingFilter(ObjectMapper objectMapper) {
-        SecurityRateLimitProperties props = new SecurityRateLimitProperties();
-        props.setEnabled(false);
-        return new LoginRateLimitingFilter(new LoginRateLimiter(60, 1000), objectMapper, props);
+    public LoginRateLimitingFilter loginRateLimitingFilter() {
+        return mock(LoginRateLimitingFilter.class);
     }
 }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-subclass


### PR DESCRIPTION
## What changed

- Removed the global Mockito subclass mock-maker override
- Configured Mockito as a Java agent for Maven Surefire and Failsafe
- Simplified `src/test/java/com/renewsim/backend/config/TestSecurityConfig.java`
- Replaced the test security override so it mocks `LoginRateLimitingFilter` directly
- Removed `src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker`

## Included in this phase

- Test runtime stabilization for local and CI execution
- Fix for Spring test context loading in user-role management tests
- Preservation of support for tests that mock final classes

## Why

The previous subclass mock-maker workaround fixed one local issue but introduced a bigger compatibility problem: it breaks tests that mock final classes.

On top of that, the failing CI tests were also hitting a Spring `ApplicationContext` loading issue because `TestSecurityConfig` still referenced `LoginRateLimiter` unnecessarily during test-classpath scanning.

This PR fixes the test runtime setup in a way that works across both local runs and CI.

## Benefits

- Keeps Mockito compatible with final-class mocks
- Prevents fragile self-attach behavior from being the only path locally
- Fixes Spring test context initialization for affected controller tests
- Aligns the PR scope with the actual root cause

## Not included

- No production business logic changes
- No simulation refactor changes
- No API contract changes

## Validation

- `mvn "-Dtest=UserControllerRoleManagementTest,SimulationDashboardControllerTest,CreateUserServiceTest" test --batch-mode --no-transfer-progress`

## Notes for reviewers

This PR started as a local Mockito workaround, but investigation showed the correct fix needed to cover both:
- final-class mocking compatibility
- Spring test context stability in CI