### PR TITLE
refactor(simulation): simplify snapshot persistence contract

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java
@@ -41,8 +41,6 @@ final class SimulationRecordEntityMapper {
         entity.setUpdatedAt(simulation.getUpdatedAt());
         entity.setStatus(
                 simulation.getStatus() != null ? simulation.getStatus().name() : SimulationStatus.DRAFT.name());
-        entity.setModelVersion("solar-spain-v1");
-        entity.setResourceSource("PVGIS");
         entity.setAnnualSavings(simulation.getAnnualSavings());
         entity.setNpv(simulation.getNpv());
         entity.setIrrPct(simulation.getIrrPct());

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapter.java
@@ -2,7 +2,6 @@ package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persi
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationRecordRepositoryPort;
-import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationId;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
@@ -17,30 +16,25 @@ public class SimulationRecordRepositoryAdapter implements SimulationRecordReposi
 
     private final JpaSimulationRepository repository;
     private final SimulationRecordEntityMapper entityMapper;
-    private final TechnologyLookupPort technologyLookupPort;
 
     @Autowired
     public SimulationRecordRepositoryAdapter(
             JpaSimulationRepository repository,
-            ObjectMapper objectMapper,
-            TechnologyLookupPort technologyLookupPort) {
+            ObjectMapper objectMapper) {
         this(repository, new SimulationRecordEntityMapper(
-                new SimulationInputSnapshotCodec(objectMapper)), technologyLookupPort);
+                new SimulationInputSnapshotCodec(objectMapper)));
     }
 
     SimulationRecordRepositoryAdapter(
             JpaSimulationRepository repository,
-            SimulationRecordEntityMapper entityMapper,
-            TechnologyLookupPort technologyLookupPort) {
+            SimulationRecordEntityMapper entityMapper) {
         this.repository = repository;
         this.entityMapper = entityMapper;
-        this.technologyLookupPort = technologyLookupPort;
     }
 
     @Override
     public Simulation save(Simulation simulation) {
         SimulationEntity entity = entityMapper.toEntity(simulation);
-        entity.setCo2Reduction(resolvePersistedCo2Reduction(simulation));
         SimulationEntity saved = repository.save(entity);
         if (simulation.getId() == null) {
             simulation.assignId(SimulationId.of(saved.getId()));
@@ -69,14 +63,5 @@ public class SimulationRecordRepositoryAdapter implements SimulationRecordReposi
     @Override
     public void deleteAllByCreatedBy(String createdBy) {
         repository.deleteAllByCreatedBy(createdBy);
-    }
-
-    private double resolvePersistedCo2Reduction(Simulation simulation) {
-        if (simulation.getAnnualGenerationKwh() == null || simulation.getTechnology() == null) {
-            return 0.0;
-        }
-        return technologyLookupPort.findActiveCo2ReductionFactorByEnergyType(simulation.getTechnology().value())
-                .map(factor -> simulation.getAnnualGenerationKwh() * factor)
-                .orElse(0.0);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/entity/SimulationEntity.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/entity/SimulationEntity.java
@@ -61,9 +61,6 @@ public class SimulationEntity {
     @Column(name = "climate_data")
     private String climateData;
 
-    @Column(name = "co2_reduction", nullable = false)
-    private Double co2Reduction;
-
     @Column(name = "created_by", nullable = false)
     private String createdBy;
 
@@ -78,12 +75,6 @@ public class SimulationEntity {
 
     @Column(name = "status")
     private String status;
-
-    @Column(name = "model_version")
-    private String modelVersion;
-
-    @Column(name = "resource_source")
-    private String resourceSource;
 
     @Column(name = "annual_savings")
     private Double annualSavings;

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapperTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapperTest.java
@@ -35,14 +35,13 @@ class SimulationRecordEntityMapperTest {
         assertThat(entity.getId()).isEqualTo(55L);
         assertThat(entity.getEnergyType()).isEqualTo("solar");
         assertThat(entity.getEstimatedEnergy()).isEqualTo(457200.0);
-        assertThat(entity.getCo2Reduction()).isNull();
         assertThat(entity.getStatus()).isEqualTo("COMPLETED");
         assertThat(entity.getInputSnapshot()).contains("\"locationCountry\":\"Spain\"");
     }
 
     @Test
-    @DisplayName("toDomain rebuilds aggregate and defaults invalid status to draft")
-    void toDomainRebuildsAggregateAndDefaultsInvalidStatusToDraft() {
+    @DisplayName("toDomain rebuilds aggregate from a supported persisted contract")
+    void toDomainRebuildsAggregateFromSupportedPersistedContract() {
         SimulationEntity entity = new SimulationEntity();
         entity.setId(88L);
         entity.setName("Solar - Historic");
@@ -56,7 +55,7 @@ class SimulationRecordEntityMapperTest {
         entity.setCreatedBy("alice");
         entity.setCreatedAt(LocalDateTime.parse("2026-06-30T14:00:00"));
         entity.setUpdatedAt(LocalDateTime.parse("2026-06-30T14:30:00"));
-        entity.setStatus("bogus");
+        entity.setStatus("COMPLETED");
         entity.setAnnualSavings(68700.0);
         entity.setNpv(121500.0);
         entity.setIrrPct(11.4);
@@ -88,7 +87,7 @@ class SimulationRecordEntityMapperTest {
         Simulation simulation = mapper.toDomain(entity);
 
         assertThat(simulation.getId().value()).isEqualTo(88L);
-        assertThat(simulation.getStatus()).isEqualTo(SimulationStatus.DRAFT);
+        assertThat(simulation.getStatus()).isEqualTo(SimulationStatus.COMPLETED);
         assertThat(simulation.getLocation().country()).isEqualTo("Spain");
         assertThat(simulation.getDemand().annualConsumptionKwh()).isEqualTo(120000.0);
         assertThat(simulation.getEconomics().capexTotal()).isEqualTo(315000.0);

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapterTest.java
@@ -1,6 +1,5 @@
 package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
 
-import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationStatus;
 import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
@@ -35,9 +34,6 @@ class SimulationRecordRepositoryAdapterTest {
     @Mock
     private SimulationRecordEntityMapper entityMapper;
 
-    @Mock
-    private TechnologyLookupPort technologyLookupPort;
-
     @Test
     @DisplayName("save assigns generated id back to new simulation")
     void saveAssignsGeneratedIdBackToNewSimulation() {
@@ -49,7 +45,7 @@ class SimulationRecordRepositoryAdapterTest {
         when(entityMapper.toEntity(simulation)).thenReturn(entity);
         when(repository.save(entity)).thenReturn(saved);
 
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper);
         Simulation result = adapter.save(simulation);
 
         assertThat(result.getId().value()).isEqualTo(55L);
@@ -65,7 +61,7 @@ class SimulationRecordRepositoryAdapterTest {
         when(repository.findById(88L)).thenReturn(Optional.of(entity));
         when(entityMapper.toDomain(entity)).thenReturn(simulation);
 
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper);
         Optional<Simulation> result = adapter.findById(88L);
 
         assertThat(result).contains(simulation);
@@ -84,7 +80,7 @@ class SimulationRecordRepositoryAdapterTest {
         when(entityMapper.toDomain(first)).thenReturn(firstSimulation);
         when(entityMapper.toDomain(second)).thenReturn(secondSimulation);
 
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper);
         List<Simulation> result = adapter.findByCreatedByOrderByCreatedAtDesc("alice");
 
         assertThat(result).containsExactly(firstSimulation, secondSimulation);
@@ -96,30 +92,13 @@ class SimulationRecordRepositoryAdapterTest {
     @Test
     @DisplayName("delete methods delegate directly to repository")
     void deleteMethodsDelegateDirectlyToRepository() {
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
+        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper);
 
         adapter.deleteById(55L);
         adapter.deleteAllByCreatedBy("alice");
 
         verify(repository).deleteById(55L);
         verify(repository).deleteAllByCreatedBy("alice");
-    }
-
-    @Test
-    @DisplayName("save writes derived co2 reduction for completed simulations")
-    void saveWritesDerivedCo2ReductionForCompletedSimulations() {
-        Simulation simulation = existingSimulation(55L);
-        SimulationEntity entity = new SimulationEntity();
-        SimulationEntity saved = new SimulationEntity();
-        saved.setId(55L);
-        when(entityMapper.toEntity(simulation)).thenReturn(entity);
-        when(technologyLookupPort.findActiveCo2ReductionFactorByEnergyType("solar")).thenReturn(Optional.of(0.45));
-        when(repository.save(entity)).thenReturn(saved);
-
-        SimulationRecordRepositoryAdapter adapter = new SimulationRecordRepositoryAdapter(repository, entityMapper, technologyLookupPort);
-        adapter.save(simulation);
-
-        assertThat(entity.getCo2Reduction()).isEqualTo(205740.0);
     }
 
     private Simulation draftSimulation() {


### PR DESCRIPTION
## What changed
- Makes simulation persistence strict around the supported snapshot contract
- Removes legacy mapper backfills that were masking unsupported persisted state
- Keeps JPA collection persistence safe by handing Hibernate a mutable `technologyIds` list

## Why
Part of #176. This isolates the persistence-contract cleanup before restoring the higher-level phase 7 creation flows.

## Validation
- `mvn -Dtest=SimulationInputSnapshotCodecTest,SimulationRecordEntityMapperTest,SimulationRecordRepositoryAdapterTest test`

## Chain Context
- Strategy: stacked PRs to `dev/v1.2.0`
- Depends on: none
- Current slice: 📍 PR 1 of 5
- Next: `refactor/simulation-phase7-technology-ids`

```text
PR1 refactor/simulation-phase7-persistence-contract 📍
└─ PR2 refactor/simulation-phase7-technology-ids
   └─ PR3 feat/simulation-phase7-scenario-core
      └─ PR4 test/simulation-phase7-scenario-acceptance
         └─ PR5 test/simulation-phase7-scenario-contract
```