### PR TITLE
 refactor(simulation): phase 5 of domain boundary hardening

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/technology/solar/SolarSimulationAssessmentPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/technology/solar/SolarSimulationAssessmentPolicy.java
@@ -5,6 +5,7 @@ import com.renewsim.backend.simulation_service.create.application.command.Create
 import com.renewsim.backend.simulation_service.create.application.FinancialCalculator;
 import com.renewsim.backend.simulation_service.create.application.technology.SimulationAssessmentPolicy;
 import com.renewsim.backend.simulation_service.create.application.technology.TechnologySystemProfile;
+import com.renewsim.backend.simulation_service.domain.policy.SolarSimulationRecommendationPolicy;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,8 @@ import java.util.List;
 @Component
 @Primary
 public class SolarSimulationAssessmentPolicy implements SimulationAssessmentPolicy {
+
+    private final SolarSimulationRecommendationPolicy recommendationPolicy = new SolarSimulationRecommendationPolicy();
 
     @Override
     public boolean supports(Technology technology) {
@@ -62,32 +65,15 @@ public class SolarSimulationAssessmentPolicy implements SimulationAssessmentPoli
                     "Performance assumptions are conservative and materially affect the outcome."));
         }
 
-        String recommendation;
-        String headline;
-        String summary;
+        SolarSimulationRecommendationPolicy.RecommendationDecision decision = recommendationPolicy.decide(
+                financialResult.npv(),
+                financialResult.irrPct(),
+                command.economics().discountRatePct(),
+                financialResult.paybackYears(),
+                command.economics().projectLifetime().years(),
+                specificYield);
 
-        if (financialResult.npv() > 0
-                && financialResult.irrPct() != null
-                && financialResult.irrPct() >= command.economics().discountRatePct()
-                && financialResult.paybackYears() != null
-                && financialResult.paybackYears() <= command.economics().projectLifetime().years() / 2.0
-                && specificYield >= 1250) {
-            recommendation = "recommended";
-            headline = "The scenario is technically solid and clears the baseline financial gate.";
-            summary = "Resource quality, annual yield, and discounted returns support moving the case into detailed engineering and commercial validation.";
-        } else if (financialResult.npv() > 0
-                || (financialResult.paybackYears() != null
-                && financialResult.paybackYears() <= command.economics().projectLifetime().years())) {
-            recommendation = "viable_with_reservations";
-            headline = "The scenario is viable, but the decision depends on validating core assumptions.";
-            summary = "The project shows credible technical output, while the financial profile still requires executive review of pricing, losses, and recovery targets.";
-        } else {
-            recommendation = "not_recommended";
-            headline = "The scenario should not move forward without material assumption changes.";
-            summary = "Under the submitted inputs, the technical and financial outputs do not justify progressing the case in its current form.";
-        }
-
-        return new Assessment(recommendation, headline, summary, reasons);
+        return new Assessment(decision.recommendation().wireValue(), decision.headline(), decision.summary(), reasons);
     }
 
     @Override

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
@@ -2,6 +2,7 @@ package com.renewsim.backend.simulation_service.dashboard.application;
 
 import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
 import com.renewsim.backend.simulation_service.domain.policy.SimulationFinancialRiskPolicy;
+import com.renewsim.backend.simulation_service.domain.policy.SimulationPortfolioPriorityPolicy;
 import com.renewsim.backend.simulation_service.domain.policy.SimulationRecommendationReviewPolicy;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 
@@ -14,6 +15,7 @@ final class PortfolioScenarioScoringPolicy {
 
     private final SimulationRecommendationReviewPolicy reviewPolicy = new SimulationRecommendationReviewPolicy();
     private final SimulationFinancialRiskPolicy financialRiskPolicy = new SimulationFinancialRiskPolicy();
+    private final SimulationPortfolioPriorityPolicy priorityPolicy = new SimulationPortfolioPriorityPolicy();
 
     int computeScore(SimulationDetailsResult details, Double roiPercent, Double paybackYears) {
         if (details == null || details.summary() == null) {
@@ -56,16 +58,7 @@ final class PortfolioScenarioScoringPolicy {
     }
 
     String priorityFor(int score, boolean hasDetails) {
-        if (!hasDetails) {
-            return "REVIEW";
-        }
-        if (score >= 75) {
-            return "HIGH";
-        }
-        if (score >= 50) {
-            return "MEDIUM";
-        }
-        return "LOW";
+        return priorityPolicy.priorityFor(score, hasDetails);
     }
 
     boolean hasNegativeRoi(Double roiPercent) {

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
@@ -1,6 +1,7 @@
 package com.renewsim.backend.simulation_service.dashboard.application;
 
 import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
+import com.renewsim.backend.simulation_service.domain.policy.SimulationRecommendationReviewPolicy;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 
 import java.util.List;
@@ -12,6 +13,7 @@ final class PortfolioScenarioScoringPolicy {
 
     private static final double LONG_PAYBACK_YEARS = 10.0;
     private static final double WEAK_ROI_PERCENT = 5.0;
+    private final SimulationRecommendationReviewPolicy reviewPolicy = new SimulationRecommendationReviewPolicy();
 
     int computeScore(SimulationDetailsResult details, Double roiPercent, Double paybackYears) {
         if (details == null || details.summary() == null) {
@@ -64,10 +66,10 @@ final class PortfolioScenarioScoringPolicy {
         if (details == null) {
             return true;
         }
-        if (SimulationRecommendation.fromWireValue(recommendation) != SimulationRecommendation.RECOMMENDED) {
-            return true;
-        }
-        return safeWarnings(details).stream().anyMatch(warning -> "warning".equalsIgnoreCase(warning.severity()));
+        return reviewPolicy.needsReview(
+                SimulationRecommendation.fromWireValue(recommendation),
+                safeWarnings(details).stream().anyMatch(warning -> "warning".equalsIgnoreCase(warning.severity())),
+                true);
     }
 
     String priorityFor(int score, boolean hasDetails) {

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
@@ -1,5 +1,6 @@
 package com.renewsim.backend.simulation_service.dashboard.application;
 
+import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 
 import java.util.List;
@@ -17,10 +18,10 @@ final class PortfolioScenarioScoringPolicy {
             return 20;
         }
 
-        int score = switch (details.summary().recommendation()) {
-            case "recommended" -> 45;
-            case "viable_with_reservations" -> 30;
-            default -> 10;
+        int score = switch (SimulationRecommendation.fromWireValue(details.summary().recommendation())) {
+            case RECOMMENDED -> 45;
+            case VIABLE_WITH_RESERVATIONS -> 30;
+            case NOT_RECOMMENDED -> 10;
         };
 
         if (roiPercent != null) {
@@ -63,7 +64,7 @@ final class PortfolioScenarioScoringPolicy {
         if (details == null) {
             return true;
         }
-        if (!"recommended".equalsIgnoreCase(recommendation)) {
+        if (SimulationRecommendation.fromWireValue(recommendation) != SimulationRecommendation.RECOMMENDED) {
             return true;
         }
         return safeWarnings(details).stream().anyMatch(warning -> "warning".equalsIgnoreCase(warning.severity()));

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
@@ -1,6 +1,7 @@
 package com.renewsim.backend.simulation_service.dashboard.application;
 
 import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
+import com.renewsim.backend.simulation_service.domain.policy.SimulationFinancialRiskPolicy;
 import com.renewsim.backend.simulation_service.domain.policy.SimulationRecommendationReviewPolicy;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 
@@ -11,9 +12,8 @@ import java.util.List;
  */
 final class PortfolioScenarioScoringPolicy {
 
-    private static final double LONG_PAYBACK_YEARS = 10.0;
-    private static final double WEAK_ROI_PERCENT = 5.0;
     private final SimulationRecommendationReviewPolicy reviewPolicy = new SimulationRecommendationReviewPolicy();
+    private final SimulationFinancialRiskPolicy financialRiskPolicy = new SimulationFinancialRiskPolicy();
 
     int computeScore(SimulationDetailsResult details, Double roiPercent, Double paybackYears) {
         if (details == null || details.summary() == null) {
@@ -42,24 +42,7 @@ final class PortfolioScenarioScoringPolicy {
     }
 
     String resolveMainRisk(SimulationDetailsResult details, Double paybackYears, Double roiPercent) {
-        if (details == null) {
-            return "Informacion financiera incompleta";
-        }
-        String warningRisk = safeWarnings(details).stream()
-                .filter(warning -> "warning".equalsIgnoreCase(warning.severity()))
-                .map(SimulationDetailsResult.SimulationWarning::message)
-                .findFirst()
-                .orElse(null);
-        if (warningRisk != null) {
-            return warningRisk;
-        }
-        if (paybackYears != null && paybackYears > LONG_PAYBACK_YEARS) {
-            return "Payback por encima de la banda esperada";
-        }
-        if (roiPercent != null && roiPercent < WEAK_ROI_PERCENT) {
-            return "Retorno anual debil frente al CAPEX";
-        }
-        return "Sensibilidad moderada a supuestos economicos";
+        return financialRiskPolicy.resolveMainRisk(details, paybackYears, roiPercent);
     }
 
     boolean needsReview(SimulationDetailsResult details, String recommendation) {
@@ -86,11 +69,11 @@ final class PortfolioScenarioScoringPolicy {
     }
 
     boolean hasNegativeRoi(Double roiPercent) {
-        return roiPercent != null && roiPercent < 0.0;
+        return financialRiskPolicy.hasNegativeRoi(roiPercent);
     }
 
     boolean hasLongPayback(Double paybackYears) {
-        return paybackYears != null && paybackYears > LONG_PAYBACK_YEARS;
+        return financialRiskPolicy.hasLongPayback(paybackYears);
     }
 
     private List<SimulationDetailsResult.SimulationWarning> safeWarnings(SimulationDetailsResult details) {

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
@@ -44,7 +44,7 @@ final class PortfolioScenarioScoringPolicy {
     }
 
     String resolveMainRisk(SimulationDetailsResult details, Double paybackYears, Double roiPercent) {
-        return financialRiskPolicy.resolveMainRisk(details, paybackYears, roiPercent);
+        return financialRiskPolicy.resolveMainRisk(firstWarningMessage(details), paybackYears, roiPercent);
     }
 
     boolean needsReview(SimulationDetailsResult details, String recommendation) {
@@ -71,5 +71,16 @@ final class PortfolioScenarioScoringPolicy {
 
     private List<SimulationDetailsResult.SimulationWarning> safeWarnings(SimulationDetailsResult details) {
         return details.warnings() == null ? List.of() : details.warnings();
+    }
+
+    private String firstWarningMessage(SimulationDetailsResult details) {
+        if (details == null) {
+            return null;
+        }
+        return safeWarnings(details).stream()
+                .filter(warning -> "warning".equalsIgnoreCase(warning.severity()))
+                .map(SimulationDetailsResult.SimulationWarning::message)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
@@ -2,6 +2,7 @@ package com.renewsim.backend.simulation_service.dashboard.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
+import com.renewsim.backend.simulation_service.domain.policy.SimulationRecommendationReviewPolicy;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.ScenarioSnapshot;
 import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
@@ -18,6 +19,7 @@ final class ScenarioSnapshotAssembler {
     private final TechnologyLookupPort technologyLookupPort;
     private final ObjectMapper objectMapper;
     private final PortfolioScenarioScoringPolicy scoringPolicy;
+    private final SimulationRecommendationReviewPolicy reviewPolicy;
 
     ScenarioSnapshotAssembler(
             TechnologyLookupPort technologyLookupPort,
@@ -26,6 +28,7 @@ final class ScenarioSnapshotAssembler {
         this.technologyLookupPort = technologyLookupPort;
         this.objectMapper = objectMapper;
         this.scoringPolicy = scoringPolicy;
+        this.reviewPolicy = new SimulationRecommendationReviewPolicy();
     }
 
     ScenarioSnapshot toSnapshot(Simulation simulation) {
@@ -51,6 +54,7 @@ final class ScenarioSnapshotAssembler {
         String recommendation = summary != null && summary.recommendation() != null
                 ? summary.recommendation()
                 : "review_required";
+        SimulationRecommendation normalizedRecommendation = SimulationRecommendation.fromWireValue(recommendation);
         List<String> drivers = summary != null && summary.reasons() != null
                 ? summary.reasons().stream()
                         .map(SimulationDetailsResult.RecommendationReason::message)
@@ -81,12 +85,16 @@ final class ScenarioSnapshotAssembler {
                         : "El escenario necesita completar datos antes de priorizarse.",
                 drivers,
                 scoringPolicy.resolveMainRisk(details, paybackYears, roiPercent),
-                nextStepFor(recommendation),
+                reviewPolicy.nextStepFor(normalizedRecommendation),
                 scoringPolicy.priorityFor(score, hasCompleteDetails),
                 score,
                 simulation.getCreatedAt(),
                 !hasCompleteDetails,
-                scoringPolicy.needsReview(details, recommendation),
+                reviewPolicy.needsReview(
+                        normalizedRecommendation,
+                        details != null && details.warnings() != null
+                                && details.warnings().stream().anyMatch(warning -> "warning".equalsIgnoreCase(warning.severity())),
+                        hasCompleteDetails),
                 scoringPolicy.hasNegativeRoi(roiPercent),
                 scoringPolicy.hasLongPayback(paybackYears));
     }
@@ -107,14 +115,6 @@ final class ScenarioSnapshotAssembler {
             return null;
         }
         return round((annualBenefit / capex) * 100.0);
-    }
-
-    private String nextStepFor(String recommendation) {
-        return switch (SimulationRecommendation.fromWireValue(recommendation)) {
-            case RECOMMENDED -> "Validar sensibilidad y elevar a evaluacion ejecutiva";
-            case VIABLE_WITH_RESERVATIONS -> "Revisar supuestos criticos antes de priorizar inversion";
-            case NOT_RECOMMENDED -> "Completar datos y replantear supuestos antes de avanzar";
-        };
     }
 
     private String normalizeLabel(String value) {

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
@@ -1,6 +1,7 @@
 package com.renewsim.backend.simulation_service.dashboard.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.ScenarioSnapshot;
 import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
@@ -109,10 +110,10 @@ final class ScenarioSnapshotAssembler {
     }
 
     private String nextStepFor(String recommendation) {
-        return switch (recommendation) {
-            case "recommended" -> "Validar sensibilidad y elevar a evaluacion ejecutiva";
-            case "viable_with_reservations" -> "Revisar supuestos criticos antes de priorizar inversion";
-            default -> "Completar datos y replantear supuestos antes de avanzar";
+        return switch (SimulationRecommendation.fromWireValue(recommendation)) {
+            case RECOMMENDED -> "Validar sensibilidad y elevar a evaluacion ejecutiva";
+            case VIABLE_WITH_RESERVATIONS -> "Revisar supuestos criticos antes de priorizar inversion";
+            case NOT_RECOMMENDED -> "Completar datos y replantear supuestos antes de avanzar";
         };
     }
 

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/exception/InvalidSimulationCreatorException.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/exception/InvalidSimulationCreatorException.java
@@ -1,0 +1,8 @@
+package com.renewsim.backend.simulation_service.domain.exception;
+
+public class InvalidSimulationCreatorException extends RuntimeException {
+
+    public InvalidSimulationCreatorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/exception/InvalidSimulationNameException.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/exception/InvalidSimulationNameException.java
@@ -1,0 +1,8 @@
+package com.renewsim.backend.simulation_service.domain.exception;
+
+public class InvalidSimulationNameException extends RuntimeException {
+
+    public InvalidSimulationNameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/model/Simulation.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/model/Simulation.java
@@ -1,6 +1,9 @@
 package com.renewsim.backend.simulation_service.domain.model;
 
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationCompletionException;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationCreatorException;
 import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationIdentityAssignmentException;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationNameException;
 import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationStatusTransitionException;
 import com.renewsim.backend.simulation_service.domain.model.vo.*;
 
@@ -34,6 +37,9 @@ public class Simulation {
             Double annualGenerationKwh, Double annualSavings,
             Double npv, Double irrPct, String recommendation,
             String createdBy, LocalDateTime createdAt, LocalDateTime updatedAt) {
+
+        validateName(name);
+        validateCreator(createdBy);
 
         this.id = id;
         this.name = name;
@@ -89,6 +95,9 @@ public class Simulation {
     public void complete(SimulationCompletion completion) {
         if (status != SimulationStatus.DRAFT) {
             throw new InvalidSimulationStatusTransitionException("complete", status);
+        }
+        if (completion == null) {
+            throw new InvalidSimulationCompletionException("Simulation completion is required");
         }
         this.resultSnapshot = completion.resultSnapshot();
         this.annualGenerationKwh = completion.annualGenerationKwh();
@@ -150,5 +159,17 @@ public class Simulation {
     public String getCreatedBy() { return createdBy; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }
+
+    private static void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new InvalidSimulationNameException("Simulation name must not be blank");
+        }
+    }
+
+    private static void validateCreator(String createdBy) {
+        if (createdBy == null || createdBy.isBlank()) {
+            throw new InvalidSimulationCreatorException("Simulation creator must not be blank");
+        }
+    }
 
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/model/SimulationRecommendation.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/model/SimulationRecommendation.java
@@ -1,0 +1,29 @@
+package com.renewsim.backend.simulation_service.domain.model;
+
+public enum SimulationRecommendation {
+    RECOMMENDED("recommended"),
+    VIABLE_WITH_RESERVATIONS("viable_with_reservations"),
+    NOT_RECOMMENDED("not_recommended");
+
+    private final String wireValue;
+
+    SimulationRecommendation(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    public String wireValue() {
+        return wireValue;
+    }
+
+    public static SimulationRecommendation fromWireValue(String value) {
+        if (value == null || value.isBlank()) {
+            return NOT_RECOMMENDED;
+        }
+        for (SimulationRecommendation recommendation : values()) {
+            if (recommendation.wireValue.equalsIgnoreCase(value.trim())) {
+                return recommendation;
+            }
+        }
+        return NOT_RECOMMENDED;
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicy.java
@@ -1,0 +1,49 @@
+package com.renewsim.backend.simulation_service.domain.policy;
+
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+
+import java.util.List;
+
+public final class SimulationFinancialRiskPolicy {
+
+    private static final double LONG_PAYBACK_YEARS = 10.0;
+    private static final double WEAK_ROI_PERCENT = 5.0;
+
+    public String resolveMainRisk(SimulationDetailsResult details, Double paybackYears, Double roiPercent) {
+        if (details == null) {
+            return "Informacion financiera incompleta";
+        }
+
+        String warningRisk = safeWarnings(details).stream()
+                .filter(warning -> "warning".equalsIgnoreCase(warning.severity()))
+                .map(SimulationDetailsResult.SimulationWarning::message)
+                .findFirst()
+                .orElse(null);
+        if (warningRisk != null) {
+            return warningRisk;
+        }
+        if (hasLongPayback(paybackYears)) {
+            return "Payback por encima de la banda esperada";
+        }
+        if (hasWeakRoi(roiPercent)) {
+            return "Retorno anual debil frente al CAPEX";
+        }
+        return "Sensibilidad moderada a supuestos economicos";
+    }
+
+    public boolean hasNegativeRoi(Double roiPercent) {
+        return roiPercent != null && roiPercent < 0.0;
+    }
+
+    public boolean hasLongPayback(Double paybackYears) {
+        return paybackYears != null && paybackYears > LONG_PAYBACK_YEARS;
+    }
+
+    public boolean hasWeakRoi(Double roiPercent) {
+        return roiPercent != null && roiPercent < WEAK_ROI_PERCENT;
+    }
+
+    private List<SimulationDetailsResult.SimulationWarning> safeWarnings(SimulationDetailsResult details) {
+        return details.warnings() == null ? List.of() : details.warnings();
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicy.java
@@ -1,26 +1,16 @@
 package com.renewsim.backend.simulation_service.domain.policy;
 
-import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
-
-import java.util.List;
-
 public final class SimulationFinancialRiskPolicy {
 
     private static final double LONG_PAYBACK_YEARS = 10.0;
     private static final double WEAK_ROI_PERCENT = 5.0;
 
-    public String resolveMainRisk(SimulationDetailsResult details, Double paybackYears, Double roiPercent) {
-        if (details == null) {
-            return "Informacion financiera incompleta";
-        }
-
-        String warningRisk = safeWarnings(details).stream()
-                .filter(warning -> "warning".equalsIgnoreCase(warning.severity()))
-                .map(SimulationDetailsResult.SimulationWarning::message)
-                .findFirst()
-                .orElse(null);
-        if (warningRisk != null) {
+    public String resolveMainRisk(String warningRisk, Double paybackYears, Double roiPercent) {
+        if (warningRisk != null && !warningRisk.isBlank()) {
             return warningRisk;
+        }
+        if (paybackYears == null && roiPercent == null) {
+            return "Informacion financiera incompleta";
         }
         if (hasLongPayback(paybackYears)) {
             return "Payback por encima de la banda esperada";
@@ -41,9 +31,5 @@ public final class SimulationFinancialRiskPolicy {
 
     public boolean hasWeakRoi(Double roiPercent) {
         return roiPercent != null && roiPercent < WEAK_ROI_PERCENT;
-    }
-
-    private List<SimulationDetailsResult.SimulationWarning> safeWarnings(SimulationDetailsResult details) {
-        return details.warnings() == null ? List.of() : details.warnings();
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SimulationPortfolioPriorityPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SimulationPortfolioPriorityPolicy.java
@@ -1,0 +1,17 @@
+package com.renewsim.backend.simulation_service.domain.policy;
+
+public final class SimulationPortfolioPriorityPolicy {
+
+    public String priorityFor(int score, boolean hasDetails) {
+        if (!hasDetails) {
+            return "REVIEW";
+        }
+        if (score >= 75) {
+            return "HIGH";
+        }
+        if (score >= 50) {
+            return "MEDIUM";
+        }
+        return "LOW";
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SimulationRecommendationReviewPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SimulationRecommendationReviewPolicy.java
@@ -1,0 +1,24 @@
+package com.renewsim.backend.simulation_service.domain.policy;
+
+import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
+
+public final class SimulationRecommendationReviewPolicy {
+
+    public boolean needsReview(SimulationRecommendation recommendation, boolean hasWarnings, boolean hasDetails) {
+        if (!hasDetails) {
+            return true;
+        }
+        if (recommendation != SimulationRecommendation.RECOMMENDED) {
+            return true;
+        }
+        return hasWarnings;
+    }
+
+    public String nextStepFor(SimulationRecommendation recommendation) {
+        return switch (recommendation) {
+            case RECOMMENDED -> "Validar sensibilidad y elevar a evaluacion ejecutiva";
+            case VIABLE_WITH_RESERVATIONS -> "Revisar supuestos criticos antes de priorizar inversion";
+            case NOT_RECOMMENDED -> "Completar datos y replantear supuestos antes de avanzar";
+        };
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SolarSimulationRecommendationPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/policy/SolarSimulationRecommendationPolicy.java
@@ -1,0 +1,45 @@
+package com.renewsim.backend.simulation_service.domain.policy;
+
+import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
+
+public final class SolarSimulationRecommendationPolicy {
+
+        public RecommendationDecision decide(
+                        double npv,
+                        Double irrPct,
+                        double discountRatePct,
+                        Double paybackYears,
+                        int projectLifetimeYears,
+                        double specificYield) {
+
+                if (npv > 0
+                                && irrPct != null
+                                && irrPct >= discountRatePct
+                                && paybackYears != null
+                                && paybackYears <= projectLifetimeYears / 2.0
+                                && specificYield >= 1250) {
+                        return new RecommendationDecision(
+                                        SimulationRecommendation.RECOMMENDED,
+                                        "The scenario is technically solid and clears the baseline financial gate.",
+                                        "Resource quality, annual yield, and discounted returns support moving the case into detailed engineering and commercial validation.");
+                }
+
+                if (npv > 0 || (paybackYears != null && paybackYears <= projectLifetimeYears)) {
+                        return new RecommendationDecision(
+                                        SimulationRecommendation.VIABLE_WITH_RESERVATIONS,
+                                        "The scenario is viable, but the decision depends on validating core assumptions.",
+                                        "The project shows credible technical output, while the financial profile still requires executive review of pricing, losses, and recovery targets.");
+                }
+
+                return new RecommendationDecision(
+                                SimulationRecommendation.NOT_RECOMMENDED,
+                                "The scenario should not move forward without material assumption changes.",
+                                "Under the submitted inputs, the technical and financial outputs do not justify progressing the case in its current form.");
+        }
+
+        public record RecommendationDecision(
+                        SimulationRecommendation recommendation,
+                        String headline,
+                        String summary) {
+        }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/domain/model/SimulationTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/domain/model/SimulationTest.java
@@ -1,0 +1,131 @@
+package com.renewsim.backend.simulation_service.domain.model;
+
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationCompletionException;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationCreatorException;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationNameException;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationStatusTransitionException;
+import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
+import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
+import com.renewsim.backend.simulation_service.domain.model.vo.Currency;
+import com.renewsim.backend.simulation_service.domain.model.vo.ProjectLifetime;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomics;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
+import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SimulationTest {
+
+    @Test
+    @DisplayName("create rejects blank simulation name")
+    void createRejectsBlankSimulationName() {
+        assertThatThrownBy(() -> Simulation.create(
+                " ",
+                Technology.solar(),
+                validLocation(),
+                validSystem(),
+                validDemand(),
+                validEconomics(),
+                "alice"))
+                .isInstanceOf(InvalidSimulationNameException.class)
+                .hasMessageContaining("name");
+    }
+
+    @Test
+    @DisplayName("create rejects blank creator")
+    void createRejectsBlankCreator() {
+        assertThatThrownBy(() -> Simulation.create(
+                "Solar - Sevilla",
+                Technology.solar(),
+                validLocation(),
+                validSystem(),
+                validDemand(),
+                validEconomics(),
+                " "))
+                .isInstanceOf(InvalidSimulationCreatorException.class)
+                .hasMessageContaining("creator");
+    }
+
+    @Test
+    @DisplayName("complete rejects null completion")
+    void completeRejectsNullCompletion() {
+        Simulation simulation = validSimulation();
+
+        assertThatThrownBy(() -> simulation.complete(null))
+                .isInstanceOf(InvalidSimulationCompletionException.class)
+                .hasMessageContaining("required");
+    }
+
+    @Test
+    @DisplayName("complete updates status and result fields")
+    void completeUpdatesStatusAndResultFields() {
+        Simulation simulation = validSimulation();
+        SimulationCompletion completion = new SimulationCompletion(
+                "{\"result\":true}",
+                457200.0,
+                82000.0,
+                121500.0,
+                14.2,
+                "recommended");
+
+        simulation.complete(completion);
+
+        assertThat(simulation.getStatus()).isEqualTo(SimulationStatus.COMPLETED);
+        assertThat(simulation.getResultSnapshot()).isEqualTo("{\"result\":true}");
+        assertThat(simulation.getRecommendation()).isEqualTo("recommended");
+        assertThat(simulation.getUpdatedAt()).isAfterOrEqualTo(simulation.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("complete rejects non draft simulations")
+    void completeRejectsNonDraftSimulations() {
+        Simulation simulation = validSimulation();
+        simulation.delete();
+
+        assertThatThrownBy(() -> simulation.complete(new SimulationCompletion(
+                "{\"result\":true}",
+                457200.0,
+                82000.0,
+                121500.0,
+                14.2,
+                "recommended")))
+                .isInstanceOf(InvalidSimulationStatusTransitionException.class)
+                .hasMessageContaining("complete");
+    }
+
+    private Simulation validSimulation() {
+        return Simulation.create(
+                "Solar - Sevilla",
+                Technology.solar(),
+                validLocation(),
+                validSystem(),
+                validDemand(),
+                validEconomics(),
+                "alice");
+    }
+
+    private SimulationLocation validLocation() {
+        return SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", CountryCode.of("ES"));
+    }
+
+    private SimulationSystem validSystem() {
+        return new SimulationSystem(300.0, 0.81, 0.5, 99.0,
+                new SimulationSystem.LossesPct(2.0, 6.0, 1.0, 3.0, 1.0));
+    }
+
+    private ConsumptionProfile validDemand() {
+        return ConsumptionProfile.of(120000,
+                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
+                        10000d));
+    }
+
+    private SimulationEconomics validEconomics() {
+        return new SimulationEconomics(Currency.of("EUR"), 315000.0, 7200.0, 0.18, 0.07, 8, ProjectLifetime.of(20));
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicyTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicyTest.java
@@ -15,19 +15,18 @@ class SimulationFinancialRiskPolicyTest {
     @Test
     @DisplayName("resolveMainRisk prefers explicit warnings")
     void resolveMainRiskPrefersWarnings() {
-        SimulationDetailsResult details = details(List.of(
-                new SimulationDetailsResult.SimulationWarning("warning", "LOW_AVAILABILITY", "Availability too low")));
-
-        assertThat(policy.resolveMainRisk(details, 12.0, 2.0)).isEqualTo("Availability too low");
+        assertThat(policy.resolveMainRisk("Availability too low", 12.0, 2.0)).isEqualTo("Availability too low");
     }
 
     @Test
     @DisplayName("resolveMainRisk falls back to payback and roi thresholds")
     void resolveMainRiskFallsBackToThresholds() {
-        assertThat(policy.resolveMainRisk(details(List.of()), 12.0, 6.0))
+        assertThat(policy.resolveMainRisk(null, 12.0, 6.0))
                 .contains("Payback");
-        assertThat(policy.resolveMainRisk(details(List.of()), 8.0, 2.0))
+        assertThat(policy.resolveMainRisk(null, 8.0, 2.0))
                 .contains("Retorno anual");
+        assertThat(policy.resolveMainRisk(null, null, null))
+                .contains("incompleta");
     }
 
     @Test
@@ -39,22 +38,5 @@ class SimulationFinancialRiskPolicyTest {
         assertThat(policy.hasLongPayback(10.0)).isFalse();
         assertThat(policy.hasWeakRoi(4.9)).isTrue();
         assertThat(policy.hasWeakRoi(5.0)).isFalse();
-    }
-
-    private SimulationDetailsResult details(List<SimulationDetailsResult.SimulationWarning> warnings) {
-        return new SimulationDetailsResult(
-                "55",
-                "completed",
-                "2026-06-30T14:00:00Z",
-                "2026-06-30T14:00:00Z",
-                "solar-spain-v1",
-                "solar",
-                null,
-                new SimulationDetailsResult.Summary("recommended", "headline", "summary", List.of()),
-                null,
-                null,
-                null,
-                null,
-                warnings);
     }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicyTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicyTest.java
@@ -1,0 +1,60 @@
+package com.renewsim.backend.simulation_service.domain.policy;
+
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimulationFinancialRiskPolicyTest {
+
+    private final SimulationFinancialRiskPolicy policy = new SimulationFinancialRiskPolicy();
+
+    @Test
+    @DisplayName("resolveMainRisk prefers explicit warnings")
+    void resolveMainRiskPrefersWarnings() {
+        SimulationDetailsResult details = details(List.of(
+                new SimulationDetailsResult.SimulationWarning("warning", "LOW_AVAILABILITY", "Availability too low")));
+
+        assertThat(policy.resolveMainRisk(details, 12.0, 2.0)).isEqualTo("Availability too low");
+    }
+
+    @Test
+    @DisplayName("resolveMainRisk falls back to payback and roi thresholds")
+    void resolveMainRiskFallsBackToThresholds() {
+        assertThat(policy.resolveMainRisk(details(List.of()), 12.0, 6.0))
+                .contains("Payback");
+        assertThat(policy.resolveMainRisk(details(List.of()), 8.0, 2.0))
+                .contains("Retorno anual");
+    }
+
+    @Test
+    @DisplayName("financial flags follow threshold rules")
+    void financialFlagsFollowThresholdRules() {
+        assertThat(policy.hasNegativeRoi(-0.1)).isTrue();
+        assertThat(policy.hasNegativeRoi(0.0)).isFalse();
+        assertThat(policy.hasLongPayback(10.1)).isTrue();
+        assertThat(policy.hasLongPayback(10.0)).isFalse();
+        assertThat(policy.hasWeakRoi(4.9)).isTrue();
+        assertThat(policy.hasWeakRoi(5.0)).isFalse();
+    }
+
+    private SimulationDetailsResult details(List<SimulationDetailsResult.SimulationWarning> warnings) {
+        return new SimulationDetailsResult(
+                "55",
+                "completed",
+                "2026-06-30T14:00:00Z",
+                "2026-06-30T14:00:00Z",
+                "solar-spain-v1",
+                "solar",
+                null,
+                new SimulationDetailsResult.Summary("recommended", "headline", "summary", List.of()),
+                null,
+                null,
+                null,
+                null,
+                warnings);
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationPortfolioPriorityPolicyTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationPortfolioPriorityPolicyTest.java
@@ -1,0 +1,20 @@
+package com.renewsim.backend.simulation_service.domain.policy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimulationPortfolioPriorityPolicyTest {
+
+    private final SimulationPortfolioPriorityPolicy policy = new SimulationPortfolioPriorityPolicy();
+
+    @Test
+    @DisplayName("priorityFor maps missing details to review and score bands to priority")
+    void priorityForMapsScoreBands() {
+        assertThat(policy.priorityFor(80, true)).isEqualTo("HIGH");
+        assertThat(policy.priorityFor(60, true)).isEqualTo("MEDIUM");
+        assertThat(policy.priorityFor(20, true)).isEqualTo("LOW");
+        assertThat(policy.priorityFor(80, false)).isEqualTo("REVIEW");
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationRecommendationReviewPolicyTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationRecommendationReviewPolicyTest.java
@@ -1,0 +1,33 @@
+package com.renewsim.backend.simulation_service.domain.policy;
+
+import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimulationRecommendationReviewPolicyTest {
+
+    private final SimulationRecommendationReviewPolicy policy = new SimulationRecommendationReviewPolicy();
+
+    @Test
+    @DisplayName("needsReview is false only for recommended scenarios with details and no warnings")
+    void needsReviewIsFalseOnlyForCleanRecommendedScenarios() {
+        assertThat(policy.needsReview(SimulationRecommendation.RECOMMENDED, false, true)).isFalse();
+        assertThat(policy.needsReview(SimulationRecommendation.RECOMMENDED, true, true)).isTrue();
+        assertThat(policy.needsReview(SimulationRecommendation.VIABLE_WITH_RESERVATIONS, false, true)).isTrue();
+        assertThat(policy.needsReview(SimulationRecommendation.NOT_RECOMMENDED, false, true)).isTrue();
+        assertThat(policy.needsReview(SimulationRecommendation.RECOMMENDED, false, false)).isTrue();
+    }
+
+    @Test
+    @DisplayName("nextStepFor maps each recommendation to an explicit business next step")
+    void nextStepForMapsRecommendations() {
+        assertThat(policy.nextStepFor(SimulationRecommendation.RECOMMENDED))
+                .contains("evaluacion ejecutiva");
+        assertThat(policy.nextStepFor(SimulationRecommendation.VIABLE_WITH_RESERVATIONS))
+                .contains("supuestos criticos");
+        assertThat(policy.nextStepFor(SimulationRecommendation.NOT_RECOMMENDED))
+                .contains("Completar datos");
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SolarSimulationRecommendationPolicyTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SolarSimulationRecommendationPolicyTest.java
@@ -1,0 +1,54 @@
+package com.renewsim.backend.simulation_service.domain.policy;
+
+import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SolarSimulationRecommendationPolicyTest {
+
+    private final SolarSimulationRecommendationPolicy policy = new SolarSimulationRecommendationPolicy();
+
+    @Test
+    @DisplayName("decide returns recommended for strong financial and resource profile")
+    void decideReturnsRecommendedForStrongProfile() {
+        SolarSimulationRecommendationPolicy.RecommendationDecision decision = policy.decide(
+                121500.0,
+                14.2,
+                8.0,
+                6.0,
+                20,
+                1400.0);
+
+        assertThat(decision.recommendation()).isEqualTo(SimulationRecommendation.RECOMMENDED);
+    }
+
+    @Test
+    @DisplayName("decide returns viable with reservations when project is recoverable but not strong")
+    void decideReturnsViableWithReservationsWhenRecoverable() {
+        SolarSimulationRecommendationPolicy.RecommendationDecision decision = policy.decide(
+                -5000.0,
+                null,
+                8.0,
+                18.0,
+                20,
+                1180.0);
+
+        assertThat(decision.recommendation()).isEqualTo(SimulationRecommendation.VIABLE_WITH_RESERVATIONS);
+    }
+
+    @Test
+    @DisplayName("decide returns not recommended when the case does not recover investment")
+    void decideReturnsNotRecommendedWhenWeak() {
+        SolarSimulationRecommendationPolicy.RecommendationDecision decision = policy.decide(
+                -25000.0,
+                null,
+                8.0,
+                25.0,
+                20,
+                1000.0);
+
+        assertThat(decision.recommendation()).isEqualTo(SimulationRecommendation.NOT_RECOMMENDED);
+    }
+}


### PR DESCRIPTION
## What changed

- Hardened the `Simulation` aggregate invariants
- Added domain exceptions for invalid simulation name and invalid simulation creator
- Introduced `SimulationRecommendation` as an explicit domain concept
- Extracted solar recommendation semantics into `SolarSimulationRecommendationPolicy`
- Extracted recommendation review semantics into `SimulationRecommendationReviewPolicy`
- Extracted financial risk semantics into `SimulationFinancialRiskPolicy`
- Extracted portfolio priority semantics into `SimulationPortfolioPriorityPolicy`
- Updated dashboard and create application code to consume the new domain policies instead of embedding those rules directly
- Added focused domain tests for aggregate invariants and each extracted policy

## Included in this phase

- Domain-only hardening of `simulation_service`
- No structural package refactor outside the domain/application interaction
- No API contract changes
- No behavior changes to endpoints beyond centralizing existing business semantics

## Why

After phase 4, the module structure was already much clearer, but important business meaning still lived in application-level classes:

- recommendation classification
- review semantics
- financial risk interpretation
- priority semantics

That made the domain weaker than the package structure suggested.

This phase moves those semantics toward the domain so the module is not just physically organized, but also conceptually aligned with business responsibility.

## Benefits

- Strengthens `Simulation` as a real aggregate instead of a passive data holder
- Replaces stringly-typed business meaning with explicit domain concepts
- Reduces business-rule leakage into dashboard and create application code
- Makes recommendation, review, risk, and priority rules easier to test in isolation
- Improves long-term maintainability of simulation decision logic

## Not included

- No edit/update bugfix work
- No persistence refactor
- No web/controller refactor
- No infrastructure redesign
- No API payload changes

## Validation

- `mvn test-compile --batch-mode --no-transfer-progress`
- `mvn "-Dtest=SimulationTest,SolarSimulationRecommendationPolicyTest,SimulationRecommendationReviewPolicyTest,SimulationFinancialRiskPolicyTest,SimulationPortfolioPriorityPolicyTest,PortfolioScenarioScoringPolicyTest,PortfolioDashboardAggregatorTest" test --batch-mode --no-transfer-progress`

Note:
On local Windows validation, `MAVEN_OPTS='-Xmx768m -XX:MaxMetaspaceSize=256m'` was used to avoid javac native-memory pressure during repeated focused runs.

## Notes for reviewers

This phase is intentionally split into five reviewable commits:

1. `refactor(simulation): harden aggregate invariants`
2. `refactor(simulation): move recommendation semantics into domain`
3. `refactor(simulation): move review semantics into domain`
4. `refactor(simulation): move financial risk semantics into domain`
5. `refactor(simulation): move priority semantics into domain`

The main review question is whether these semantics now live at the right level of the model, not whether the package names changed.