### PR TITLE
test(simulation): cover scenario controller contract

### DIFF
--- a/src/test/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationControllerTest.java
@@ -1,63 +1,129 @@
 package com.renewsim.backend.simulation_service.create.web;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
-import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.auth_service.infrastructure.security.JwtTokenProvider;
+import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimitingFilter;
+import com.renewsim.backend.config.TestSecurityConfig;
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateRealSimulationUseCase;
+import com.renewsim.backend.simulation_service.create.application.port.in.CreateSimulationFromScenarioUseCase;
+import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationFromScenarioRequestDTO;
 import com.renewsim.backend.simulation_service.create.web.dto.CreateSolarSimulationRequestDTO;
-import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.TestingAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
 class CreateSimulationControllerTest {
 
-    @Mock
+    private static final String AUTHORIZED_TOKEN = "authorized-token";
+    private static final String ROLE_ONLY_TOKEN = "role-only-token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private LoginRateLimitingFilter loginRateLimitingFilter;
+
+    @MockitoBean
     private CreateRealSimulationUseCase createRealSimulationUseCase;
 
-    @InjectMocks
-    private CreateSimulationController controller;
+    @MockitoBean
+    private CreateSimulationFromScenarioUseCase createSimulationFromScenarioUseCase;
 
-    @Test
-    @DisplayName("createSimulation returns the real simulation details contract")
-    void createSimulationReturnsRealContract() {
-        Authentication auth = authentication("alice", "ROLE_USER");
-        CreateSolarSimulationRequestDTO request = request();
+    @BeforeEach
+    void setUp() throws Exception {
+        doAnswer(invocation -> {
+            invocation.getArgument(0, ServletRequest.class);
+            invocation.getArgument(1, ServletResponse.class);
+            invocation.getArgument(2, FilterChain.class).doFilter(
+                    invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(loginRateLimitingFilter).doFilter(any(), any(), any());
 
-        when(createRealSimulationUseCase.createSimulation(any())).thenReturn(sampleResult());
+        when(jwtTokenProvider.validate(AUTHORIZED_TOKEN))
+                .thenReturn(Optional.of(new AuthenticatedUser(
+                        "alice",
+                        Set.of("USER"),
+                        Set.of("write:simulations", "read:simulations"))));
 
-        SimulationDetailsResponseDTO body = controller.createSimulation(request, auth).getBody();
-
-        assertThat(body).isNotNull();
-        assertThat(body.id()).isEqualTo("55");
-        assertThat(body.technical().annualGenerationKwh()).isEqualTo(457200);
-        verify(createRealSimulationUseCase).createSimulation(any());
+        when(jwtTokenProvider.validate(ROLE_ONLY_TOKEN))
+                .thenReturn(Optional.of(new AuthenticatedUser(
+                        "bob",
+                        Set.of("USER"),
+                        Set.of("read:simulations"))));
     }
 
-    private CreateSolarSimulationRequestDTO request() {
-        return new CreateSolarSimulationRequestDTO(
-                "Solar - Sevilla",
-                new CreateSolarSimulationRequestDTO.LocationDTO("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", "ES"),
-                new CreateSolarSimulationRequestDTO.SolarSystemDTO(300, 0.81, 0.5, 99,
-                        new CreateSolarSimulationRequestDTO.LossesPctDTO(2, 6, 1, 3, 1)),
-                new CreateSolarSimulationRequestDTO.DemandDTO(120000,
-                        List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
-                                10000d)),
-                new CreateSolarSimulationRequestDTO.EconomicsDTO("EUR", 315000, 7200, 0.18, 0.07, 8, 20));
+    @Test
+    @DisplayName("createSimulationFromScenario returns 201 for a user with write scope")
+    void createSimulationFromScenarioReturns201ForUserWithWriteScope() throws Exception {
+        when(createSimulationFromScenarioUseCase.createSimulationFromScenario(any())).thenReturn(sampleResult());
+
+        mockMvc.perform(post("/api/v1/simulations/from-scenario")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(AUTHORIZED_TOKEN))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateSimulationFromScenarioRequestDTO(
+                                7L,
+                                null,
+                                new CreateSolarSimulationRequestDTO.LocationDTO(
+                                        "Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", "ES")))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("55"))
+                .andExpect(jsonPath("$.technical.annualGenerationKwh").value(457200));
+
+        verify(createSimulationFromScenarioUseCase).createSimulationFromScenario(any());
+    }
+
+    @Test
+    @DisplayName("createSimulationFromScenario returns 403 for a role-only user without write scope")
+    void createSimulationFromScenarioReturns403ForRoleOnlyUserWithoutWriteScope() throws Exception {
+        mockMvc.perform(post("/api/v1/simulations/from-scenario")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(ROLE_ONLY_TOKEN))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateSimulationFromScenarioRequestDTO(
+                                7L,
+                                null,
+                                new CreateSolarSimulationRequestDTO.LocationDTO(
+                                        "Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", "ES")))))
+                .andExpect(status().isForbidden());
+    }
+
+    private static String bearer(String token) {
+        return "Bearer " + token;
     }
 
     private SimulationDetailsResult sampleResult() {
@@ -70,10 +136,5 @@ class CreateSimulationControllerTest {
                 new SimulationDetailsResult.Financial("EUR", 68700, 8800, 70300, 6.9, 8.7, 121500, 11.4, 0.071, List.of(new SimulationDetailsResult.FinancialYearItem(0, 0, 0, 0, 0, -315000, -315000, -315000))),
                 new SimulationDetailsResult.Assumptions(8, 20, 0.5, 0.18, 0.07, "PVGIS", "2005-2020"),
                 List.of(new SimulationDetailsResult.SimulationWarning("info", "MONTHLY_PROFILE_USER_SUPPLIED", "warning")));
-    }
-
-    private Authentication authentication(String username, String role) {
-        AuthenticatedUser user = AuthenticatedUser.of(username, Set.of(role.replace("ROLE_", "")), Set.of("read:simulations", "write:simulations"));
-        return new TestingAuthenticationToken(user, null, List.of(new SimpleGrantedAuthority(role)));
     }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/ScenarioLookupJpaAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/ScenarioLookupJpaAdapterTest.java
@@ -1,0 +1,70 @@
+package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
+
+import com.renewsim.backend.scenario_service.application.command.GetScenarioByIdCommand;
+import com.renewsim.backend.scenario_service.application.port.in.GetScenarioUseCase;
+import com.renewsim.backend.scenario_service.application.result.ScenarioResponseDTO;
+import com.renewsim.backend.scenario_service.domain.exception.ScenarioNotFoundException;
+import com.renewsim.backend.shared.domain.vo.ClimateData;
+import com.renewsim.backend.shared.domain.vo.Money;
+import com.renewsim.backend.simulation_service.shared.application.port.out.ScenarioLookupPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ScenarioLookupJpaAdapterTest {
+
+    @Mock
+    private GetScenarioUseCase getScenarioUseCase;
+
+    @InjectMocks
+    private ScenarioLookupJpaAdapter adapter;
+
+    @Test
+    @DisplayName("findActiveScenarioById maps the active scenario snapshot")
+    void findActiveScenarioByIdMapsTheActiveScenarioSnapshot() {
+        when(getScenarioUseCase.getScenarioById(any(GetScenarioByIdCommand.class))).thenReturn(new ScenarioResponseDTO(
+                7L,
+                "Hogar solar - Sevilla",
+                "Scenario description",
+                1L,
+                5.0,
+                new Money(new BigDecimal("12000.00"), "EUR"),
+                0.15,
+                6000.0,
+                new ClimateData(5.4, 3.1, 18.0),
+                true));
+
+        Optional<ScenarioLookupPort.ScenarioSnapshot> result = adapter.findActiveScenarioById(7L);
+
+        assertThat(result).isPresent();
+        assertThat(result.orElseThrow()).isEqualTo(new ScenarioLookupPort.ScenarioSnapshot(
+                7L,
+                "Hogar solar - Sevilla",
+                1L,
+                5.0,
+                12000.0,
+                "EUR",
+                0.15,
+                6000.0));
+    }
+
+    @Test
+    @DisplayName("findActiveScenarioById returns empty when the scenario does not exist or is inactive")
+    void findActiveScenarioByIdReturnsEmptyWhenTheScenarioDoesNotExistOrIsInactive() {
+        when(getScenarioUseCase.getScenarioById(any(GetScenarioByIdCommand.class)))
+                .thenThrow(new ScenarioNotFoundException(7L));
+
+        assertThat(adapter.findActiveScenarioById(7L)).isEmpty();
+    }
+}


### PR DESCRIPTION
## What changed
- Adds controller coverage for `POST /api/v1/simulations/from-scenario`
- Adds adapter coverage for `ScenarioLookupJpaAdapter`
- Closes the remaining external contract gaps around the new scenario flow

## Why
Closes #176. This is the final review slice that locks the HTTP contract and the scenario lookup adapter behavior after the core implementation and acceptance tests land.

## Validation
- `mvn -Dtest=CreateSimulationControllerTest,ScenarioLookupJpaAdapterTest test`

## Chain Context
- Strategy: stacked PRs to `dev/v1.2.0`
- Depends on: #180
- Current slice: 📍 PR 5 of 5
- Next: none

```text
PR1 #177 refactor/simulation-phase7-persistence-contract
└─ PR2 #178 refactor/simulation-phase7-technology-ids
   └─ PR3 #179 feat/simulation-phase7-scenario-core
      └─ PR4 #180 test/simulation-phase7-scenario-acceptance
         └─ PR5 test/simulation-phase7-scenario-contract 📍
```