### PR TITLE
refactor(simulation): persist recommended technology ids

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
@@ -30,22 +30,31 @@ public class CreateSimulationService implements CreateRealSimulationUseCase {
         SimulationEngine simulationEngine = resolveEngine(command.technology());
         simulationEngine.assertImplemented();
 
-        Simulation simulation = persistDraft(command);
+        List<Long> technologyIds = resolveTechnologyIds(command);
+        Simulation simulation = persistDraft(command, technologyIds);
         SimulationDetailsResult result = simulationEngine.simulate(simulation, command);
-        simulation.complete(completionMapper.toCompletion(result));
+        simulation.complete(completionMapper.toCompletion(result, technologyIds));
         repository.save(simulation);
 
         return result;
     }
 
-    private Simulation persistDraft(CreateRealSimulationCommand command) {
-        return repository.save(SimulationCommandMapper.toNewSimulation(command));
+    private Simulation persistDraft(CreateRealSimulationCommand command, List<Long> technologyIds) {
+        return repository.save(SimulationCommandMapper.toNewSimulation(command, technologyIds));
+    }
+
+    private List<Long> resolveTechnologyIds(CreateRealSimulationCommand command) {
+        if (command.technologyIds() != null && !command.technologyIds().isEmpty()) {
+            return List.copyOf(command.technologyIds());
+        }
+        return technologyLookupPort.recommendActiveTechnologyIdsByEnergyType(command.technology().value());
     }
 
     private void validateTechnology(Technology technology) {
         if (!technologyLookupPort.existsActiveByEnergyType(technology.value())) {
             throw new InvalidSimulationTechnologyException(
-                    "UNSUPPORTED_TECHNOLOGY: '" + technology.value() + "' is not registered or is inactive in the technology catalog");
+                    "UNSUPPORTED_TECHNOLOGY: '" + technology.value()
+                            + "' is not registered or is inactive in the technology catalog");
         }
     }
 

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/SimulationCommandMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/SimulationCommandMapper.java
@@ -3,12 +3,14 @@ package com.renewsim.backend.simulation_service.create.application;
 import com.renewsim.backend.simulation_service.create.application.command.CreateRealSimulationCommand;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 
+import java.util.List;
+
 final class SimulationCommandMapper {
 
     private SimulationCommandMapper() {
     }
 
-    static Simulation toNewSimulation(CreateRealSimulationCommand command) {
+    static Simulation toNewSimulation(CreateRealSimulationCommand command, List<Long> technologyIds) {
         return Simulation.create(
                 command.name(),
                 command.technology(),
@@ -16,6 +18,8 @@ final class SimulationCommandMapper {
                 command.system(),
                 command.demand(),
                 command.economics(),
+                technologyIds,
+                command.scenarioId(),
                 command.createdBy());
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/SimulationCompletionMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/SimulationCompletionMapper.java
@@ -7,20 +7,23 @@ import com.renewsim.backend.simulation_service.domain.model.SimulationCompletion
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class SimulationCompletionMapper {
 
     private final ObjectMapper objectMapper;
 
-    SimulationCompletion toCompletion(SimulationDetailsResult result) {
+    SimulationCompletion toCompletion(SimulationDetailsResult result, List<Long> technologyIds) {
         return new SimulationCompletion(
                 writeJson(result),
                 result.technical().annualGenerationKwh(),
                 result.financial().annualSavings(),
                 result.financial().npv(),
                 result.financial().irrPct(),
-                result.summary().recommendation());
+                result.summary().recommendation(),
+                technologyIds);
     }
 
     private String writeJson(Object value) {

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/command/CreateRealSimulationCommand.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/command/CreateRealSimulationCommand.java
@@ -6,12 +6,16 @@ import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocatio
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 
+import java.util.List;
+
 public record CreateRealSimulationCommand(
-                String name,
-                Technology technology,
-                SimulationLocation location,
-                SimulationSystem system,
-                ConsumptionProfile demand,
-                SimulationEconomics economics,
-                String createdBy) {
+        String name,
+        Technology technology,
+        SimulationLocation location,
+        SimulationSystem system,
+        ConsumptionProfile demand,
+        SimulationEconomics economics,
+        List<Long> technologyIds,
+        Long scenarioId,
+        String createdBy) {
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationWebMapper.java
@@ -11,6 +11,8 @@ import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 import com.renewsim.backend.simulation_service.create.web.dto.CreateSolarSimulationRequestDTO;
 
+import java.util.List;
+
 public final class CreateSimulationWebMapper {
 
     public CreateRealSimulationCommand toCommand(CreateSolarSimulationRequestDTO request, String username) {
@@ -45,6 +47,8 @@ public final class CreateSimulationWebMapper {
                         request.economics().exportPricePerKwh(),
                         request.economics().discountRatePct(),
                         ProjectLifetime.of(request.economics().projectLifetimeYears())),
+                List.of(),
+                null,
                 username);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/model/Simulation.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/model/Simulation.java
@@ -8,6 +8,8 @@ import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulatio
 import com.renewsim.backend.simulation_service.domain.model.vo.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Simulation {
 
@@ -25,6 +27,8 @@ public class Simulation {
     private Double npv;
     private Double irrPct;
     private String recommendation;
+    private List<Long> technologyIds;
+    private Long scenarioId;
     private final String createdBy;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -36,6 +40,7 @@ public class Simulation {
             SimulationStatus status, String resultSnapshot,
             Double annualGenerationKwh, Double annualSavings,
             Double npv, Double irrPct, String recommendation,
+            List<Long> technologyIds, Long scenarioId,
             String createdBy, LocalDateTime createdAt, LocalDateTime updatedAt) {
 
         validateName(name);
@@ -55,6 +60,8 @@ public class Simulation {
         this.npv = npv;
         this.irrPct = irrPct;
         this.recommendation = recommendation;
+        this.technologyIds = technologyIds == null ? new ArrayList<>() : new ArrayList<>(technologyIds);
+        this.scenarioId = scenarioId;
         this.createdBy = createdBy;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -66,12 +73,14 @@ public class Simulation {
             String name, Technology technology,
             SimulationLocation location, SimulationSystem system,
             ConsumptionProfile demand, SimulationEconomics economics,
+            List<Long> technologyIds, Long scenarioId,
             String createdBy) {
         LocalDateTime now = LocalDateTime.now();
         return new Simulation(
                 null, name, technology, location, system, demand, economics,
                 SimulationStatus.DRAFT, null,
                 null, null, null, null, null,
+                technologyIds, scenarioId,
                 createdBy, now, now);
     }
 
@@ -82,11 +91,13 @@ public class Simulation {
             SimulationStatus status, String resultSnapshot,
             Double annualGenerationKwh, Double annualSavings,
             Double npv, Double irrPct, String recommendation,
+            List<Long> technologyIds, Long scenarioId,
             String createdBy, LocalDateTime createdAt, LocalDateTime updatedAt) {
         return new Simulation(
                 id == null ? null : SimulationId.of(id), name, technology, location, system, demand, economics,
                 status, resultSnapshot,
                 annualGenerationKwh, annualSavings, npv, irrPct, recommendation,
+                technologyIds, scenarioId,
                 createdBy, createdAt, updatedAt);
     }
 
@@ -105,6 +116,9 @@ public class Simulation {
         this.npv = completion.npv();
         this.irrPct = completion.irrPct();
         this.recommendation = completion.recommendation();
+        if (completion.technologyIds() != null) {
+            this.technologyIds = new ArrayList<>(completion.technologyIds());
+        }
         this.status = SimulationStatus.COMPLETED;
         this.updatedAt = LocalDateTime.now();
     }
@@ -140,6 +154,14 @@ public class Simulation {
         this.id = id;
     }
 
+    public void assignTechnologyIds(List<Long> technologyIds) {
+        this.technologyIds = technologyIds == null ? new ArrayList<>() : new ArrayList<>(technologyIds);
+    }
+
+    public void assignScenarioId(Long scenarioId) {
+        this.scenarioId = scenarioId;
+    }
+
     // ========== GETTERS ==========
 
     public SimulationId getId() { return id; }
@@ -156,6 +178,8 @@ public class Simulation {
     public Double getNpv() { return npv; }
     public Double getIrrPct() { return irrPct; }
     public String getRecommendation() { return recommendation; }
+    public List<Long> getTechnologyIds() { return List.copyOf(technologyIds); }
+    public Long getScenarioId() { return scenarioId; }
     public String getCreatedBy() { return createdBy; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }

--- a/src/main/java/com/renewsim/backend/simulation_service/domain/model/SimulationCompletion.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/domain/model/SimulationCompletion.java
@@ -2,13 +2,16 @@ package com.renewsim.backend.simulation_service.domain.model;
 
 import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationCompletionException;
 
+import java.util.List;
+
 public record SimulationCompletion(
         String resultSnapshot,
         Double annualGenerationKwh,
         Double annualSavings,
         Double npv,
         Double irrPct,
-        String recommendation) {
+        String recommendation,
+        List<Long> technologyIds) {
 
     public SimulationCompletion {
         if (resultSnapshot == null || resultSnapshot.isBlank()) {

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java
@@ -13,6 +13,8 @@ import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.SimulationInputSnapshotCodec.SimulationInputData;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 
+import java.util.ArrayList;
+
 /**
  * Maps between the simulation aggregate and its persistence entity.
  */
@@ -47,6 +49,7 @@ final class SimulationRecordEntityMapper {
         entity.setRecommendation(simulation.getRecommendation());
         entity.setInputSnapshot(snapshotCodec.write(simulation));
         entity.setResultSnapshot(simulation.getResultSnapshot());
+        entity.setTechnologyIds(new ArrayList<>(simulation.getTechnologyIds()));
         return entity;
     }
 
@@ -93,6 +96,8 @@ final class SimulationRecordEntityMapper {
                 entity.getNpv(),
                 entity.getIrrPct(),
                 entity.getRecommendation(),
+                entity.getTechnologyIds(),
+                null,
                 entity.getCreatedBy(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt());

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/TechnologyLookupJpaAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/TechnologyLookupJpaAdapter.java
@@ -5,6 +5,7 @@ import com.renewsim.backend.technology_service.application.port.in.TechnologyCat
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component("simulationTechnologyLookupAdapter")
@@ -21,5 +22,15 @@ public class TechnologyLookupJpaAdapter implements TechnologyLookupPort {
     @Override
     public Optional<Double> findActiveCo2ReductionFactorByEnergyType(String energyType) {
         return technologyCatalogLookupUseCase.findActiveCo2ReductionFactorByEnergyType(energyType);
+    }
+
+    @Override
+    public List<Long> recommendActiveTechnologyIdsByEnergyType(String energyType) {
+        return technologyCatalogLookupUseCase.recommendActiveTechnologyIdsByEnergyType(energyType);
+    }
+
+    @Override
+    public Optional<String> findActiveEnergyTypeByTechnologyId(Long technologyId) {
+        return technologyCatalogLookupUseCase.findActiveEnergyTypeByTechnologyId(technologyId);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/application/port/out/TechnologyLookupPort.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/application/port/out/TechnologyLookupPort.java
@@ -1,5 +1,6 @@
 package com.renewsim.backend.simulation_service.shared.application.port.out;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TechnologyLookupPort {
@@ -7,4 +8,8 @@ public interface TechnologyLookupPort {
     boolean existsActiveByEnergyType(String energyType);
 
     Optional<Double> findActiveCo2ReductionFactorByEnergyType(String energyType);
+
+    List<Long> recommendActiveTechnologyIdsByEnergyType(String energyType);
+
+    Optional<String> findActiveEnergyTypeByTechnologyId(Long technologyId);
 }

--- a/src/main/java/com/renewsim/backend/technology_service/application/port/in/TechnologyCatalogLookupUseCase.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/port/in/TechnologyCatalogLookupUseCase.java
@@ -1,5 +1,6 @@
 package com.renewsim.backend.technology_service.application.port.in;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TechnologyCatalogLookupUseCase {
@@ -9,4 +10,8 @@ public interface TechnologyCatalogLookupUseCase {
     boolean existsActiveByEnergyType(String energyType);
 
     Optional<Double> findActiveCo2ReductionFactorByEnergyType(String energyType);
+
+    List<Long> recommendActiveTechnologyIdsByEnergyType(String energyType);
+
+    Optional<String> findActiveEnergyTypeByTechnologyId(Long technologyId);
 }

--- a/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupService.java
+++ b/src/main/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupService.java
@@ -4,9 +4,11 @@ import com.renewsim.backend.technology_service.application.port.in.TechnologyCat
 import com.renewsim.backend.technology_service.application.port.out.TechnologyRepositoryPort;
 import com.renewsim.backend.technology_service.domain.model.vo.EnergyType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -38,6 +40,25 @@ public class TechnologyCatalogLookupService implements TechnologyCatalogLookupUs
         }
         return technologyRepository.findFirstActiveByEnergyType(parsed)
                 .map(technology -> technology.getCo2Reduction().value().doubleValue());
+    }
+
+    @Override
+    public List<Long> recommendActiveTechnologyIdsByEnergyType(String energyType) {
+        EnergyType parsed = parseEnergyType(energyType);
+        if (parsed == null) {
+            return List.of();
+        }
+        return technologyRepository.findActiveByEnergyType(parsed, PageRequest.of(0, 100))
+                .getContent()
+                .stream()
+                .map(technology -> technology.getId())
+                .toList();
+    }
+
+    @Override
+    public Optional<String> findActiveEnergyTypeByTechnologyId(Long technologyId) {
+        return technologyRepository.findActiveById(technologyId)
+                .map(technology -> technology.getEnergyType().name().toLowerCase());
     }
 
     private EnergyType parseEnergyType(String value) {

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
@@ -63,6 +63,7 @@ class RealSimulationServiceTest {
                 CreateRealSimulationCommand command = validCommand();
 
                 when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
                 when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
                 when(repository.save(any())).thenAnswer(invocation -> {
                         Simulation sim = invocation.getArgument(0);
@@ -81,6 +82,8 @@ class RealSimulationServiceTest {
                 ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
                 verify(repository, times(2)).save(captor.capture());
                 assertThat(captor.getAllValues().get(1).getResultSnapshot()).isNotBlank();
+                assertThat(captor.getAllValues().get(1).getTechnologyIds()).containsExactly(1L, 2L);
+                verify(technologyLookupPort).recommendActiveTechnologyIdsByEnergyType("solar");
         }
 
         @Test
@@ -99,6 +102,8 @@ class RealSimulationServiceTest {
                                 validCommand().system(),
                                 validCommand().demand(),
                                 validCommand().economics(),
+                                validCommand().technologyIds(),
+                                validCommand().scenarioId(),
                                 validCommand().createdBy());
 
                 when(technologyLookupPort.existsActiveByEnergyType("wind")).thenReturn(true);
@@ -126,16 +131,19 @@ class RealSimulationServiceTest {
         }
 
         @Test
-        @DisplayName("getUserSimulations maps stored summary columns into list projection")
-        void getUserSimulationsMapsStoredSummaryColumns() {
+        @DisplayName("getUserSimulations maps stored summary columns for scenario-created simulations")
+        void getUserSimulationsMapsStoredSummaryColumnsForScenarioCreatedSimulations() {
                 ListSimulationsService service = new ListSimulationsService(repository);
                 Simulation simulation = completedSimulation(55L, "alice", null);
+                simulation.assignScenarioId(42L);
+                simulation.assignTechnologyIds(List.of(11L, 12L));
                 when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(simulation));
 
                 UserSimulationListResult response = service.getUserSimulations("alice");
 
                 assertThat(response.total()).isEqualTo(1);
                 assertThat(response.items().getFirst().annualSavings()).isEqualTo(68700.0);
+                assertThat(response.items().getFirst().technology()).isEqualTo("solar");
         }
 
         @Test
@@ -149,12 +157,16 @@ class RealSimulationServiceTest {
                 Simulation best = completedSimulation(55L, "alice",
                                 new ObjectMapper().writeValueAsString(resultWithMetrics(
                                                 "55", "recommended", 82000, 9100, 6.2, 1820, List.of())));
+                best.assignScenarioId(42L);
+                best.assignTechnologyIds(List.of(11L, 12L));
                 Simulation risky = completedSimulation(56L, "alice",
                                 new ObjectMapper().writeValueAsString(resultWithMetrics(
                                                 "56", "not_recommended", 12000, -5000, 12.4, 980,
                                                 List.of(new SimulationDetailsResult.SimulationWarning("warning",
                                                                 "LOW_AVAILABILITY_ASSUMPTION",
                                                                 "Availability assumption is below 95% and may materially reduce annual output.")))));
+                risky.assignScenarioId(43L);
+                risky.assignTechnologyIds(List.of(12L, 13L));
                 Simulation draft = Simulation.create(
                                 "Solar - Draft",
                                 Technology.solar(),
@@ -167,8 +179,12 @@ class RealSimulationServiceTest {
                                                                 4000d, 4000d, 4000d)),
                                 new SimulationEconomics(Currency.of("EUR"), 110000.0, 3000.0, 0.18, 0.07, 8,
                                                 ProjectLifetime.of(20)),
+                                List.of(),
+                                null,
                                 "alice");
                 draft.assignId(SimulationId.of(57L));
+                draft.assignScenarioId(44L);
+                draft.assignTechnologyIds(List.of(11L));
 
                 when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(best, risky, draft));
                 when(technologyLookupPort.findActiveCo2ReductionFactorByEnergyType("solar"))
@@ -248,6 +264,8 @@ class RealSimulationServiceTest {
                                                                 10000d, 10000d, 10000d, 10000d)),
                                 new SimulationEconomics(Currency.of("EUR"), 315000, 7200, 0.18, 0.07, 8,
                                                 ProjectLifetime.of(20)),
+                                List.of(),
+                                null,
                                 "alice");
         }
 
@@ -275,6 +293,8 @@ class RealSimulationServiceTest {
                                 economics,
                                 SimulationStatus.COMPLETED, resultJson,
                                 457200.0, 68700.0, 121500.0, 11.4, "viable_with_reservations",
+                                List.of(11L, 12L),
+                                null,
                                 owner, LocalDateTime.parse("2026-06-30T14:00:00"),
                                 LocalDateTime.parse("2026-06-30T14:00:00"));
         }

--- a/src/test/java/com/renewsim/backend/simulation_service/domain/model/SimulationTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/domain/model/SimulationTest.java
@@ -32,6 +32,8 @@ class SimulationTest {
                 validSystem(),
                 validDemand(),
                 validEconomics(),
+                List.of(),
+                null,
                 "alice"))
                 .isInstanceOf(InvalidSimulationNameException.class)
                 .hasMessageContaining("name");
@@ -47,6 +49,8 @@ class SimulationTest {
                 validSystem(),
                 validDemand(),
                 validEconomics(),
+                List.of(),
+                null,
                 " "))
                 .isInstanceOf(InvalidSimulationCreatorException.class)
                 .hasMessageContaining("creator");
@@ -72,13 +76,15 @@ class SimulationTest {
                 82000.0,
                 121500.0,
                 14.2,
-                "recommended");
+                "recommended",
+                List.of(21L, 22L));
 
         simulation.complete(completion);
 
         assertThat(simulation.getStatus()).isEqualTo(SimulationStatus.COMPLETED);
         assertThat(simulation.getResultSnapshot()).isEqualTo("{\"result\":true}");
         assertThat(simulation.getRecommendation()).isEqualTo("recommended");
+        assertThat(simulation.getTechnologyIds()).containsExactly(21L, 22L);
         assertThat(simulation.getUpdatedAt()).isAfterOrEqualTo(simulation.getCreatedAt());
     }
 
@@ -94,7 +100,8 @@ class SimulationTest {
                 82000.0,
                 121500.0,
                 14.2,
-                "recommended")))
+                "recommended",
+                List.of(21L, 22L))))
                 .isInstanceOf(InvalidSimulationStatusTransitionException.class)
                 .hasMessageContaining("complete");
     }
@@ -107,6 +114,8 @@ class SimulationTest {
                 validSystem(),
                 validDemand(),
                 validEconomics(),
+                List.of(11L, 12L),
+                null,
                 "alice");
     }
 

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapperTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapperTest.java
@@ -37,6 +37,20 @@ class SimulationRecordEntityMapperTest {
         assertThat(entity.getEstimatedEnergy()).isEqualTo(457200.0);
         assertThat(entity.getStatus()).isEqualTo("COMPLETED");
         assertThat(entity.getInputSnapshot()).contains("\"locationCountry\":\"Spain\"");
+        assertThat(entity.getTechnologyIds()).containsExactly(11L, 12L);
+    }
+
+    @Test
+    @DisplayName("toEntity keeps technologyIds mutable for JPA merge operations")
+    void toEntityKeepsTechnologyIdsMutableForJpaMergeOperations() {
+        Simulation simulation = completedSimulation();
+
+        SimulationEntity entity = mapper.toEntity(simulation);
+
+        entity.getTechnologyIds().clear();
+
+        assertThat(entity.getTechnologyIds()).isEmpty();
+        assertThat(simulation.getTechnologyIds()).containsExactly(11L, 12L);
     }
 
     @Test
@@ -61,6 +75,7 @@ class SimulationRecordEntityMapperTest {
         entity.setIrrPct(11.4);
         entity.setRecommendation("viable_with_reservations");
         entity.setResultSnapshot("{}");
+        entity.setTechnologyIds(List.of(11L, 12L));
         entity.setInputSnapshot("""
                 {
                   "locationCountry": "Spain",
@@ -92,6 +107,7 @@ class SimulationRecordEntityMapperTest {
         assertThat(simulation.getDemand().annualConsumptionKwh()).isEqualTo(120000.0);
         assertThat(simulation.getEconomics().capexTotal()).isEqualTo(315000.0);
         assertThat(simulation.getRecommendation()).isEqualTo("viable_with_reservations");
+        assertThat(simulation.getTechnologyIds()).containsExactly(11L, 12L);
     }
 
     private Simulation completedSimulation() {
@@ -112,6 +128,8 @@ class SimulationRecordEntityMapperTest {
                 121500.0,
                 11.4,
                 "viable_with_reservations",
+                List.of(11L, 12L),
+                null,
                 "alice",
                 LocalDateTime.parse("2026-06-30T14:00:00"),
                 LocalDateTime.parse("2026-06-30T14:30:00"));

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordRepositoryAdapterTest.java
@@ -111,6 +111,8 @@ class SimulationRecordRepositoryAdapterTest {
                         List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
                                 10000d)),
                 new SimulationEconomics(Currency.of("EUR"), 315000.0, 7200.0, 0.18, 0.07, 8, ProjectLifetime.of(20)),
+                List.of(),
+                null,
                 "alice");
     }
 
@@ -132,6 +134,8 @@ class SimulationRecordRepositoryAdapterTest {
                 121500.0,
                 11.4,
                 "viable_with_reservations",
+                List.of(11L, 12L),
+                null,
                 "alice",
                 LocalDateTime.parse("2026-06-30T14:00:00"),
                 LocalDateTime.parse("2026-06-30T14:30:00"));

--- a/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupServiceTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupServiceTest.java
@@ -3,17 +3,29 @@ package com.renewsim.backend.technology_service.application.service;
 import com.renewsim.backend.technology_service.application.port.out.TechnologyRepositoryPort;
 import com.renewsim.backend.technology_service.domain.factory.TechnologyFactory;
 import com.renewsim.backend.technology_service.domain.model.Technology;
+import com.renewsim.backend.technology_service.domain.model.vo.CapacityFactor;
+import com.renewsim.backend.technology_service.domain.model.vo.Co2Reduction;
+import com.renewsim.backend.technology_service.domain.model.vo.Efficiency;
 import com.renewsim.backend.technology_service.domain.model.vo.EnergyType;
+import com.renewsim.backend.technology_service.domain.model.vo.EnvironmentalImpact;
+import com.renewsim.backend.technology_service.domain.model.vo.InstallationCost;
+import com.renewsim.backend.technology_service.domain.model.vo.MaintenanceCost;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -68,7 +80,61 @@ class TechnologyCatalogLookupServiceTest {
         verify(technologyRepository).findFirstActiveByEnergyType(EnergyType.SOLAR);
     }
 
+    @Test
+    @DisplayName("recommendActiveTechnologyIdsByEnergyType returns active technology ids for the energy type")
+    void recommendActiveTechnologyIdsByEnergyTypeReturnsActiveIds() {
+        when(technologyRepository.findActiveByEnergyType(EnergyType.SOLAR, PageRequest.of(0, 100)))
+                .thenReturn(new PageImpl<>(List.of(activeSolarTechnology(), anotherActiveSolarTechnology())));
+
+        List<Long> result = service.recommendActiveTechnologyIdsByEnergyType("solar");
+
+        assertThat(result).containsExactly(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("recommendActiveTechnologyIdsByEnergyType returns empty list for invalid values")
+    void recommendActiveTechnologyIdsByEnergyTypeReturnsEmptyForInvalidValues() {
+        List<Long> result = service.recommendActiveTechnologyIdsByEnergyType("unknown");
+
+        assertThat(result).isEmpty();
+        verify(technologyRepository, never()).findActiveByEnergyType(any(), any());
+    }
+
+    @Test
+    @DisplayName("findActiveEnergyTypeByTechnologyId returns the lowercase energy type for active technologies")
+    void findActiveEnergyTypeByTechnologyIdReturnsTheLowercaseEnergyTypeForActiveTechnologies() {
+        when(technologyRepository.findActiveById(1L)).thenReturn(Optional.of(activeSolarTechnology()));
+
+        Optional<String> result = service.findActiveEnergyTypeByTechnologyId(1L);
+
+        assertThat(result).contains("solar");
+        verify(technologyRepository).findActiveById(1L);
+    }
+
+    @Test
+    @DisplayName("findActiveEnergyTypeByTechnologyId returns empty for unknown technologies")
+    void findActiveEnergyTypeByTechnologyIdReturnsEmptyForUnknownTechnologies() {
+        when(technologyRepository.findActiveById(99L)).thenReturn(Optional.empty());
+
+        Optional<String> result = service.findActiveEnergyTypeByTechnologyId(99L);
+
+        assertThat(result).isEmpty();
+        verify(technologyRepository).findActiveById(99L);
+    }
+
     private Technology activeSolarTechnology() {
-        return TechnologyFactory.create("Solar Utility", 20.0, 1200.0, 2.5, 10.0, 0.45, 25.0, "solar");
+        return new Technology(
+                1L, "Solar Utility", EnergyType.SOLAR,
+                new Efficiency(20.0), new InstallationCost(BigDecimal.valueOf(1200.0)),
+                new MaintenanceCost(BigDecimal.valueOf(2.5)),
+                new EnvironmentalImpact(10.0), new Co2Reduction(0.45), new CapacityFactor(25.0));
+    }
+
+    private Technology anotherActiveSolarTechnology() {
+        return new Technology(
+                2L, "Solar Farm", EnergyType.SOLAR,
+                new Efficiency(22.0), new InstallationCost(BigDecimal.valueOf(1100.0)),
+                new MaintenanceCost(BigDecimal.valueOf(2.0)),
+                new EnvironmentalImpact(9.0), new Co2Reduction(0.42), new CapacityFactor(24.0));
     }
 }


### PR DESCRIPTION
## What changed
- Restores `technologyIds` as a persisted list of recommended/comparable technologies
- Resolves recommended technology ids during manual simulation creation
- Threads the ids through draft persistence and final completion snapshots

## Why
Part of #176. This restores the product model where `energyType` is the user input and `technologyIds` are persisted recommendation/comparison data.

## Validation
- `mvn -Dtest=RealSimulationServiceTest,SimulationTest,TechnologyCatalogLookupServiceTest test`

## Chain Context
- Strategy: stacked PRs to `dev/v1.2.0`
- Depends on: #177
- Current slice: 📍 PR 2 of 5
- Next: `feat/simulation-phase7-scenario-core`

```text
PR1 #177 refactor/simulation-phase7-persistence-contract
└─ PR2 refactor/simulation-phase7-technology-ids 📍
   └─ PR3 feat/simulation-phase7-scenario-core
      └─ PR4 test/simulation-phase7-scenario-acceptance
         └─ PR5 test/simulation-phase7-scenario-contract
```