### PR TITLE
test(simulation): cover scenario snapshot stability

### DIFF
--- a/docs/architecture/simulation-phase7-flows.md
+++ b/docs/architecture/simulation-phase7-flows.md
@@ -1,0 +1,61 @@
+# Simulation Phase 7 Flows
+
+Phase 7 defines two valid ways to create a simulation and restores the product model that separates `energyType`, `technologyIds`, and `scenarioId`.
+
+## Quick path
+
+1. Use `POST /api/v1/simulations` for manual simulations.
+2. Use `POST /api/v1/simulations/from-scenario` to start from a predefined scenario.
+3. Persist the simulation with its own snapshot so later catalog changes do not mutate stored results.
+
+## Core model
+
+| Topic | Decision |
+|-------|----------|
+| Manual input | The current manual endpoint is solar-only and receives full solar simulation inputs. |
+| Scenario input | The user provides `scenarioId` plus allowed overrides (`name`, `location`). |
+| `energyType` | Remains part of the target product model, but the current manual HTTP contract is still solar-only. |
+| `technologyIds` | Persisted as the recommended/comparable technologies for the simulation. |
+| `scenarioId` | Optional persisted reference to the source scenario. |
+| Snapshot rule | A simulation created from a scenario copies the scenario defaults into its own persisted snapshot at creation time. |
+
+## Flow details
+
+### 1. Manual simulation
+
+- Request enters `CreateSimulationController` through `POST /api/v1/simulations`.
+- `CreateSimulationWebMapper` builds `CreateRealSimulationCommand` for solar simulations and hard-codes `Technology.solar()`.
+- `CreateSimulationService` validates the active technology, recommends `technologyIds` when the request does not provide them, persists the draft, runs the engine, and persists the completed simulation.
+
+### 2. Simulation from scenario
+
+- Request enters `CreateSimulationController` through `POST /api/v1/simulations/from-scenario`.
+- `CreateSimulationFromScenarioService` resolves the active scenario through `ScenarioLookupPort`.
+- The service derives `energyType` from the scenario's `technologyId` through `TechnologyLookupPort`.
+- The service copies scenario defaults into a new `CreateRealSimulationCommand`:
+  - system capacity
+  - investment amount/currency
+  - tariff
+  - annual consumption
+- The service persists `scenarioId` and recommended `technologyIds` together with the simulation snapshot.
+
+## What this phase protects
+
+- `technologyId` from the scenario does not replace the simulation's `technologyIds` list.
+- A later scenario catalog update does not rewrite historical simulations.
+- Cleanup of legacy snapshot compatibility happens only after this functional model is in place.
+
+## Verification checklist
+
+- [ ] Manual creation remains solar-only until a broader manual contract is introduced.
+- [ ] Scenario creation persists `scenarioId`.
+- [ ] Simulations persist `technologyIds` as recommended/comparable technologies.
+- [ ] Stored simulations remain stable even if scenario defaults change later.
+
+## Relevant files
+
+- `src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java`
+- `src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioService.java`
+- `src/main/java/com/renewsim/backend/simulation_service/domain/model/Simulation.java`
+- `src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationRecordEntityMapper.java`
+- `src/main/resources/db/migration/V26__add_simulation_scenario_origin.sql`

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
@@ -1,0 +1,362 @@
+package com.renewsim.backend.simulation_service.create.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.scenario_service.domain.exception.ScenarioNotFoundException;
+import com.renewsim.backend.simulation_service.create.application.command.CreateSimulationFromScenarioCommand;
+import com.renewsim.backend.simulation_service.create.application.port.in.CreateRealSimulationUseCase;
+import com.renewsim.backend.simulation_service.create.application.technology.hydro.HydroSimulationEngine;
+import com.renewsim.backend.simulation_service.create.application.technology.solar.SolarSimulationAssessmentPolicy;
+import com.renewsim.backend.simulation_service.create.application.technology.solar.SolarSimulationEngine;
+import com.renewsim.backend.simulation_service.create.application.technology.wind.WindSimulationEngine;
+import com.renewsim.backend.simulation_service.create.application.port.out.PvgisSolarResourcePort;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidConsumptionProfileException;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.port.out.ScenarioLookupPort;
+import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationRecordRepositoryPort;
+import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
+import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import com.renewsim.backend.simulation_service.domain.model.SimulationId;
+import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.JpaSimulationRepository;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.SimulationRecordRepositoryAdapter;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class CreateSimulationFromScenarioServiceTest {
+
+    @Mock
+    private ScenarioLookupPort scenarioLookupPort;
+    @Mock
+    private TechnologyLookupPort technologyLookupPort;
+    @Mock
+    private SimulationRecordRepositoryPort repository;
+    @Mock
+    private PvgisSolarResourcePort resourcePort;
+
+    @Test
+    @DisplayName("createSimulationFromScenario resolves scenario defaults and delegates to the real flow")
+    void createSimulationFromScenarioResolvesScenarioDefaultsAndDelegates() {
+        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                scenarioLookupPort,
+                technologyLookupPort,
+                realCreateService());
+
+        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
+        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
+        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+        when(repository.save(any())).thenAnswer(invocation -> {
+            Simulation sim = invocation.getArgument(0);
+            if (sim.getId() == null) {
+                sim.assignId(SimulationId.of(60L));
+            }
+            return sim;
+        });
+
+        SimulationDetailsResult response = service.createSimulationFromScenario(
+                new CreateSimulationFromScenarioCommand(
+                        7L, null,
+                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES")),
+                        "alice"));
+
+        assertThat(response.id()).isEqualTo("60");
+        assertThat(response.input().technology()).isEqualTo("solar");
+
+        ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
+        verify(repository, atLeastOnce()).save(captor.capture());
+        Simulation persisted = captor.getAllValues().get(captor.getAllValues().size() - 1);
+        assertThat(persisted.getScenarioId()).isEqualTo(7L);
+        assertThat(persisted.getName()).isEqualTo("Hogar solar - Sevilla");
+        assertThat(persisted.getSystem().installedCapacityKw()).isEqualTo(5.0);
+        assertThat(persisted.getDemand().annualConsumptionKwh()).isEqualTo(6000.0);
+        assertThat(persisted.getEconomics().capexTotal()).isEqualTo(12000.0);
+        assertThat(persisted.getTechnologyIds()).containsExactly(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("createSimulationFromScenario keeps request name when provided")
+    void createSimulationFromScenarioKeepsRequestNameWhenProvided() {
+        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                scenarioLookupPort,
+                technologyLookupPort,
+                realCreateService());
+
+        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
+        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
+        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.createSimulationFromScenario(
+                new CreateSimulationFromScenarioCommand(
+                        7L, "Mi simulacion personalizada",
+                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES")),
+                        "alice"));
+
+        ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
+        verify(repository, atLeastOnce()).save(captor.capture());
+        assertThat(captor.getAllValues().get(captor.getAllValues().size() - 1).getName())
+                .isEqualTo("Mi simulacion personalizada");
+    }
+
+    @Test
+    @DisplayName("createSimulationFromScenario snapshots scenario defaults at creation time")
+    void createSimulationFromScenarioSnapshotsScenarioDefaultsAtCreationTime() {
+        JpaSimulationRepository jpaRepository = mock(JpaSimulationRepository.class);
+        SimulationRecordRepositoryPort persistenceRepository = inMemoryPersistenceRepository(jpaRepository);
+        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                scenarioLookupPort,
+                technologyLookupPort,
+                realCreateService(persistenceRepository));
+
+        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(
+                Optional.of(scenarioSnapshot()),
+                Optional.of(new ScenarioLookupPort.ScenarioSnapshot(
+                        7L, "Hogar solar - Sevilla", 1L,
+                        8.0, 18000.0, "USD", 0.21, 9000.0)));
+        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
+        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+
+        SimulationDetailsResult firstResponse = service.createSimulationFromScenario(
+                new CreateSimulationFromScenarioCommand(
+                        7L, "Simulation 1",
+                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES")),
+                        "alice"));
+        service.createSimulationFromScenario(
+                new CreateSimulationFromScenarioCommand(
+                        7L, "Simulation 2",
+                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES")),
+                        "alice"));
+
+        Simulation firstSimulation = persistenceRepository.findById(Long.valueOf(firstResponse.id())).orElseThrow();
+        Simulation secondSimulation = persistenceRepository.findByCreatedByOrderByCreatedAtDesc("alice").stream()
+                .filter(simulation -> "Simulation 2".equals(simulation.getName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(firstSimulation.getSystem().installedCapacityKw()).isEqualTo(5.0);
+        assertThat(firstSimulation.getDemand().annualConsumptionKwh()).isEqualTo(6000.0);
+        assertThat(firstSimulation.getEconomics().capexTotal()).isEqualTo(12000.0);
+        assertThat(firstSimulation.getEconomics().currency().value()).isEqualTo("EUR");
+
+        assertThat(secondSimulation.getSystem().installedCapacityKw()).isEqualTo(8.0);
+        assertThat(secondSimulation.getDemand().annualConsumptionKwh()).isEqualTo(9000.0);
+        assertThat(secondSimulation.getEconomics().capexTotal()).isEqualTo(18000.0);
+        assertThat(secondSimulation.getEconomics().currency().value()).isEqualTo("EUR");
+    }
+
+    @Test
+    @DisplayName("createSimulationFromScenario falls back to the scenario name when request name is blank")
+    void createSimulationFromScenarioFallsBackToScenarioNameWhenRequestNameIsBlank() {
+        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                scenarioLookupPort,
+                technologyLookupPort,
+                realCreateService());
+
+        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
+        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
+        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.createSimulationFromScenario(
+                new CreateSimulationFromScenarioCommand(
+                        7L, "   ",
+                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES")),
+                        "alice"));
+
+        ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
+        verify(repository, atLeastOnce()).save(captor.capture());
+        assertThat(captor.getAllValues().get(captor.getAllValues().size() - 1).getName())
+                .isEqualTo("Hogar solar - Sevilla");
+    }
+
+    @Test
+    @DisplayName("createSimulationFromScenario fails when scenario is missing or inactive")
+    void createSimulationFromScenarioFailsWhenScenarioMissing() {
+        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                scenarioLookupPort,
+                technologyLookupPort,
+                realCreateService());
+
+        when(scenarioLookupPort.findActiveScenarioById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createSimulationFromScenario(
+                new CreateSimulationFromScenarioCommand(
+                        99L, null,
+                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES")),
+                        "alice")))
+                .isInstanceOf(ScenarioNotFoundException.class);
+
+        verify(technologyLookupPort, never()).findActiveEnergyTypeByTechnologyId(any());
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createSimulationFromScenario fails when the scenario technology is not active")
+    void createSimulationFromScenarioFailsWhenScenarioTechnologyIsNotActive() {
+        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                scenarioLookupPort,
+                technologyLookupPort,
+                realCreateService());
+
+        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
+        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createSimulationFromScenario(
+                new CreateSimulationFromScenarioCommand(
+                        7L, null,
+                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES")),
+                        "alice")))
+                .isInstanceOf(ScenarioNotFoundException.class);
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("createSimulationFromScenario fails when the scenario consumption is not positive")
+    void createSimulationFromScenarioFailsWhenScenarioConsumptionIsNotPositive() {
+        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                scenarioLookupPort,
+                technologyLookupPort,
+                realCreateService());
+
+        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(
+                new ScenarioLookupPort.ScenarioSnapshot(7L, "Hogar solar - Sevilla", 1L,
+                        5.0, 12000.0, "EUR", 0.15, 0.0)));
+        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
+
+        assertThatThrownBy(() -> service.createSimulationFromScenario(
+                new CreateSimulationFromScenarioCommand(
+                        7L, null,
+                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES")),
+                        "alice")))
+                .isInstanceOf(InvalidConsumptionProfileException.class)
+                .hasMessage("VALIDATION_ERROR: scenario defaultConsumption must be positive");
+
+        verify(repository, never()).save(any());
+    }
+
+    private CreateRealSimulationUseCase realCreateService() {
+        return realCreateService(repository);
+    }
+
+    private CreateRealSimulationUseCase realCreateService(SimulationRecordRepositoryPort simulationRepository) {
+        return new CreateSimulationService(
+                simulationRepository,
+                technologyLookupPort,
+                List.of(
+                        new SolarSimulationEngine(resourcePort, new SolarSimulationAssessmentPolicy()),
+                        new WindSimulationEngine(),
+                        new HydroSimulationEngine()),
+                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+    }
+
+    private SimulationRecordRepositoryPort inMemoryPersistenceRepository(JpaSimulationRepository jpaRepository) {
+        Map<Long, SimulationEntity> store = new HashMap<>();
+        AtomicLong sequence = new AtomicLong(60L);
+
+        when(jpaRepository.save(any(SimulationEntity.class))).thenAnswer(invocation -> {
+            SimulationEntity entity = invocation.getArgument(0);
+            SimulationEntity stored = copyEntity(entity);
+            if (stored.getId() == null) {
+                stored.setId(sequence.getAndIncrement());
+            }
+            store.put(stored.getId(), stored);
+            return copyEntity(stored);
+        });
+        when(jpaRepository.findById(any(Long.class))).thenAnswer(invocation -> {
+            Long id = invocation.getArgument(0);
+            SimulationEntity stored = store.get(id);
+            return Optional.ofNullable(stored == null ? null : copyEntity(stored));
+        });
+        when(jpaRepository.findByCreatedByOrderByCreatedAtDesc("alice")).thenAnswer(invocation ->
+                store.values().stream()
+                        .filter(entity -> "alice".equals(entity.getCreatedBy()))
+                        .sorted((left, right) -> right.getCreatedAt().compareTo(left.getCreatedAt()))
+                        .map(this::copyEntity)
+                        .toList());
+
+        return new SimulationRecordRepositoryAdapter(jpaRepository, new ObjectMapper().findAndRegisterModules());
+    }
+
+    private SimulationEntity copyEntity(SimulationEntity source) {
+        SimulationEntity copy = new SimulationEntity();
+        copy.setId(source.getId());
+        copy.setName(source.getName());
+        copy.setLocation(source.getLocation());
+        copy.setEnergyType(source.getEnergyType());
+        copy.setLocationLat(source.getLocationLat());
+        copy.setLocationLng(source.getLocationLng());
+        copy.setProjectSize(source.getProjectSize());
+        copy.setBudget(source.getBudget());
+        copy.setEstimatedEnergy(source.getEstimatedEnergy());
+        copy.setClimateData(source.getClimateData());
+        copy.setCreatedBy(source.getCreatedBy());
+        copy.setCreatedAt(source.getCreatedAt());
+        copy.setUpdatedAt(source.getUpdatedAt());
+        copy.setStatus(source.getStatus());
+        copy.setAnnualSavings(source.getAnnualSavings());
+        copy.setNpv(source.getNpv());
+        copy.setIrrPct(source.getIrrPct());
+        copy.setRecommendation(source.getRecommendation());
+        copy.setScenarioId(source.getScenarioId());
+        copy.setInputSnapshot(source.getInputSnapshot());
+        copy.setResultSnapshot(source.getResultSnapshot());
+        copy.setTechnologyIds(source.getTechnologyIds() == null ? List.of() : List.copyOf(source.getTechnologyIds()));
+        return copy;
+    }
+
+    private ScenarioLookupPort.ScenarioSnapshot scenarioSnapshot() {
+        return new ScenarioLookupPort.ScenarioSnapshot(
+                7L, "Hogar solar - Sevilla", 1L,
+                5.0, 12000.0, "USD", 0.15, 6000.0);
+    }
+
+    private PvgisSolarResourcePort.PvgisSolarResourceProfile profile() {
+        return new PvgisSolarResourcePort.PvgisSolarResourceProfile(
+                List.of(117.91, 117.78, 140.16, 142.40, 155.64, 154.71, 164.37, 161.96, 145.57, 132.00,
+                        112.14, 112.69),
+                List.of(144.21, 146.57, 177.98, 185.86, 208.58, 212.34, 230.04, 226.42, 197.02, 172.86,
+                        140.05, 137.50),
+                List.of(10.0, 12.0, 15.0, 17.0, 22.0, 27.0, 31.0, 31.0, 27.0, 21.0, 15.0, 11.0),
+                "2005-2020",
+                "PVGIS");
+    }
+}


### PR DESCRIPTION
## What changed
- Adds scenario-creation acceptance coverage
- Verifies scenario default snapshot stability over time
- Documents the phase 7 target model and the two creation flows

## Why
Part of #176. The implementation was functionally done, but the issue was not strictly closable without an explicit stability test and a written description of the target flow.

## Validation
- `mvn -Dtest=CreateSimulationFromScenarioServiceTest,RealSimulationServiceTest test`

## Chain Context
- Strategy: stacked PRs to `dev/v1.2.0`
- Depends on: #179
- Current slice: 📍 PR 4 of 5
- Next: `test/simulation-phase7-scenario-contract`

```text
PR1 #177 refactor/simulation-phase7-persistence-contract
└─ PR2 #178 refactor/simulation-phase7-technology-ids
   └─ PR3 #179 feat/simulation-phase7-scenario-core
      └─ PR4 test/simulation-phase7-scenario-acceptance 📍
         └─ PR5 test/simulation-phase7-scenario-contract
```