### PR TITLE
refactor(simulation): align infrastructure boundaries in phase 6

### DIFF
--- a/src/main/java/com/renewsim/backend/scenario_service/infrastructure/adapter/TechnologyLookupJpaAdapter.java
+++ b/src/main/java/com/renewsim/backend/scenario_service/infrastructure/adapter/TechnologyLookupJpaAdapter.java
@@ -1,7 +1,7 @@
 package com.renewsim.backend.scenario_service.infrastructure.adapter;
 
 import com.renewsim.backend.scenario_service.application.port.out.ScenarioTechnologyLookupPort;
-import com.renewsim.backend.technology_service.infrastructure.persistence.repository.JpaTechnologyRepository;
+import com.renewsim.backend.technology_service.application.port.in.TechnologyCatalogLookupUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TechnologyLookupJpaAdapter implements ScenarioTechnologyLookupPort {
 
-    private final JpaTechnologyRepository technologyRepository;
+    private final TechnologyCatalogLookupUseCase technologyCatalogLookupUseCase;
 
     @Override
     public boolean existsActiveTechnology(Long technologyId) {
-        return technologyRepository.findByIdAndIsActiveTrue(technologyId).isPresent();
+        return technologyCatalogLookupUseCase.existsActiveTechnology(technologyId);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/model/vo/CountryCode.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/model/vo/CountryCode.java
@@ -4,17 +4,21 @@ import com.renewsim.backend.simulation_service.domain.exception.InvalidCountryCo
 
 public record CountryCode(String value) {
 
+    private static final String SUPPORTED_PHASE1 = "ES";
+
     public static CountryCode of(String value) {
         return new CountryCode(value);
     }
 
-    private static final String SUPPORTED_PHASE1 = "ES";
+    public static boolean isSupported(String value) {
+        return value != null && SUPPORTED_PHASE1.equalsIgnoreCase(value.trim());
+    }
 
     public CountryCode {
         if (value == null || value.isBlank()) {
             throw new InvalidCountryCodeException("VALIDATION_ERROR: countryCode is required");
         }
-        if (!SUPPORTED_PHASE1.equalsIgnoreCase(value.trim())) {
+        if (!isSupported(value)) {
             throw new InvalidCountryCodeException("LOCATION_NOT_FOUND: only Spain locations are supported in phase 1");
         }
         value = value.trim().toUpperCase();

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
@@ -2,7 +2,7 @@ package com.renewsim.backend.simulation_service.infrastructure.adapter.out.exter
 
 import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
 import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
-import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupPort;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -18,13 +18,13 @@ import java.util.Map;
 /**
  * Adapter for resolving and searching locations through OpenWeatherMap.
  *
- * <p>Implements {@link LocationLookupPort} and is activated only when the
+ * <p>Implements {@link LocationLookupProvider} and is activated only when the
  * simulation climate provider is configured as {@code openweathermap}.</p>
  */
 @Component
 @ConditionalOnProperty(prefix = "simulation.climate", name = "provider", havingValue = "openweathermap")
 @RequiredArgsConstructor
-public class OpenWeatherMapAdapter implements LocationLookupPort {
+public class OpenWeatherMapAdapter implements LocationLookupProvider {
 
     private static final Logger log = LoggerFactory.getLogger(OpenWeatherMapAdapter.class);
 

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
@@ -1,5 +1,6 @@
 package com.renewsim.backend.simulation_service.infrastructure.adapter.out.external;
 
+import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
 import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
 import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
 import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
@@ -13,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -37,31 +39,32 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
         try {
             Map<?, ?> response = fetchWeatherResponse(latitude, longitude);
             if (response == null) {
-                return new ResolvedLocation(String.format("%.4f, %.4f", latitude, longitude), "Unknown");
+                return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
             }
 
             String name = response.get("name") != null ? String.valueOf(response.get("name")) : null;
             Map<?, ?> sys = (Map<?, ?>) response.get("sys");
             String country = sys != null && sys.get("country") != null ? String.valueOf(sys.get("country")) : null;
+            if (!CountryCode.isSupported(country)) {
+                return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
+            }
 
             return new ResolvedLocation(
-                    name != null && !name.isBlank() ? name : String.format("%.4f, %.4f", latitude, longitude),
+                    name != null && !name.isBlank() ? name : coordinateLabel(latitude, longitude),
                     country != null && !country.isBlank() ? country : "Unknown");
         } catch (Exception e) {
-            log.error("Error resolving location for coordinates: {}, {} ({})",
-                    latitude,
-                    longitude,
-                    summarizeFailure(e));
-            return new ResolvedLocation(String.format("%.4f, %.4f", latitude, longitude), "Unknown");
+            log.error("Error resolving location from weather provider ({})", summarizeFailure(e));
+            return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
         }
     }
 
     @Override
     public List<ResolvedLocation> searchLocations(String query, int limit) {
+        int requestedLimit = Math.max(1, limit);
         try {
             String url = UriComponentsBuilder.fromHttpUrl(baseUrl() + "/geo/1.0/direct")
                     .queryParam("q", query)
-                    .queryParam("limit", Math.max(1, limit))
+                    .queryParam("limit", Math.max(requestedLimit * 5, 10))
                     .queryParam("appid", apiKey())
                     .toUriString();
 
@@ -74,9 +77,14 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
                     .filter(Map.class::isInstance)
                     .map(Map.class::cast)
                     .map(this::toResolvedLocation)
+                    .filter(location -> CountryCode.isSupported(location.country()))
+                    .limit(requestedLimit)
                     .toList();
         } catch (Exception e) {
-            log.error("Error searching locations for query: {} ({})", query, summarizeFailure(e));
+            log.error("Error searching locations from weather provider (queryLength={}, limit={}) ({})",
+                    query == null ? 0 : query.length(),
+                    requestedLimit,
+                    summarizeFailure(e));
             return List.of();
         }
     }
@@ -124,9 +132,21 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
     }
 
     private String sanitize(String value) {
-        return value
+        String sanitized = value
+                .replaceAll("[\r\n]", " ")
+                .replaceAll("q=[^&\\s]+", "q=<redacted>")
                 .replaceAll("appid=[^&\\s]+", "appid=<redacted>")
-                .replace(apiKey(), "<redacted>");
+                .replaceAll("lat=[^&\\s]+", "lat=<redacted>")
+                .replaceAll("lon=[^&\\s]+", "lon=<redacted>");
+        String key = apiKey();
+        if (key == null || key.isBlank()) {
+            return sanitized;
+        }
+        return sanitized.replace(key, "<redacted>");
+    }
+
+    private String coordinateLabel(double latitude, double longitude) {
+        return String.format(Locale.ROOT, "%.4f, %.4f", latitude, longitude);
     }
 
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/JpaSimulationRepository.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/JpaSimulationRepository.java
@@ -2,7 +2,7 @@ package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persi
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.renewsim.backend.simulation_service.infrastructure.persistence.entity.SimulationEntity;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 
 import java.util.List;
 

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodec.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodec.java
@@ -2,6 +2,7 @@ package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persi
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 
 import java.util.Collections;
@@ -48,12 +49,8 @@ final class SimulationInputSnapshotCodec {
 
     SimulationInputData readNormalized(String json, SimulationEntity entity) {
         SimulationInputData input = read(json);
-        String normalizedCountryCode = isBlank(input.locationCountryCode())
-                ? deriveCountryCode(entity.getLocation())
-                : input.locationCountryCode();
-        String normalizedCountry = isBlank(input.locationCountry())
-                ? deriveCountry(normalizedCountryCode)
-                : input.locationCountry();
+        String normalizedCountryCode = normalizeCountryCode(input.locationCountryCode(), entity.getLocation());
+        String normalizedCountry = deriveCountry(normalizedCountryCode);
 
         double annualConsumption = input.annualConsumptionKwh() > 0
                 ? input.annualConsumptionKwh()
@@ -105,6 +102,13 @@ final class SimulationInputSnapshotCodec {
             }
         }
         return "ES";
+    }
+
+    private String normalizeCountryCode(String snapshotCountryCode, String locationLabel) {
+        String candidate = isBlank(snapshotCountryCode)
+                ? deriveCountryCode(locationLabel)
+                : snapshotCountryCode.trim().toUpperCase();
+        return CountryCode.isSupported(candidate) ? candidate : "ES";
     }
 
     private String deriveCountry(String countryCode) {

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodec.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodec.java
@@ -2,7 +2,7 @@ package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persi
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
-import com.renewsim.backend.simulation_service.infrastructure.persistence.entity.SimulationEntity;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java
@@ -1,6 +1,5 @@
 package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
 
-import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationStatus;
 import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
@@ -12,7 +11,7 @@ import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocatio
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.SimulationInputSnapshotCodec.SimulationInputData;
-import com.renewsim.backend.simulation_service.infrastructure.persistence.entity.SimulationEntity;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 
 /**
  * Maps between the simulation aggregate and its persistence entity.
@@ -20,13 +19,9 @@ import com.renewsim.backend.simulation_service.infrastructure.persistence.entity
 final class SimulationRecordEntityMapper {
 
     private final SimulationInputSnapshotCodec snapshotCodec;
-    private final TechnologyLookupPort technologyLookupPort;
 
-    SimulationRecordEntityMapper(
-            SimulationInputSnapshotCodec snapshotCodec,
-            TechnologyLookupPort technologyLookupPort) {
+    SimulationRecordEntityMapper(SimulationInputSnapshotCodec snapshotCodec) {
         this.snapshotCodec = snapshotCodec;
-        this.technologyLookupPort = technologyLookupPort;
     }
 
     SimulationEntity toEntity(Simulation simulation) {
@@ -41,7 +36,6 @@ final class SimulationRecordEntityMapper {
         entity.setBudget(simulation.getEconomics().capexTotal());
         entity.setEstimatedEnergy(
                 simulation.getAnnualGenerationKwh() != null ? simulation.getAnnualGenerationKwh() : 0.0);
-        entity.setCo2Reduction(calculateCo2Reduction(simulation));
         entity.setCreatedBy(simulation.getCreatedBy());
         entity.setCreatedAt(simulation.getCreatedAt());
         entity.setUpdatedAt(simulation.getUpdatedAt());
@@ -104,15 +98,6 @@ final class SimulationRecordEntityMapper {
                 entity.getCreatedBy(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt());
-    }
-
-    private double calculateCo2Reduction(Simulation simulation) {
-        if (simulation.getAnnualGenerationKwh() == null || simulation.getTechnology() == null) {
-            return 0.0;
-        }
-        return technologyLookupPort.findActiveCo2ReductionFactorByEnergyType(simulation.getTechnology().value())
-                .map(factor -> simulation.getAnnualGenerationKwh() * factor)
-                .orElse(0.0);
     }
 
     private SimulationStatus parseStatus(String status) {

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapter.java
@@ -5,7 +5,7 @@ import com.renewsim.backend.simulation_service.shared.application.port.out.Simul
 import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationId;
-import com.renewsim.backend.simulation_service.infrastructure.persistence.entity.SimulationEntity;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
@@ -17,6 +17,7 @@ public class SimulationRecordRepositoryAdapter implements SimulationRecordReposi
 
     private final JpaSimulationRepository repository;
     private final SimulationRecordEntityMapper entityMapper;
+    private final TechnologyLookupPort technologyLookupPort;
 
     @Autowired
     public SimulationRecordRepositoryAdapter(
@@ -24,20 +25,22 @@ public class SimulationRecordRepositoryAdapter implements SimulationRecordReposi
             ObjectMapper objectMapper,
             TechnologyLookupPort technologyLookupPort) {
         this(repository, new SimulationRecordEntityMapper(
-                new SimulationInputSnapshotCodec(objectMapper),
-                technologyLookupPort));
+                new SimulationInputSnapshotCodec(objectMapper)), technologyLookupPort);
     }
 
     SimulationRecordRepositoryAdapter(
             JpaSimulationRepository repository,
-            SimulationRecordEntityMapper entityMapper) {
+            SimulationRecordEntityMapper entityMapper,
+            TechnologyLookupPort technologyLookupPort) {
         this.repository = repository;
         this.entityMapper = entityMapper;
+        this.technologyLookupPort = technologyLookupPort;
     }
 
     @Override
     public Simulation save(Simulation simulation) {
         SimulationEntity entity = entityMapper.toEntity(simulation);
+        entity.setCo2Reduction(resolvePersistedCo2Reduction(simulation));
         SimulationEntity saved = repository.save(entity);
         if (simulation.getId() == null) {
             simulation.assignId(SimulationId.of(saved.getId()));
@@ -66,5 +69,14 @@ public class SimulationRecordRepositoryAdapter implements SimulationRecordReposi
     @Override
     public void deleteAllByCreatedBy(String createdBy) {
         repository.deleteAllByCreatedBy(createdBy);
+    }
+
+    private double resolvePersistedCo2Reduction(Simulation simulation) {
+        if (simulation.getAnnualGenerationKwh() == null || simulation.getTechnology() == null) {
+            return 0.0;
+        }
+        return technologyLookupPort.findActiveCo2ReductionFactorByEnergyType(simulation.getTechnology().value())
+                .map(factor -> simulation.getAnnualGenerationKwh() * factor)
+                .orElse(0.0);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/TechnologyLookupJpaAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/TechnologyLookupJpaAdapter.java
@@ -1,10 +1,8 @@
 package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
 
 import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
-import com.renewsim.backend.technology_service.infrastructure.persistence.entity.TechnologyEntity;
-import com.renewsim.backend.technology_service.infrastructure.persistence.repository.JpaTechnologyRepository;
+import com.renewsim.backend.technology_service.application.port.in.TechnologyCatalogLookupUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -13,35 +11,15 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class TechnologyLookupJpaAdapter implements TechnologyLookupPort {
 
-    private final JpaTechnologyRepository technologyRepository;
+    private final TechnologyCatalogLookupUseCase technologyCatalogLookupUseCase;
 
     @Override
     public boolean existsActiveByEnergyType(String energyType) {
-        TechnologyEntity.EnergyType type = parseEnergyType(energyType);
-        if (type == null) {
-            return false;
-        }
-        return technologyRepository.findByEnergyTypeAndIsActiveTrue(type, PageRequest.of(0, 1)).hasContent();
+        return technologyCatalogLookupUseCase.existsActiveByEnergyType(energyType);
     }
 
     @Override
     public Optional<Double> findActiveCo2ReductionFactorByEnergyType(String energyType) {
-        TechnologyEntity.EnergyType type = parseEnergyType(energyType);
-        if (type == null) {
-            return Optional.empty();
-        }
-        return technologyRepository.findFirstByEnergyTypeAndIsActiveTrueOrderByIdAsc(type)
-                .map(entity -> entity.getCo2ReductionFactor().doubleValue());
-    }
-
-    private TechnologyEntity.EnergyType parseEnergyType(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        try {
-            return TechnologyEntity.EnergyType.valueOf(value.trim().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+        return technologyCatalogLookupUseCase.findActiveCo2ReductionFactorByEnergyType(energyType);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/entity/SimulationEntity.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/entity/SimulationEntity.java
@@ -1,4 +1,4 @@
-package com.renewsim.backend.simulation_service.infrastructure.persistence.entity;
+package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupService.java
@@ -1,0 +1,28 @@
+package com.renewsim.backend.simulation_service.location_lookup.application;
+
+import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupUseCase;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@ConditionalOnBean(LocationLookupProvider.class)
+@RequiredArgsConstructor
+public class LocationLookupService implements LocationLookupUseCase {
+
+    private final LocationLookupProvider locationLookupProvider;
+
+    @Override
+    public ResolvedLocation resolveLocation(double latitude, double longitude) {
+        return locationLookupProvider.resolveLocation(latitude, longitude);
+    }
+
+    @Override
+    public List<ResolvedLocation> searchLocations(String query, int limit) {
+        return locationLookupProvider.searchLocations(query, limit);
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/port/in/LocationLookupUseCase.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/port/in/LocationLookupUseCase.java
@@ -4,7 +4,7 @@ import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
 
 import java.util.List;
 
-public interface LocationLookupPort {
+public interface LocationLookupUseCase {
     ResolvedLocation resolveLocation(double latitude, double longitude);
 
     List<ResolvedLocation> searchLocations(String query, int limit);

--- a/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/port/out/LocationLookupProvider.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/port/out/LocationLookupProvider.java
@@ -1,0 +1,11 @@
+package com.renewsim.backend.simulation_service.location_lookup.application.port.out;
+
+import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
+
+import java.util.List;
+
+public interface LocationLookupProvider {
+    ResolvedLocation resolveLocation(double latitude, double longitude);
+
+    List<ResolvedLocation> searchLocations(String query, int limit);
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/location_lookup/web/SimulationLocationLookupController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/location_lookup/web/SimulationLocationLookupController.java
@@ -2,11 +2,12 @@ package com.renewsim.backend.simulation_service.location_lookup.web;
 
 import com.renewsim.backend.shared.domain.vo.Location;
 import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
-import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupPort;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupUseCase;
 import com.renewsim.backend.simulation_service.location_lookup.web.dto.ResolvedLocationResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,12 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
+@ConditionalOnBean(LocationLookupUseCase.class)
 @RequestMapping("/api/v1/simulations/locations")
 @RequiredArgsConstructor
 @Tag(name = "Simulation Location Lookup API", description = "Location resolution and search for simulation inputs")
 public class SimulationLocationLookupController {
 
-    private final LocationLookupPort locationLookupPort;
+    private final LocationLookupUseCase locationLookupUseCase;
 
     @Operation(summary = "Resolve location from coordinates")
     @PreAuthorize("hasAuthority('SCOPE_read:simulations') or hasRole('ADMIN')")
@@ -31,7 +33,7 @@ public class SimulationLocationLookupController {
             @RequestParam double lat,
             @RequestParam double lon) {
         new Location(lat, lon);
-        ResolvedLocation resolvedLocation = locationLookupPort.resolveLocation(lat, lon);
+        ResolvedLocation resolvedLocation = locationLookupUseCase.resolveLocation(lat, lon);
 
         return ResponseEntity.ok(new ResolvedLocationResponseDTO(
                 resolvedLocation.name(),
@@ -53,7 +55,7 @@ public class SimulationLocationLookupController {
 
         int safeLimit = Math.min(Math.max(limit, 1), 10);
 
-        List<ResolvedLocationResponseDTO> results = locationLookupPort.searchLocations(query, safeLimit)
+        List<ResolvedLocationResponseDTO> results = locationLookupUseCase.searchLocations(query, safeLimit)
                 .stream()
                 .map(location -> new ResolvedLocationResponseDTO(
                         location.name(),

--- a/src/main/java/com/renewsim/backend/technology_service/application/port/in/TechnologyCatalogLookupUseCase.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/port/in/TechnologyCatalogLookupUseCase.java
@@ -1,0 +1,12 @@
+package com.renewsim.backend.technology_service.application.port.in;
+
+import java.util.Optional;
+
+public interface TechnologyCatalogLookupUseCase {
+
+    boolean existsActiveTechnology(Long technologyId);
+
+    boolean existsActiveByEnergyType(String energyType);
+
+    Optional<Double> findActiveCo2ReductionFactorByEnergyType(String energyType);
+}

--- a/src/main/java/com/renewsim/backend/technology_service/application/port/out/TechnologyRepositoryPort.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/port/out/TechnologyRepositoryPort.java
@@ -26,6 +26,8 @@ public interface TechnologyRepositoryPort {
 
     Page<Technology> findActiveByEnergyType(EnergyType energyType, Pageable pageable);
 
+    Optional<Technology> findFirstActiveByEnergyType(EnergyType energyType);
+
     Page<Technology> findAllActive(Pageable pageable);
 
     Page<Technology> findAllActiveByNameContaining(String name, Pageable pageable);

--- a/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupService.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupService.java
@@ -1,0 +1,53 @@
+package com.renewsim.backend.technology_service.application.service;
+
+import com.renewsim.backend.technology_service.application.port.in.TechnologyCatalogLookupUseCase;
+import com.renewsim.backend.technology_service.application.port.out.TechnologyRepositoryPort;
+import com.renewsim.backend.technology_service.domain.model.vo.EnergyType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TechnologyCatalogLookupService implements TechnologyCatalogLookupUseCase {
+
+    private final TechnologyRepositoryPort technologyRepository;
+
+    @Override
+    public boolean existsActiveTechnology(Long technologyId) {
+        return technologyRepository.findActiveById(technologyId).isPresent();
+    }
+
+    @Override
+    public boolean existsActiveByEnergyType(String energyType) {
+        EnergyType parsed = parseEnergyType(energyType);
+        if (parsed == null) {
+            return false;
+        }
+        return technologyRepository.findFirstActiveByEnergyType(parsed).isPresent();
+    }
+
+    @Override
+    public Optional<Double> findActiveCo2ReductionFactorByEnergyType(String energyType) {
+        EnergyType parsed = parseEnergyType(energyType);
+        if (parsed == null) {
+            return Optional.empty();
+        }
+        return technologyRepository.findFirstActiveByEnergyType(parsed)
+                .map(technology -> technology.getCo2Reduction().value().doubleValue());
+    }
+
+    private EnergyType parseEnergyType(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return EnergyType.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/renewsim/backend/technology_service/infrastructure/persistence/adapter/TechnologyRepositoryAdapter.java
+++ b/src/main/java/com/renewsim/backend/technology_service/infrastructure/persistence/adapter/TechnologyRepositoryAdapter.java
@@ -72,6 +72,12 @@ public class TechnologyRepositoryAdapter implements TechnologyRepositoryPort {
     }
 
     @Override
+    public Optional<Technology> findFirstActiveByEnergyType(EnergyType energyType) {
+        return jpaRepository.findFirstByEnergyTypeAndIsActiveTrueOrderByIdAsc(toEntityEnergyType(energyType))
+                .map(mapper::toDomain);
+    }
+
+    @Override
     public Page<Technology> findAllActive(Pageable pageable) {
         return jpaRepository.findByIsActiveTrue(pageable).map(mapper::toDomain);
     }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapterTest.java
@@ -17,26 +17,51 @@ import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServ
 class OpenWeatherMapAdapterTest {
 
     @Test
-    @DisplayName("searchLocations maps upstream results into resolved locations")
-    void searchLocationsMapsResolvedLocations() {
+    @DisplayName("searchLocations keeps only supported Spain results")
+    void searchLocationsKeepsOnlySupportedSpainResults() {
         RestTemplate restTemplate = new RestTemplate();
         MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
         OpenWeatherMapAdapter adapter = new OpenWeatherMapAdapter(
                 new WeatherServiceProperties("https://api.openweathermap.org", "test-key", null, null),
                 restTemplate);
 
-        server.expect(requestTo("https://api.openweathermap.org/geo/1.0/direct?q=mendoza&limit=5&appid=test-key"))
+        server.expect(requestTo("https://api.openweathermap.org/geo/1.0/direct?q=mendoza&limit=25&appid=test-key"))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess(
-                        "[{\"name\":\"Mendoza\",\"state\":\"Mendoza\",\"country\":\"AR\",\"lat\":-32.8895,\"lon\":-68.8458}]",
+                        "[{\"name\":\"Mendoza\",\"state\":\"Mendoza\",\"country\":\"AR\",\"lat\":-32.8895,\"lon\":-68.8458},{\"name\":\"Sevilla\",\"state\":\"Andalucia\",\"country\":\"ES\",\"lat\":37.3891,\"lon\":-5.9845}]",
                         MediaType.APPLICATION_JSON));
 
         var results = adapter.searchLocations("mendoza", 5);
 
         assertThat(results).hasSize(1);
-        assertThat(results.getFirst().name()).isEqualTo("Mendoza, Mendoza");
-        assertThat(results.getFirst().country()).isEqualTo("AR");
-        assertThat(results.getFirst().latitude()).isEqualTo(-32.8895);
+        assertThat(results.getFirst().name()).isEqualTo("Sevilla, Andalucia");
+        assertThat(results.getFirst().country()).isEqualTo("ES");
+        assertThat(results.getFirst().latitude()).isEqualTo(37.3891);
         server.verify();
+    }
+
+    @Test
+    @DisplayName("searchLocations returns empty list on provider failure when api key is missing")
+    void searchLocationsReturnsEmptyListOnProviderFailureWhenApiKeyIsMissing() {
+        OpenWeatherMapAdapter adapter = new OpenWeatherMapAdapter(
+                new WeatherServiceProperties("not-a-valid-url", null, null, null),
+                new RestTemplate());
+
+        var results = adapter.searchLocations("sevilla", 5);
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("resolveLocation returns unknown on provider failure when api key is missing")
+    void resolveLocationReturnsUnknownOnProviderFailureWhenApiKeyIsMissing() {
+        OpenWeatherMapAdapter adapter = new OpenWeatherMapAdapter(
+                new WeatherServiceProperties("not-a-valid-url", null, null, null),
+                new RestTemplate());
+
+        var result = adapter.resolveLocation(37.3891, -5.9845);
+
+        assertThat(result.name()).isEqualTo("37.3891, -5.9845");
+        assertThat(result.country()).isEqualTo("Unknown");
     }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodecTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodecTest.java
@@ -2,7 +2,7 @@ package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persi
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.SimulationInputSnapshotCodec.SimulationInputData;
-import com.renewsim.backend.simulation_service.infrastructure.persistence.entity.SimulationEntity;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodecTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodecTest.java
@@ -59,8 +59,8 @@ class SimulationInputSnapshotCodecTest {
   }
 
   @Test
-  @DisplayName("readNormalized preserves complete snapshot data")
-  void readNormalizedPreservesCompleteSnapshotData() {
+  @DisplayName("readNormalized falls back unsupported country codes to Spain")
+  void readNormalizedFallsBackUnsupportedCountryCodesToSpain() {
     SimulationEntity entity = new SimulationEntity();
     entity.setLocation("Cordoba, Andalucia, ES");
     entity.setEstimatedEnergy(1000.0);
@@ -88,8 +88,8 @@ class SimulationInputSnapshotCodecTest {
         }
         """, entity);
 
-    assertThat(normalized.locationCountry()).isEqualTo("Argentina");
-    assertThat(normalized.locationCountryCode()).isEqualTo("AR");
+    assertThat(normalized.locationCountry()).isEqualTo("Spain");
+    assertThat(normalized.locationCountryCode()).isEqualTo("ES");
     assertThat(normalized.monthlyConsumptionKwh())
         .isEqualTo(List.of(1000d, 1000d, 1000d, 1000d, 1000d, 1000d, 1000d, 1000d, 1000d, 1000d, 1000d, 1000d));
     assertThat(normalized.currency()).isEqualTo("USD");

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapperTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapperTest.java
@@ -1,7 +1,6 @@
 package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationStatus;
 import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
@@ -12,37 +11,23 @@ import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomi
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
-import com.renewsim.backend.simulation_service.infrastructure.persistence.entity.SimulationEntity;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SimulationRecordEntityMapperTest {
 
-    private final TechnologyLookupPort technologyLookupPort = new TechnologyLookupPort() {
-        @Override
-        public boolean existsActiveByEnergyType(String energyType) {
-            return true;
-        }
-
-        @Override
-        public Optional<Double> findActiveCo2ReductionFactorByEnergyType(String energyType) {
-            return Optional.of(0.45);
-        }
-    };
-
     private final SimulationRecordEntityMapper mapper = new SimulationRecordEntityMapper(
-            new SimulationInputSnapshotCodec(new ObjectMapper().findAndRegisterModules()),
-            technologyLookupPort);
+            new SimulationInputSnapshotCodec(new ObjectMapper().findAndRegisterModules()));
 
     @Test
-    @DisplayName("toEntity persists aggregate values and computed co2 reduction")
-    void toEntityPersistsAggregateValuesAndComputedCo2Reduction() {
+    @DisplayName("toEntity persists aggregate values without recomputing co2 reduction")
+    void toEntityPersistsAggregateValuesWithoutRecomputingCo2Reduction() {
         Simulation simulation = completedSimulation();
 
         SimulationEntity entity = mapper.toEntity(simulation);
@@ -50,7 +35,7 @@ class SimulationRecordEntityMapperTest {
         assertThat(entity.getId()).isEqualTo(55L);
         assertThat(entity.getEnergyType()).isEqualTo("solar");
         assertThat(entity.getEstimatedEnergy()).isEqualTo(457200.0);
-        assertThat(entity.getCo2Reduction()).isEqualTo(205740.0);
+        assertThat(entity.getCo2Reduction()).isNull();
         assertThat(entity.getStatus()).isEqualTo("COMPLETED");
         assertThat(entity.getInputSnapshot()).contains("\"locationCountry\":\"Spain\"");
     }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapterTest.java
@@ -1,5 +1,6 @@
 package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
 
+import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationStatus;
 import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
@@ -10,7 +11,7 @@ import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomi
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
-import com.renewsim.backend.simulation_service.infrastructure.persistence.entity.SimulationEntity;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +35,9 @@ class SimulationRecordRepositoryAdapterTest {
     @Mock
     private SimulationRecordEntityMapper entityMapper;
 
+    @Mock
+    private TechnologyLookupPort technologyLookupPort;
+
     @Test
     @DisplayName("save assigns generated id back to new simulation")
     void saveAssignsGeneratedIdBackToNewSimulation() {
@@ -45,7 +49,7 @@ class SimulationRecordRepositoryAdapterTest {
         when(entityMapper.toEntity(simulation)).thenReturn(entity);
         when(repository.save(entity)).thenReturn(saved);
 
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper);
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
         Simulation result = adapter.save(simulation);
 
         assertThat(result.getId().value()).isEqualTo(55L);
@@ -61,7 +65,7 @@ class SimulationRecordRepositoryAdapterTest {
         when(repository.findById(88L)).thenReturn(Optional.of(entity));
         when(entityMapper.toDomain(entity)).thenReturn(simulation);
 
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper);
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
         Optional<Simulation> result = adapter.findById(88L);
 
         assertThat(result).contains(simulation);
@@ -80,7 +84,7 @@ class SimulationRecordRepositoryAdapterTest {
         when(entityMapper.toDomain(first)).thenReturn(firstSimulation);
         when(entityMapper.toDomain(second)).thenReturn(secondSimulation);
 
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper);
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
         List<Simulation> result = adapter.findByCreatedByOrderByCreatedAtDesc("alice");
 
         assertThat(result).containsExactly(firstSimulation, secondSimulation);
@@ -92,13 +96,30 @@ class SimulationRecordRepositoryAdapterTest {
     @Test
     @DisplayName("delete methods delegate directly to repository")
     void deleteMethodsDelegateDirectlyToRepository() {
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper);
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
 
         adapter.deleteById(55L);
         adapter.deleteAllByCreatedBy("alice");
 
         verify(repository).deleteById(55L);
         verify(repository).deleteAllByCreatedBy("alice");
+    }
+
+    @Test
+    @DisplayName("save writes derived co2 reduction for completed simulations")
+    void saveWritesDerivedCo2ReductionForCompletedSimulations() {
+        Simulation simulation = existingSimulation(55L);
+        SimulationEntity entity = new SimulationEntity();
+        SimulationEntity saved = new SimulationEntity();
+        saved.setId(55L);
+        when(entityMapper.toEntity(simulation)).thenReturn(entity);
+        when(technologyLookupPort.findActiveCo2ReductionFactorByEnergyType("solar")).thenReturn(Optional.of(0.45));
+        when(repository.save(entity)).thenReturn(saved);
+
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
+        adapter.save(simulation);
+
+        assertThat(entity.getCo2Reduction()).isEqualTo(205740.0);
     }
 
     private Simulation draftSimulation() {

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/config/ClimateProviderWiringTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/config/ClimateProviderWiringTest.java
@@ -1,7 +1,8 @@
 package com.renewsim.backend.simulation_service.infrastructure.config;
 
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.external.OpenWeatherMapAdapter;
-import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupPort;
+import com.renewsim.backend.simulation_service.location_lookup.application.LocationLookupService;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +18,7 @@ class ClimateProviderWiringTest {
             .withConfiguration(AutoConfigurations.of(
                     RestTemplateAutoConfiguration.class,
                     OpenWeatherClientConfig.class,
+                    LocationLookupService.class,
                     OpenWeatherMapAdapter.class));
 
     @Test
@@ -24,7 +26,7 @@ class ClimateProviderWiringTest {
     void missingProviderDoesNotInstantiateLocationLookupProvider() {
         contextRunner
                 .run(context -> {
-                    assertThat(context).doesNotHaveBean(LocationLookupPort.class);
+                    assertThat(context).doesNotHaveBean(LocationLookupProvider.class);
                     assertThat(context).doesNotHaveBean(OpenWeatherMapAdapter.class);
                 });
     }
@@ -39,8 +41,9 @@ class ClimateProviderWiringTest {
                         "services.weather.url=https://api.openweathermap.org",
                         "services.weather.key=test-key")
                 .run(context -> {
-                    assertThat(context).hasSingleBean(LocationLookupPort.class);
-                    assertThat(context.getBean(LocationLookupPort.class)).isInstanceOf(OpenWeatherMapAdapter.class);
+                    assertThat(context).hasSingleBean(LocationLookupProvider.class);
+                    assertThat(context.getBean(LocationLookupProvider.class)).isInstanceOf(OpenWeatherMapAdapter.class);
+                    assertThat(context).hasSingleBean(LocationLookupService.class);
                     assertThat(context).hasBean("openWeatherRestTemplate");
                     assertThat(context.getBean("openWeatherRestTemplate", RestTemplate.class)).isNotNull();
                 });

--- a/src/test/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupServiceTest.java
@@ -1,0 +1,50 @@
+package com.renewsim.backend.simulation_service.location_lookup.application;
+
+import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LocationLookupServiceTest {
+
+    @Mock
+    private LocationLookupProvider locationLookupProvider;
+
+    @InjectMocks
+    private LocationLookupService service;
+
+    @Test
+    @DisplayName("resolveLocation delegates to provider")
+    void resolveLocationDelegatesToProvider() {
+        ResolvedLocation expected = new ResolvedLocation("Mendoza", "AR", -32.8895, -68.8458);
+        when(locationLookupProvider.resolveLocation(-32.8895, -68.8458)).thenReturn(expected);
+
+        ResolvedLocation result = service.resolveLocation(-32.8895, -68.8458);
+
+        assertThat(result).isEqualTo(expected);
+        verify(locationLookupProvider).resolveLocation(-32.8895, -68.8458);
+    }
+
+    @Test
+    @DisplayName("searchLocations delegates to provider")
+    void searchLocationsDelegatesToProvider() {
+        List<ResolvedLocation> expected = List.of(new ResolvedLocation("Mendoza", "AR", -32.8895, -68.8458));
+        when(locationLookupProvider.searchLocations("mendoza", 5)).thenReturn(expected);
+
+        List<ResolvedLocation> result = service.searchLocations("mendoza", 5);
+
+        assertThat(result).containsExactlyElementsOf(expected);
+        verify(locationLookupProvider).searchLocations("mendoza", 5);
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupServiceTest.java
@@ -27,7 +27,7 @@ class LocationLookupServiceTest {
     @Test
     @DisplayName("resolveLocation delegates to provider")
     void resolveLocationDelegatesToProvider() {
-        ResolvedLocation expected = new ResolvedLocation("Mendoza", "AR", -32.8895, -68.8458);
+        ResolvedLocation expected = new ResolvedLocation("Sevilla", "ES", 37.3891, -5.9845);
         when(locationLookupProvider.resolveLocation(-32.8895, -68.8458)).thenReturn(expected);
 
         ResolvedLocation result = service.resolveLocation(-32.8895, -68.8458);
@@ -39,7 +39,7 @@ class LocationLookupServiceTest {
     @Test
     @DisplayName("searchLocations delegates to provider")
     void searchLocationsDelegatesToProvider() {
-        List<ResolvedLocation> expected = List.of(new ResolvedLocation("Mendoza", "AR", -32.8895, -68.8458));
+        List<ResolvedLocation> expected = List.of(new ResolvedLocation("Sevilla", "ES", 37.3891, -5.9845));
         when(locationLookupProvider.searchLocations("mendoza", 5)).thenReturn(expected);
 
         List<ResolvedLocation> result = service.searchLocations("mendoza", 5);

--- a/src/test/java/com/renewsim/backend/simulation_service/location_lookup/web/SimulationLocationLookupControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/location_lookup/web/SimulationLocationLookupControllerTest.java
@@ -1,7 +1,7 @@
 package com.renewsim.backend.simulation_service.location_lookup.web;
 
 import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
-import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupPort;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupUseCase;
 import com.renewsim.backend.simulation_service.location_lookup.web.dto.ResolvedLocationResponseDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.when;
 class SimulationLocationLookupControllerTest {
 
     @Mock
-    private LocationLookupPort locationLookupPort;
+    private LocationLookupUseCase locationLookupUseCase;
 
     @InjectMocks
     private SimulationLocationLookupController controller;
@@ -27,7 +27,7 @@ class SimulationLocationLookupControllerTest {
     @Test
     @DisplayName("reverseGeocode returns resolved location from coordinates")
     void reverseGeocodeReturnsResolvedLocation() {
-        when(locationLookupPort.resolveLocation(-32.8895, -68.8458))
+        when(locationLookupUseCase.resolveLocation(-32.8895, -68.8458))
                 .thenReturn(new ResolvedLocation("Mendoza", "AR", -32.8895, -68.8458));
 
         ResolvedLocationResponseDTO response = controller.reverseGeocode(-32.8895, -68.8458).getBody();
@@ -39,7 +39,7 @@ class SimulationLocationLookupControllerTest {
     @Test
     @DisplayName("searchLocations returns mapped lookup results")
     void searchLocationsReturnsMappedLookupResults() {
-        when(locationLookupPort.searchLocations("mendoza", 5))
+        when(locationLookupUseCase.searchLocations("mendoza", 5))
                 .thenReturn(List.of(new ResolvedLocation("Mendoza", "AR", -32.8895, -68.8458)));
 
         List<ResolvedLocationResponseDTO> response = controller.searchLocations("mendoza", 5).getBody();

--- a/src/test/java/com/renewsim/backend/simulation_service/location_lookup/web/SimulationLocationLookupControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/location_lookup/web/SimulationLocationLookupControllerTest.java
@@ -28,24 +28,24 @@ class SimulationLocationLookupControllerTest {
     @DisplayName("reverseGeocode returns resolved location from coordinates")
     void reverseGeocodeReturnsResolvedLocation() {
         when(locationLookupUseCase.resolveLocation(-32.8895, -68.8458))
-                .thenReturn(new ResolvedLocation("Mendoza", "AR", -32.8895, -68.8458));
+                .thenReturn(new ResolvedLocation("Sevilla", "ES", 37.3891, -5.9845));
 
         ResolvedLocationResponseDTO response = controller.reverseGeocode(-32.8895, -68.8458).getBody();
 
         assertThat(response).isNotNull();
-        assertThat(response.name()).isEqualTo("Mendoza");
+        assertThat(response.name()).isEqualTo("Sevilla");
     }
 
     @Test
     @DisplayName("searchLocations returns mapped lookup results")
     void searchLocationsReturnsMappedLookupResults() {
         when(locationLookupUseCase.searchLocations("mendoza", 5))
-                .thenReturn(List.of(new ResolvedLocation("Mendoza", "AR", -32.8895, -68.8458)));
+                .thenReturn(List.of(new ResolvedLocation("Sevilla", "ES", 37.3891, -5.9845)));
 
         List<ResolvedLocationResponseDTO> response = controller.searchLocations("mendoza", 5).getBody();
 
         assertThat(response).isNotNull();
         assertThat(response).hasSize(1);
-        assertThat(response.getFirst().name()).isEqualTo("Mendoza");
+        assertThat(response.getFirst().name()).isEqualTo("Sevilla");
     }
 }

--- a/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyApplicationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyApplicationServiceTest.java
@@ -1,7 +1,12 @@
 package com.renewsim.backend.technology_service.application.service;
 
-import com.renewsim.backend.technology_service.application.command.*;
-import com.renewsim.backend.technology_service.application.result.*;
+import com.renewsim.backend.technology_service.application.command.CreateTechnologyCommand;
+import com.renewsim.backend.technology_service.application.command.DeleteTechnologyCommand;
+import com.renewsim.backend.technology_service.application.command.GetTechnologyByIdCommand;
+import com.renewsim.backend.technology_service.application.command.UpdateTechnologyCommand;
+import com.renewsim.backend.technology_service.application.result.TechnologyCreationResultDTO;
+import com.renewsim.backend.technology_service.application.result.TechnologyResponseDTO;
+import com.renewsim.backend.technology_service.application.result.TechnologyUpdateResultDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupServiceTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupServiceTest.java
@@ -1,0 +1,74 @@
+package com.renewsim.backend.technology_service.application.service;
+
+import com.renewsim.backend.technology_service.application.port.out.TechnologyRepositoryPort;
+import com.renewsim.backend.technology_service.domain.factory.TechnologyFactory;
+import com.renewsim.backend.technology_service.domain.model.Technology;
+import com.renewsim.backend.technology_service.domain.model.vo.EnergyType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TechnologyCatalogLookupServiceTest {
+
+    @Mock
+    private TechnologyRepositoryPort technologyRepository;
+
+    @InjectMocks
+    private TechnologyCatalogLookupService service;
+
+    @Test
+    @DisplayName("existsActiveTechnology delegates to active-id lookup")
+    void existsActiveTechnologyDelegatesToActiveIdLookup() {
+        when(technologyRepository.findActiveById(5L)).thenReturn(Optional.of(activeSolarTechnology()));
+
+        boolean result = service.existsActiveTechnology(5L);
+
+        assertThat(result).isTrue();
+        verify(technologyRepository).findActiveById(5L);
+    }
+
+    @Test
+    @DisplayName("existsActiveByEnergyType returns false for invalid values")
+    void existsActiveByEnergyTypeReturnsFalseForInvalidValues() {
+        boolean result = service.existsActiveByEnergyType("unknown");
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("findActiveCo2ReductionFactorByEnergyType returns first active factor")
+    void findActiveCo2ReductionFactorByEnergyTypeReturnsFirstActiveFactor() {
+        when(technologyRepository.findFirstActiveByEnergyType(EnergyType.SOLAR))
+                .thenReturn(Optional.of(activeSolarTechnology()));
+
+        Optional<Double> result = service.findActiveCo2ReductionFactorByEnergyType("solar");
+
+        assertThat(result).contains(0.45);
+    }
+
+    @Test
+    @DisplayName("existsActiveByEnergyType delegates to deterministic first-active lookup")
+    void existsActiveByEnergyTypeDelegatesToDeterministicFirstActiveLookup() {
+        when(technologyRepository.findFirstActiveByEnergyType(EnergyType.SOLAR))
+                .thenReturn(Optional.of(activeSolarTechnology()));
+
+        boolean result = service.existsActiveByEnergyType("solar");
+
+        assertThat(result).isTrue();
+        verify(technologyRepository).findFirstActiveByEnergyType(EnergyType.SOLAR);
+    }
+
+    private Technology activeSolarTechnology() {
+        return TechnologyFactory.create("Solar Utility", 20.0, 1200.0, 2.5, 10.0, 0.45, 25.0, "solar");
+    }
+}

--- a/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCommandServiceTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCommandServiceTest.java
@@ -1,8 +1,13 @@
 package com.renewsim.backend.technology_service.application.service;
 
-import com.renewsim.backend.technology_service.application.command.*;
+import com.renewsim.backend.technology_service.application.command.CreateTechnologyCommand;
+import com.renewsim.backend.technology_service.application.command.DeleteTechnologyCommand;
+import com.renewsim.backend.technology_service.application.command.GetTechnologyByIdCommand;
+import com.renewsim.backend.technology_service.application.command.UpdateTechnologyCommand;
 import com.renewsim.backend.technology_service.application.port.out.TechnologyRepositoryPort;
-import com.renewsim.backend.technology_service.application.result.*;
+import com.renewsim.backend.technology_service.application.result.TechnologyCreationResultDTO;
+import com.renewsim.backend.technology_service.application.result.TechnologyResponseDTO;
+import com.renewsim.backend.technology_service.application.result.TechnologyUpdateResultDTO;
 import com.renewsim.backend.technology_service.domain.model.Technology;
 import com.renewsim.backend.technology_service.domain.model.vo.*;
 import com.renewsim.backend.technology_service.application.mapper.TechnologyDtoMapper;


### PR DESCRIPTION
Closes #174

## What changed

- Relocated `SimulationEntity` into `simulation_service.infrastructure.adapter.out.persistence.entity`
- Kept simulation persistence responsibilities inside `SimulationRecordRepositoryAdapter` while leaving `SimulationRecordEntityMapper` focused on aggregate/entity translation
- Preserved the required persisted `co2_reduction` value during simulation writes
- Split simulation location lookup into explicit `LocationLookupUseCase` and `LocationLookupProvider` contracts
- Added `LocationLookupService` so the web layer depends on an inbound use case instead of the external adapter contract
- Updated `OpenWeatherMapAdapter` to implement the outbound provider contract
- Published `TechnologyCatalogLookupUseCase` from `technology_service` for bounded-context consumers
- Refactored `simulation_service` and `scenario_service` technology lookup adapters to stop importing `JpaTechnologyRepository` and `TechnologyEntity`
- Hardened historical snapshot normalization for unsupported country codes
- Constrained location lookup results to supported countries only
- Hardened provider failure logging so it no longer exposes raw `appid`, raw query text, or raw coordinates from provider error messages
- Added and updated focused tests for persistence, location lookup wiring, external adapter behavior, and technology catalog lookup behavior

## Included in this phase

- Infrastructure boundary alignment for `simulation_service`
- Cross-context lookup cleanup with `technology_service`
- Supported-country enforcement for simulation location flows
- Focused regression coverage for the affected slices

## Why

After the earlier simulation refactor phases, the package structure was clearer, but phase 6 still had real infrastructure drift:

- persistence entity placement did not match the `adapter/out` direction
- persistence mapping still carried derived write concerns
- location lookup modeled an external provider as an inbound contract
- cross-context consumers depended on `technology_service` JPA internals
- location lookup could return values incompatible with the simulation domain and degrade poorly on provider failures

This PR finishes that boundary cleanup so the module is not only better organized physically, but also more consistent in how responsibilities flow across domain, application, infrastructure, and external integrations.

## Benefits

- Makes `simulation_service` persistence boundaries clearer and easier to reason about
- Keeps cross-context lookup behavior behind a published application contract instead of JPA internals
- Prevents create/read flows from breaking on unsupported country lookup data
- Reduces sensitive data exposure in provider failure logs
- Improves testability of persistence, lookup wiring, and integration boundary behavior

## Not included

- No API payload redesign
- No new simulation feature behavior
- No broad controller/web refactor outside location lookup wiring
- No database schema migration work
- No full historical CO2 snapshot redesign

## Validation

```bash
mvn -DskipTests compile
mvn "-Dtest=SimulationRecordEntityMapperTest,SimulationRecordRepositoryAdapterTest,TechnologyCatalogLookupServiceTest,RealSimulationServiceTest,PortfolioDashboardAggregatorTest,ScenarioApplicationServiceTest,TechnologyApplicationServiceTest,TechnologyCommandServiceTest" test
mvn "-Dtest=OpenWeatherMapAdapterTest,SimulationInputSnapshotCodecTest,LocationLookupServiceTest,SimulationLocationLookupControllerTest,ClimateProviderWiringTest,SimulationRecordRepositoryAdapterTest,SimulationRecordEntityMapperTest,TechnologyCatalogLookupServiceTest,RealSimulationServiceTest,ScenarioApplicationServiceTest,TechnologyApplicationServiceTest,TechnologyCommandServiceTest,PortfolioDashboardAggregatorTest" test
```

## Notes for reviewers

This work is intentionally split into four reviewable commits:

- `refactor(simulation): align persistence boundaries in phase 6`
- `refactor(simulation): split location lookup use case from provider`
- `refactor(technology): publish catalog lookup for bounded contexts`
- `fix(simulation): constrain location lookup to supported countries`

The main review question is whether the infrastructure responsibilities now live at the right boundaries, not whether the feature behavior changed.
