### PR TITLE
feat(simulation): add scenario-based creation flow

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioService.java
@@ -1,0 +1,107 @@
+package com.renewsim.backend.simulation_service.create.application;
+
+import com.renewsim.backend.scenario_service.domain.exception.ScenarioNotFoundException;
+import com.renewsim.backend.simulation_service.create.application.command.CreateRealSimulationCommand;
+import com.renewsim.backend.simulation_service.create.application.command.CreateSimulationFromScenarioCommand;
+import com.renewsim.backend.simulation_service.create.application.port.in.CreateRealSimulationUseCase;
+import com.renewsim.backend.simulation_service.create.application.port.in.CreateSimulationFromScenarioUseCase;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidConsumptionProfileException;
+import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
+import com.renewsim.backend.simulation_service.domain.model.vo.Currency;
+import com.renewsim.backend.simulation_service.domain.model.vo.ProjectLifetime;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomics;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
+import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.port.out.ScenarioLookupPort;
+import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateSimulationFromScenarioService implements CreateSimulationFromScenarioUseCase {
+
+    private static final double DEFAULT_PERFORMANCE_RATIO = 0.81;
+    private static final double DEFAULT_DEGRADATION_RATE_ANNUAL_PCT = 0.5;
+    private static final double DEFAULT_AVAILABILITY_PCT = 99.0;
+    private static final int DEFAULT_PROJECT_LIFETIME_YEARS = 20;
+    private static final double DEFAULT_OPEX_ANNUAL = 0.0;
+    private static final double DEFAULT_EXPORT_PRICE_PER_KWH = 0.07;
+    private static final double DEFAULT_DISCOUNT_RATE_PCT = 8.0;
+    private static final String SUPPORTED_SIMULATION_CURRENCY = "EUR";
+
+    private final ScenarioLookupPort scenarioLookupPort;
+    private final TechnologyLookupPort technologyLookupPort;
+    private final CreateRealSimulationUseCase createRealSimulationUseCase;
+
+    @Override
+    public SimulationDetailsResult createSimulationFromScenario(CreateSimulationFromScenarioCommand command) {
+        ScenarioLookupPort.ScenarioSnapshot scenario = scenarioLookupPort.findActiveScenarioById(command.scenarioId())
+                .orElseThrow(() -> new ScenarioNotFoundException(command.scenarioId()));
+
+        String energyType = technologyLookupPort.findActiveEnergyTypeByTechnologyId(scenario.technologyId())
+                .orElseThrow(() -> new ScenarioNotFoundException(command.scenarioId()));
+
+        List<Long> technologyIds = technologyLookupPort.recommendActiveTechnologyIdsByEnergyType(energyType);
+
+        CreateRealSimulationCommand realCommand = new CreateRealSimulationCommand(
+                resolveSimulationName(command.name(), scenario.name()),
+                Technology.of(energyType),
+                command.location(),
+                buildSystem(scenario),
+                buildDemand(scenario),
+                buildEconomics(scenario),
+                technologyIds,
+                scenario.id(),
+                command.createdBy());
+
+        return createRealSimulationUseCase.createSimulation(realCommand);
+    }
+
+    private String resolveSimulationName(String requestedName, String scenarioName) {
+        return requestedName == null || requestedName.isBlank() ? scenarioName : requestedName;
+    }
+
+    private SimulationSystem buildSystem(ScenarioLookupPort.ScenarioSnapshot scenario) {
+        return new SimulationSystem(
+                scenario.defaultCapacityKw(),
+                DEFAULT_PERFORMANCE_RATIO,
+                DEFAULT_DEGRADATION_RATE_ANNUAL_PCT,
+                DEFAULT_AVAILABILITY_PCT,
+                new SimulationSystem.LossesPct(2.0, 6.0, 1.0, 3.0, 1.0));
+    }
+
+    private ConsumptionProfile buildDemand(ScenarioLookupPort.ScenarioSnapshot scenario) {
+        if (scenario.defaultConsumption() <= 0) {
+            throw new InvalidConsumptionProfileException(
+                    "VALIDATION_ERROR: scenario defaultConsumption must be positive");
+        }
+        double monthly = scenario.defaultConsumption() / 12.0;
+        List<Double> monthlyConsumption = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            monthlyConsumption.add(monthly);
+        }
+        return ConsumptionProfile.of(scenario.defaultConsumption(), monthlyConsumption);
+    }
+
+    private SimulationEconomics buildEconomics(ScenarioLookupPort.ScenarioSnapshot scenario) {
+        return new SimulationEconomics(
+                Currency.of(resolveSimulationCurrency(scenario.defaultInvestmentCurrency())),
+                scenario.defaultInvestmentAmount(),
+                DEFAULT_OPEX_ANNUAL,
+                scenario.defaultTariff(),
+                DEFAULT_EXPORT_PRICE_PER_KWH,
+                DEFAULT_DISCOUNT_RATE_PCT,
+                ProjectLifetime.of(DEFAULT_PROJECT_LIFETIME_YEARS));
+    }
+
+    private String resolveSimulationCurrency(String scenarioCurrency) {
+        return SUPPORTED_SIMULATION_CURRENCY;
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/command/CreateSimulationFromScenarioCommand.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/command/CreateSimulationFromScenarioCommand.java
@@ -1,0 +1,10 @@
+package com.renewsim.backend.simulation_service.create.application.command;
+
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
+
+public record CreateSimulationFromScenarioCommand(
+                Long scenarioId,
+                String name,
+                SimulationLocation location,
+                String createdBy) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/port/in/CreateSimulationFromScenarioUseCase.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/port/in/CreateSimulationFromScenarioUseCase.java
@@ -1,0 +1,9 @@
+package com.renewsim.backend.simulation_service.create.application.port.in;
+
+import com.renewsim.backend.simulation_service.create.application.command.CreateSimulationFromScenarioCommand;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+
+public interface CreateSimulationFromScenarioUseCase {
+
+    SimulationDetailsResult createSimulationFromScenario(CreateSimulationFromScenarioCommand command);
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationController.java
@@ -1,9 +1,11 @@
 package com.renewsim.backend.simulation_service.create.web;
 
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateRealSimulationUseCase;
+import com.renewsim.backend.simulation_service.create.application.port.in.CreateSimulationFromScenarioUseCase;
 import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContext;
 import com.renewsim.backend.simulation_service.shared.web.SimulationDetailsWebMapper;
 import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContextFactory;
+import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationFromScenarioRequestDTO;
 import com.renewsim.backend.simulation_service.create.web.dto.CreateSolarSimulationRequestDTO;
 import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +30,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class CreateSimulationController {
 
     private final CreateRealSimulationUseCase createRealSimulationUseCase;
+    private final CreateSimulationFromScenarioUseCase createSimulationFromScenarioUseCase;
     private final CreateSimulationWebMapper createWebMapper = new CreateSimulationWebMapper();
+    private final CreateSimulationFromScenarioWebMapper createFromScenarioWebMapper = new CreateSimulationFromScenarioWebMapper();
     private final SimulationDetailsWebMapper detailsWebMapper = new SimulationDetailsWebMapper();
     private final SimulationRequestContextFactory requestContextFactory = new SimulationRequestContextFactory();
 
@@ -44,6 +48,23 @@ public class CreateSimulationController {
         SimulationDetailsResponseDTO result = detailsWebMapper.toWebDetails(
                 createRealSimulationUseCase.createSimulation(createWebMapper.toCommand(request, requestContext.username())));
         log.info("User {} created simulation {}", requestContext.username(), result.id());
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @Operation(summary = "Create a simulation from a predefined scenario")
+    @PreAuthorize("hasAuthority('SCOPE_write:simulations') or hasRole('ADMIN')")
+    @PostMapping("/from-scenario")
+    public ResponseEntity<SimulationDetailsResponseDTO> createSimulationFromScenario(
+            @Valid @RequestBody CreateSimulationFromScenarioRequestDTO request,
+            Authentication auth) {
+
+        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+
+        SimulationDetailsResponseDTO result = detailsWebMapper.toWebDetails(
+                createSimulationFromScenarioUseCase.createSimulationFromScenario(
+                        createFromScenarioWebMapper.toCommand(request, requestContext.username())));
+        log.info("User {} created simulation {} from scenario {}", requestContext.username(), result.id(),
+                request.scenarioId());
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationFromScenarioWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationFromScenarioWebMapper.java
@@ -1,0 +1,23 @@
+package com.renewsim.backend.simulation_service.create.web;
+
+import com.renewsim.backend.simulation_service.create.application.command.CreateSimulationFromScenarioCommand;
+import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationFromScenarioRequestDTO;
+import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
+
+public final class CreateSimulationFromScenarioWebMapper {
+
+    public CreateSimulationFromScenarioCommand toCommand(
+            CreateSimulationFromScenarioRequestDTO request, String username) {
+        return new CreateSimulationFromScenarioCommand(
+                request.scenarioId(),
+                request.name(),
+                SimulationLocation.of(
+                        request.location().label(),
+                        request.location().lat(),
+                        request.location().lon(),
+                        request.location().country(),
+                        CountryCode.of(request.location().countryCode())),
+                username);
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/CreateSimulationFromScenarioRequestDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/CreateSimulationFromScenarioRequestDTO.java
@@ -1,0 +1,11 @@
+package com.renewsim.backend.simulation_service.create.web.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateSimulationFromScenarioRequestDTO(
+        @NotNull Long scenarioId,
+        @Size(min = 2, max = 120) String name,
+        @NotNull @Valid CreateSolarSimulationRequestDTO.LocationDTO location) {
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/ScenarioLookupJpaAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/ScenarioLookupJpaAdapter.java
@@ -1,0 +1,36 @@
+package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
+
+import com.renewsim.backend.scenario_service.application.command.GetScenarioByIdCommand;
+import com.renewsim.backend.scenario_service.application.port.in.GetScenarioUseCase;
+import com.renewsim.backend.scenario_service.application.result.ScenarioResponseDTO;
+import com.renewsim.backend.scenario_service.domain.exception.ScenarioNotFoundException;
+import com.renewsim.backend.simulation_service.shared.application.port.out.ScenarioLookupPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ScenarioLookupJpaAdapter implements ScenarioLookupPort {
+
+    private final GetScenarioUseCase getScenarioUseCase;
+
+    @Override
+    public Optional<ScenarioSnapshot> findActiveScenarioById(Long scenarioId) {
+        try {
+            ScenarioResponseDTO scenario = getScenarioUseCase.getScenarioById(new GetScenarioByIdCommand(scenarioId));
+            return Optional.of(new ScenarioSnapshot(
+                    scenario.id(),
+                    scenario.name(),
+                    scenario.technologyId(),
+                    scenario.defaultCapacityKw(),
+                    scenario.defaultInvestment().amount().doubleValue(),
+                    scenario.defaultInvestment().currency(),
+                    scenario.defaultTariff(),
+                    scenario.defaultConsumption()));
+        } catch (ScenarioNotFoundException ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java
@@ -50,6 +50,7 @@ final class SimulationRecordEntityMapper {
         entity.setInputSnapshot(snapshotCodec.write(simulation));
         entity.setResultSnapshot(simulation.getResultSnapshot());
         entity.setTechnologyIds(new ArrayList<>(simulation.getTechnologyIds()));
+        entity.setScenarioId(simulation.getScenarioId());
         return entity;
     }
 
@@ -97,7 +98,7 @@ final class SimulationRecordEntityMapper {
                 entity.getIrrPct(),
                 entity.getRecommendation(),
                 entity.getTechnologyIds(),
-                null,
+                entity.getScenarioId(),
                 entity.getCreatedBy(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt());

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/entity/SimulationEntity.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/entity/SimulationEntity.java
@@ -88,6 +88,9 @@ public class SimulationEntity {
     @Column(name = "recommendation")
     private String recommendation;
 
+    @Column(name = "scenario_id")
+    private Long scenarioId;
+
     @Lob
     @Column(name = "input_snapshot", columnDefinition = "LONGTEXT")
     private String inputSnapshot;

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/application/port/out/ScenarioLookupPort.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/application/port/out/ScenarioLookupPort.java
@@ -1,0 +1,19 @@
+package com.renewsim.backend.simulation_service.shared.application.port.out;
+
+import java.util.Optional;
+
+public interface ScenarioLookupPort {
+
+    Optional<ScenarioSnapshot> findActiveScenarioById(Long scenarioId);
+
+    record ScenarioSnapshot(
+            Long id,
+            String name,
+            Long technologyId,
+            double defaultCapacityKw,
+            double defaultInvestmentAmount,
+            String defaultInvestmentCurrency,
+            double defaultTariff,
+            double defaultConsumption) {
+    }
+}

--- a/src/main/resources/db/migration/V26__add_simulation_scenario_origin.sql
+++ b/src/main/resources/db/migration/V26__add_simulation_scenario_origin.sql
@@ -1,0 +1,22 @@
+-- =====================================================
+-- V26: Add optional scenario origin reference to simulations
+-- Requirements: phase 7 (simulation from scenario origin)
+-- =====================================================
+
+SET @ddl = IF (
+    EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = DATABASE()
+          AND table_name = 'simulations'
+          AND column_name = 'scenario_id'
+    ),
+    'SELECT 1',
+    'ALTER TABLE simulations ADD COLUMN scenario_id BIGINT NULL AFTER recommendation'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE INDEX idx_simulations_scenario_id
+    ON simulations(scenario_id);

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapperTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapperTest.java
@@ -108,6 +108,20 @@ class SimulationRecordEntityMapperTest {
         assertThat(simulation.getEconomics().capexTotal()).isEqualTo(315000.0);
         assertThat(simulation.getRecommendation()).isEqualTo("viable_with_reservations");
         assertThat(simulation.getTechnologyIds()).containsExactly(11L, 12L);
+        assertThat(simulation.getScenarioId()).isNull();
+    }
+
+    @Test
+    @DisplayName("toEntity and toDomain round-trip the scenario origin reference")
+    void toEntityAndToDomainRoundTripScenarioOrigin() {
+        Simulation simulation = completedSimulation();
+        simulation.assignScenarioId(42L);
+
+        SimulationEntity entity = mapper.toEntity(simulation);
+        Simulation rebuilt = mapper.toDomain(entity);
+
+        assertThat(entity.getScenarioId()).isEqualTo(42L);
+        assertThat(rebuilt.getScenarioId()).isEqualTo(42L);
     }
 
     private Simulation completedSimulation() {


### PR DESCRIPTION
## What changed
- Adds an explicit scenario-based simulation creation flow
- Persists `scenarioId` as optional origin reference
- Materializes scenario defaults into the simulation snapshot and keeps manual creation unchanged
- Adds the `POST /api/v1/simulations/from-scenario` endpoint and migration `V26`

## Why
Part of #176. This is the functional core of phase 7: manual creation stays energy-type driven, while scenario creation becomes a separate explicit flow.

## Validation
- `mvn -Dtest=CreateSimulationControllerTest,SimulationSchemaMigrationTest test`

## Chain Context
- Strategy: stacked PRs to `dev/v1.2.0`
- Depends on: #178
- Current slice: 📍 PR 3 of 5
- Next: `test/simulation-phase7-scenario-acceptance`

```text
PR1 #177 refactor/simulation-phase7-persistence-contract
└─ PR2 #178 refactor/simulation-phase7-technology-ids
   └─ PR3 feat/simulation-phase7-scenario-core 📍
      └─ PR4 test/simulation-phase7-scenario-acceptance
         └─ PR5 test/simulation-phase7-scenario-contract
```