### PR TITLE
feat(simulation): align manual creation contract with energyType model

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 
 @Service
@@ -52,6 +53,11 @@ public class CreateSimulationService implements CreateRealSimulationUseCase {
     }
 
     private void validateTechnologyIds(Technology technology, List<Long> technologyIds) {
+        if (new LinkedHashSet<>(technologyIds).size() != technologyIds.size()) {
+            throw new InvalidSimulationTechnologyException(
+                    "DUPLICATE_TECHNOLOGY_IDS: technologyIds must not contain duplicates");
+        }
+
         for (Long technologyId : technologyIds) {
             String technologyEnergyType = technologyLookupPort.findActiveEnergyTypeByTechnologyId(technologyId)
                     .orElseThrow(() -> new InvalidSimulationTechnologyException(

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
@@ -45,9 +45,25 @@ public class CreateSimulationService implements CreateRealSimulationUseCase {
 
     private List<Long> resolveTechnologyIds(CreateRealSimulationCommand command) {
         if (command.technologyIds() != null && !command.technologyIds().isEmpty()) {
+            validateTechnologyIds(command.technology(), command.technologyIds());
             return List.copyOf(command.technologyIds());
         }
         return technologyLookupPort.recommendActiveTechnologyIdsByEnergyType(command.technology().value());
+    }
+
+    private void validateTechnologyIds(Technology technology, List<Long> technologyIds) {
+        for (Long technologyId : technologyIds) {
+            String technologyEnergyType = technologyLookupPort.findActiveEnergyTypeByTechnologyId(technologyId)
+                    .orElseThrow(() -> new InvalidSimulationTechnologyException(
+                            "UNSUPPORTED_TECHNOLOGY_ID: '" + technologyId
+                                    + "' is not registered or is inactive in the technology catalog"));
+
+            if (!technology.value().equals(technologyEnergyType)) {
+                throw new InvalidSimulationTechnologyException(
+                        "INCOMPATIBLE_TECHNOLOGY_ID: '" + technologyId + "' does not belong to energyType '"
+                                + technology.value() + "'");
+            }
+        }
     }
 
     private void validateTechnology(Technology technology) {

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationController.java
@@ -5,8 +5,8 @@ import com.renewsim.backend.simulation_service.create.application.port.in.Create
 import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContext;
 import com.renewsim.backend.simulation_service.shared.web.SimulationDetailsWebMapper;
 import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContextFactory;
+import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationRequestDTO;
 import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationFromScenarioRequestDTO;
-import com.renewsim.backend.simulation_service.create.web.dto.CreateSolarSimulationRequestDTO;
 import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,42 +29,44 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Simulation Create API", description = "Create renewable energy simulations")
 public class CreateSimulationController {
 
-    private final CreateRealSimulationUseCase createRealSimulationUseCase;
-    private final CreateSimulationFromScenarioUseCase createSimulationFromScenarioUseCase;
-    private final CreateSimulationWebMapper createWebMapper = new CreateSimulationWebMapper();
-    private final CreateSimulationFromScenarioWebMapper createFromScenarioWebMapper = new CreateSimulationFromScenarioWebMapper();
-    private final SimulationDetailsWebMapper detailsWebMapper = new SimulationDetailsWebMapper();
-    private final SimulationRequestContextFactory requestContextFactory = new SimulationRequestContextFactory();
+        private final CreateRealSimulationUseCase createRealSimulationUseCase;
+        private final CreateSimulationFromScenarioUseCase createSimulationFromScenarioUseCase;
+        private final CreateSimulationWebMapper createWebMapper = new CreateSimulationWebMapper();
+        private final CreateSimulationFromScenarioWebMapper createFromScenarioWebMapper = new CreateSimulationFromScenarioWebMapper();
+        private final SimulationDetailsWebMapper detailsWebMapper = new SimulationDetailsWebMapper();
+        private final SimulationRequestContextFactory requestContextFactory = new SimulationRequestContextFactory();
 
-    @Operation(summary = "Create a new simulation")
-    @PreAuthorize("hasAuthority('SCOPE_write:simulations') or hasRole('ADMIN')")
-    @PostMapping
-    public ResponseEntity<SimulationDetailsResponseDTO> createSimulation(
-            @Valid @RequestBody CreateSolarSimulationRequestDTO request,
-            Authentication auth) {
+        @Operation(summary = "Create a new simulation")
+        @PreAuthorize("hasAuthority('SCOPE_write:simulations') or hasRole('ADMIN')")
+        @PostMapping
+        public ResponseEntity<SimulationDetailsResponseDTO> createSimulation(
+                        @Valid @RequestBody CreateSimulationRequestDTO request,
+                        Authentication auth) {
 
-        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+                SimulationRequestContext requestContext = requestContextFactory.from(auth);
 
-        SimulationDetailsResponseDTO result = detailsWebMapper.toWebDetails(
-                createRealSimulationUseCase.createSimulation(createWebMapper.toCommand(request, requestContext.username())));
-        log.info("User {} created simulation {}", requestContext.username(), result.id());
-        return ResponseEntity.status(HttpStatus.CREATED).body(result);
-    }
+                SimulationDetailsResponseDTO result = detailsWebMapper.toWebDetails(
+                                createRealSimulationUseCase.createSimulation(
+                                                createWebMapper.toCommand(request, requestContext.username())));
+                log.info("User {} created simulation {}", requestContext.username(), result.id());
+                return ResponseEntity.status(HttpStatus.CREATED).body(result);
+        }
 
-    @Operation(summary = "Create a simulation from a predefined scenario")
-    @PreAuthorize("hasAuthority('SCOPE_write:simulations') or hasRole('ADMIN')")
-    @PostMapping("/from-scenario")
-    public ResponseEntity<SimulationDetailsResponseDTO> createSimulationFromScenario(
-            @Valid @RequestBody CreateSimulationFromScenarioRequestDTO request,
-            Authentication auth) {
+        @Operation(summary = "Create a simulation from a predefined scenario")
+        @PreAuthorize("hasAuthority('SCOPE_write:simulations') or hasRole('ADMIN')")
+        @PostMapping("/from-scenario")
+        public ResponseEntity<SimulationDetailsResponseDTO> createSimulationFromScenario(
+                        @Valid @RequestBody CreateSimulationFromScenarioRequestDTO request,
+                        Authentication auth) {
 
-        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+                SimulationRequestContext requestContext = requestContextFactory.from(auth);
 
-        SimulationDetailsResponseDTO result = detailsWebMapper.toWebDetails(
-                createSimulationFromScenarioUseCase.createSimulationFromScenario(
-                        createFromScenarioWebMapper.toCommand(request, requestContext.username())));
-        log.info("User {} created simulation {} from scenario {}", requestContext.username(), result.id(),
-                request.scenarioId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(result);
-    }
+                SimulationDetailsResponseDTO result = detailsWebMapper.toWebDetails(
+                                createSimulationFromScenarioUseCase.createSimulationFromScenario(
+                                                createFromScenarioWebMapper.toCommand(request,
+                                                                requestContext.username())));
+                log.info("User {} created simulation {} from scenario {}", requestContext.username(), result.id(),
+                                request.scenarioId());
+                return ResponseEntity.status(HttpStatus.CREATED).body(result);
+        }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationWebMapper.java
@@ -9,46 +9,46 @@ import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomi
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
-import com.renewsim.backend.simulation_service.create.web.dto.CreateSolarSimulationRequestDTO;
+import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationRequestDTO;
 
 import java.util.List;
 
 public final class CreateSimulationWebMapper {
 
-    public CreateRealSimulationCommand toCommand(CreateSolarSimulationRequestDTO request, String username) {
-        return new CreateRealSimulationCommand(
-                request.name(),
-                Technology.solar(),
-                SimulationLocation.of(
-                        request.location().label(),
-                        request.location().lat(),
-                        request.location().lon(),
-                        request.location().country(),
-                        CountryCode.of(request.location().countryCode())),
-                new SimulationSystem(
-                        request.system().installedCapacityKw(),
-                        request.system().performanceRatio(),
-                        request.system().degradationRateAnnualPct(),
-                        request.system().availabilityPct(),
-                        new SimulationSystem.LossesPct(
-                                request.system().lossesPct().inverter(),
-                                request.system().lossesPct().temperature(),
-                                request.system().lossesPct().wiring(),
-                                request.system().lossesPct().soiling(),
-                                request.system().lossesPct().other())),
-                ConsumptionProfile.of(
-                        request.demand().annualConsumptionKwh(),
-                        request.demand().monthlyConsumptionKwh()),
-                new SimulationEconomics(
-                        Currency.of(request.economics().currency()),
-                        request.economics().capexTotal(),
-                        request.economics().opexAnnual(),
-                        request.economics().electricityPurchasePricePerKwh(),
-                        request.economics().exportPricePerKwh(),
-                        request.economics().discountRatePct(),
-                        ProjectLifetime.of(request.economics().projectLifetimeYears())),
-                List.of(),
-                null,
-                username);
-    }
+        public CreateRealSimulationCommand toCommand(CreateSimulationRequestDTO request, String username) {
+                return new CreateRealSimulationCommand(
+                                request.name(),
+                                Technology.of(request.energyType()),
+                                SimulationLocation.of(
+                                                request.location().label(),
+                                                request.location().lat(),
+                                                request.location().lon(),
+                                                request.location().country(),
+                                                CountryCode.of(request.location().countryCode())),
+                                new SimulationSystem(
+                                                request.system().installedCapacityKw(),
+                                                request.system().performanceRatio(),
+                                                request.system().degradationRateAnnualPct(),
+                                                request.system().availabilityPct(),
+                                                new SimulationSystem.LossesPct(
+                                                                request.system().lossesPct().inverter(),
+                                                                request.system().lossesPct().temperature(),
+                                                                request.system().lossesPct().wiring(),
+                                                                request.system().lossesPct().soiling(),
+                                                                request.system().lossesPct().other())),
+                                ConsumptionProfile.of(
+                                                request.demand().annualConsumptionKwh(),
+                                                request.demand().monthlyConsumptionKwh()),
+                                new SimulationEconomics(
+                                                Currency.of(request.economics().currency()),
+                                                request.economics().capexTotal(),
+                                                request.economics().opexAnnual(),
+                                                request.economics().electricityPurchasePricePerKwh(),
+                                                request.economics().exportPricePerKwh(),
+                                                request.economics().discountRatePct(),
+                                                ProjectLifetime.of(request.economics().projectLifetimeYears())),
+                                request.technologyIds() == null ? List.of() : List.copyOf(request.technologyIds()),
+                                null,
+                                username);
+        }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/CreateSimulationFromScenarioRequestDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/CreateSimulationFromScenarioRequestDTO.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CreateSimulationFromScenarioRequestDTO(
-        @NotNull Long scenarioId,
-        @Size(min = 2, max = 120) String name,
-        @NotNull @Valid CreateSolarSimulationRequestDTO.LocationDTO location) {
+                @NotNull Long scenarioId,
+                @Size(min = 2, max = 120) String name,
+                @NotNull @Valid SimulationLocationRequestDTO location) {
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/CreateSimulationRequestDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/CreateSimulationRequestDTO.java
@@ -19,7 +19,7 @@ public record CreateSimulationRequestDTO(
                 @NotNull @Valid SystemDTO system,
                 @NotNull @Valid DemandDTO demand,
                 @NotNull @Valid EconomicsDTO economics,
-                List<@Positive Long> technologyIds) {
+                @Size(max = 100) List<@NotNull @Positive Long> technologyIds) {
 
         public record SystemDTO(
                         @Positive double installedCapacityKw,

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/CreateSimulationRequestDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/CreateSimulationRequestDTO.java
@@ -12,22 +12,16 @@ import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
-public record CreateSolarSimulationRequestDTO(
+public record CreateSimulationRequestDTO(
                 @NotBlank @Size(min = 2, max = 120) String name,
-                @NotNull @Valid LocationDTO location,
-                @NotNull @Valid SolarSystemDTO system,
+                @NotBlank String energyType,
+                @NotNull @Valid SimulationLocationRequestDTO location,
+                @NotNull @Valid SystemDTO system,
                 @NotNull @Valid DemandDTO demand,
-                @NotNull @Valid EconomicsDTO economics) {
+                @NotNull @Valid EconomicsDTO economics,
+                List<@Positive Long> technologyIds) {
 
-        public record LocationDTO(
-                        @NotBlank String label,
-                        @DecimalMin(value = "-90.0") @DecimalMax(value = "90.0") double lat,
-                        @DecimalMin(value = "-180.0") @DecimalMax(value = "180.0") double lon,
-                        @NotBlank String country,
-                        @NotBlank String countryCode) {
-        }
-
-        public record SolarSystemDTO(
+        public record SystemDTO(
                         @Positive double installedCapacityKw,
                         @DecimalMin(value = "0.0", inclusive = false) @DecimalMax(value = "1.0") double performanceRatio,
                         @DecimalMin("0.0") @DecimalMax("5.0") double degradationRateAnnualPct,

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/SimulationLocationRequestDTO.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/dto/SimulationLocationRequestDTO.java
@@ -1,0 +1,13 @@
+package com.renewsim.backend.simulation_service.create.web.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+
+public record SimulationLocationRequestDTO(
+                @NotBlank String label,
+                @DecimalMin(value = "-90.0") @DecimalMax(value = "90.0") double lat,
+                @DecimalMin(value = "-180.0") @DecimalMax(value = "180.0") double lon,
+                @NotBlank String country,
+                @NotBlank String countryCode) {
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
@@ -46,317 +46,339 @@ import static org.mockito.Mockito.mock;
 @ExtendWith(MockitoExtension.class)
 class CreateSimulationFromScenarioServiceTest {
 
-    @Mock
-    private ScenarioLookupPort scenarioLookupPort;
-    @Mock
-    private TechnologyLookupPort technologyLookupPort;
-    @Mock
-    private SimulationRecordRepositoryPort repository;
-    @Mock
-    private PvgisSolarResourcePort resourcePort;
+        @Mock
+        private ScenarioLookupPort scenarioLookupPort;
+        @Mock
+        private TechnologyLookupPort technologyLookupPort;
+        @Mock
+        private SimulationRecordRepositoryPort repository;
+        @Mock
+        private PvgisSolarResourcePort resourcePort;
 
-    @Test
-    @DisplayName("createSimulationFromScenario resolves scenario defaults and delegates to the real flow")
-    void createSimulationFromScenarioResolvesScenarioDefaultsAndDelegates() {
-        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
-                scenarioLookupPort,
-                technologyLookupPort,
-                realCreateService());
+        @Test
+        @DisplayName("createSimulationFromScenario resolves scenario defaults and delegates to the real flow")
+        void createSimulationFromScenarioResolvesScenarioDefaultsAndDelegates() {
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService());
 
-        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
-        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
-        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
-        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
-        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
-        when(repository.save(any())).thenAnswer(invocation -> {
-            Simulation sim = invocation.getArgument(0);
-            if (sim.getId() == null) {
-                sim.assignId(SimulationId.of(60L));
-            }
-            return sim;
-        });
+                when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(2L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
+                                .thenReturn(List.of(1L, 2L));
+                when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+                when(repository.save(any())).thenAnswer(invocation -> {
+                        Simulation sim = invocation.getArgument(0);
+                        if (sim.getId() == null) {
+                                sim.assignId(SimulationId.of(60L));
+                        }
+                        return sim;
+                });
 
-        SimulationDetailsResult response = service.createSimulationFromScenario(
-                new CreateSimulationFromScenarioCommand(
-                        7L, null,
-                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES")),
-                        "alice"));
+                SimulationDetailsResult response = service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, null,
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain",
+                                                                CountryCode.of("ES")),
+                                                "alice"));
 
-        assertThat(response.id()).isEqualTo("60");
-        assertThat(response.input().technology()).isEqualTo("solar");
+                assertThat(response.id()).isEqualTo("60");
+                assertThat(response.input().technology()).isEqualTo("solar");
 
-        ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
-        verify(repository, atLeastOnce()).save(captor.capture());
-        Simulation persisted = captor.getAllValues().get(captor.getAllValues().size() - 1);
-        assertThat(persisted.getScenarioId()).isEqualTo(7L);
-        assertThat(persisted.getName()).isEqualTo("Hogar solar - Sevilla");
-        assertThat(persisted.getSystem().installedCapacityKw()).isEqualTo(5.0);
-        assertThat(persisted.getDemand().annualConsumptionKwh()).isEqualTo(6000.0);
-        assertThat(persisted.getEconomics().capexTotal()).isEqualTo(12000.0);
-        assertThat(persisted.getTechnologyIds()).containsExactly(1L, 2L);
-    }
+                ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
+                verify(repository, atLeastOnce()).save(captor.capture());
+                Simulation persisted = captor.getAllValues().get(captor.getAllValues().size() - 1);
+                assertThat(persisted.getScenarioId()).isEqualTo(7L);
+                assertThat(persisted.getName()).isEqualTo("Hogar solar - Sevilla");
+                assertThat(persisted.getSystem().installedCapacityKw()).isEqualTo(5.0);
+                assertThat(persisted.getDemand().annualConsumptionKwh()).isEqualTo(6000.0);
+                assertThat(persisted.getEconomics().capexTotal()).isEqualTo(12000.0);
+                assertThat(persisted.getTechnologyIds()).containsExactly(1L, 2L);
+        }
 
-    @Test
-    @DisplayName("createSimulationFromScenario keeps request name when provided")
-    void createSimulationFromScenarioKeepsRequestNameWhenProvided() {
-        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
-                scenarioLookupPort,
-                technologyLookupPort,
-                realCreateService());
+        @Test
+        @DisplayName("createSimulationFromScenario keeps request name when provided")
+        void createSimulationFromScenarioKeepsRequestNameWhenProvided() {
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService());
 
-        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
-        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
-        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
-        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
-        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
-        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+                when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(2L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
+                                .thenReturn(List.of(1L, 2L));
+                when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+                when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-        service.createSimulationFromScenario(
-                new CreateSimulationFromScenarioCommand(
-                        7L, "Mi simulacion personalizada",
-                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES")),
-                        "alice"));
+                service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, "Mi simulacion personalizada",
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain",
+                                                                CountryCode.of("ES")),
+                                                "alice"));
 
-        ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
-        verify(repository, atLeastOnce()).save(captor.capture());
-        assertThat(captor.getAllValues().get(captor.getAllValues().size() - 1).getName())
-                .isEqualTo("Mi simulacion personalizada");
-    }
+                ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
+                verify(repository, atLeastOnce()).save(captor.capture());
+                assertThat(captor.getAllValues().get(captor.getAllValues().size() - 1).getName())
+                                .isEqualTo("Mi simulacion personalizada");
+        }
 
-    @Test
-    @DisplayName("createSimulationFromScenario snapshots scenario defaults at creation time")
-    void createSimulationFromScenarioSnapshotsScenarioDefaultsAtCreationTime() {
-        JpaSimulationRepository jpaRepository = mock(JpaSimulationRepository.class);
-        SimulationRecordRepositoryPort persistenceRepository = inMemoryPersistenceRepository(jpaRepository);
-        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
-                scenarioLookupPort,
-                technologyLookupPort,
-                realCreateService(persistenceRepository));
+        @Test
+        @DisplayName("createSimulationFromScenario snapshots scenario defaults at creation time")
+        void createSimulationFromScenarioSnapshotsScenarioDefaultsAtCreationTime() {
+                JpaSimulationRepository jpaRepository = mock(JpaSimulationRepository.class);
+                SimulationRecordRepositoryPort persistenceRepository = inMemoryPersistenceRepository(jpaRepository);
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService(persistenceRepository));
 
-        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(
-                Optional.of(scenarioSnapshot()),
-                Optional.of(new ScenarioLookupPort.ScenarioSnapshot(
-                        7L, "Hogar solar - Sevilla", 1L,
-                        8.0, 18000.0, "USD", 0.21, 9000.0)));
-        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
-        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
-        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
-        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+                when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(
+                                Optional.of(scenarioSnapshot()),
+                                Optional.of(new ScenarioLookupPort.ScenarioSnapshot(
+                                                7L, "Hogar solar - Sevilla", 1L,
+                                                8.0, 18000.0, "USD", 0.21, 9000.0)));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(2L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
+                                .thenReturn(List.of(1L, 2L));
+                when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
 
-        SimulationDetailsResult firstResponse = service.createSimulationFromScenario(
-                new CreateSimulationFromScenarioCommand(
-                        7L, "Simulation 1",
-                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES")),
-                        "alice"));
-        service.createSimulationFromScenario(
-                new CreateSimulationFromScenarioCommand(
-                        7L, "Simulation 2",
-                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES")),
-                        "alice"));
+                SimulationDetailsResult firstResponse = service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, "Simulation 1",
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain",
+                                                                CountryCode.of("ES")),
+                                                "alice"));
+                service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, "Simulation 2",
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain",
+                                                                CountryCode.of("ES")),
+                                                "alice"));
 
-        Simulation firstSimulation = persistenceRepository.findById(Long.valueOf(firstResponse.id())).orElseThrow();
-        Simulation secondSimulation = persistenceRepository.findByCreatedByOrderByCreatedAtDesc("alice").stream()
-                .filter(simulation -> "Simulation 2".equals(simulation.getName()))
-                .findFirst()
-                .orElseThrow();
+                Simulation firstSimulation = persistenceRepository.findById(Long.valueOf(firstResponse.id()))
+                                .orElseThrow();
+                Simulation secondSimulation = persistenceRepository.findByCreatedByOrderByCreatedAtDesc("alice")
+                                .stream()
+                                .filter(simulation -> "Simulation 2".equals(simulation.getName()))
+                                .findFirst()
+                                .orElseThrow();
 
-        assertThat(firstSimulation.getSystem().installedCapacityKw()).isEqualTo(5.0);
-        assertThat(firstSimulation.getDemand().annualConsumptionKwh()).isEqualTo(6000.0);
-        assertThat(firstSimulation.getEconomics().capexTotal()).isEqualTo(12000.0);
-        assertThat(firstSimulation.getEconomics().currency().value()).isEqualTo("EUR");
+                assertThat(firstSimulation.getSystem().installedCapacityKw()).isEqualTo(5.0);
+                assertThat(firstSimulation.getDemand().annualConsumptionKwh()).isEqualTo(6000.0);
+                assertThat(firstSimulation.getEconomics().capexTotal()).isEqualTo(12000.0);
+                assertThat(firstSimulation.getEconomics().currency().value()).isEqualTo("EUR");
 
-        assertThat(secondSimulation.getSystem().installedCapacityKw()).isEqualTo(8.0);
-        assertThat(secondSimulation.getDemand().annualConsumptionKwh()).isEqualTo(9000.0);
-        assertThat(secondSimulation.getEconomics().capexTotal()).isEqualTo(18000.0);
-        assertThat(secondSimulation.getEconomics().currency().value()).isEqualTo("EUR");
-    }
+                assertThat(secondSimulation.getSystem().installedCapacityKw()).isEqualTo(8.0);
+                assertThat(secondSimulation.getDemand().annualConsumptionKwh()).isEqualTo(9000.0);
+                assertThat(secondSimulation.getEconomics().capexTotal()).isEqualTo(18000.0);
+                assertThat(secondSimulation.getEconomics().currency().value()).isEqualTo("EUR");
+        }
 
-    @Test
-    @DisplayName("createSimulationFromScenario falls back to the scenario name when request name is blank")
-    void createSimulationFromScenarioFallsBackToScenarioNameWhenRequestNameIsBlank() {
-        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
-                scenarioLookupPort,
-                technologyLookupPort,
-                realCreateService());
+        @Test
+        @DisplayName("createSimulationFromScenario falls back to the scenario name when request name is blank")
+        void createSimulationFromScenarioFallsBackToScenarioNameWhenRequestNameIsBlank() {
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService());
 
-        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
-        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
-        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
-        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
-        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
-        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+                when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(2L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
+                                .thenReturn(List.of(1L, 2L));
+                when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+                when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-        service.createSimulationFromScenario(
-                new CreateSimulationFromScenarioCommand(
-                        7L, "   ",
-                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES")),
-                        "alice"));
+                service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, "   ",
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain",
+                                                                CountryCode.of("ES")),
+                                                "alice"));
 
-        ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
-        verify(repository, atLeastOnce()).save(captor.capture());
-        assertThat(captor.getAllValues().get(captor.getAllValues().size() - 1).getName())
-                .isEqualTo("Hogar solar - Sevilla");
-    }
+                ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
+                verify(repository, atLeastOnce()).save(captor.capture());
+                assertThat(captor.getAllValues().get(captor.getAllValues().size() - 1).getName())
+                                .isEqualTo("Hogar solar - Sevilla");
+        }
 
-    @Test
-    @DisplayName("createSimulationFromScenario fails when scenario is missing or inactive")
-    void createSimulationFromScenarioFailsWhenScenarioMissing() {
-        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
-                scenarioLookupPort,
-                technologyLookupPort,
-                realCreateService());
+        @Test
+        @DisplayName("createSimulationFromScenario fails when scenario is missing or inactive")
+        void createSimulationFromScenarioFailsWhenScenarioMissing() {
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService());
 
-        when(scenarioLookupPort.findActiveScenarioById(99L)).thenReturn(Optional.empty());
+                when(scenarioLookupPort.findActiveScenarioById(99L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.createSimulationFromScenario(
-                new CreateSimulationFromScenarioCommand(
-                        99L, null,
-                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES")),
-                        "alice")))
-                .isInstanceOf(ScenarioNotFoundException.class);
+                assertThatThrownBy(() -> service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                99L, null,
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain",
+                                                                CountryCode.of("ES")),
+                                                "alice")))
+                                .isInstanceOf(ScenarioNotFoundException.class);
 
-        verify(technologyLookupPort, never()).findActiveEnergyTypeByTechnologyId(any());
-        verify(repository, never()).save(any());
-    }
+                verify(technologyLookupPort, never()).findActiveEnergyTypeByTechnologyId(any());
+                verify(repository, never()).save(any());
+        }
 
-    @Test
-    @DisplayName("createSimulationFromScenario fails when the scenario technology is not active")
-    void createSimulationFromScenarioFailsWhenScenarioTechnologyIsNotActive() {
-        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
-                scenarioLookupPort,
-                technologyLookupPort,
-                realCreateService());
+        @Test
+        @DisplayName("createSimulationFromScenario fails when the scenario technology is not active")
+        void createSimulationFromScenarioFailsWhenScenarioTechnologyIsNotActive() {
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService());
 
-        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
-        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.empty());
+                when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.createSimulationFromScenario(
-                new CreateSimulationFromScenarioCommand(
-                        7L, null,
-                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES")),
-                        "alice")))
-                .isInstanceOf(ScenarioNotFoundException.class);
+                assertThatThrownBy(() -> service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, null,
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain",
+                                                                CountryCode.of("ES")),
+                                                "alice")))
+                                .isInstanceOf(ScenarioNotFoundException.class);
 
-        verify(repository, never()).save(any());
-    }
+                verify(repository, never()).save(any());
+        }
 
-    @Test
-    @DisplayName("createSimulationFromScenario fails when the scenario consumption is not positive")
-    void createSimulationFromScenarioFailsWhenScenarioConsumptionIsNotPositive() {
-        CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
-                scenarioLookupPort,
-                technologyLookupPort,
-                realCreateService());
+        @Test
+        @DisplayName("createSimulationFromScenario fails when the scenario consumption is not positive")
+        void createSimulationFromScenarioFailsWhenScenarioConsumptionIsNotPositive() {
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService());
 
-        when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(
-                new ScenarioLookupPort.ScenarioSnapshot(7L, "Hogar solar - Sevilla", 1L,
-                        5.0, 12000.0, "EUR", 0.15, 0.0)));
-        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
-        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
+                when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(
+                                new ScenarioLookupPort.ScenarioSnapshot(7L, "Hogar solar - Sevilla", 1L,
+                                                5.0, 12000.0, "EUR", 0.15, 0.0)));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
+                                .thenReturn(List.of(1L, 2L));
 
-        assertThatThrownBy(() -> service.createSimulationFromScenario(
-                new CreateSimulationFromScenarioCommand(
-                        7L, null,
-                        SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES")),
-                        "alice")))
-                .isInstanceOf(InvalidConsumptionProfileException.class)
-                .hasMessage("VALIDATION_ERROR: scenario defaultConsumption must be positive");
+                assertThatThrownBy(() -> service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, null,
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain",
+                                                                CountryCode.of("ES")),
+                                                "alice")))
+                                .isInstanceOf(InvalidConsumptionProfileException.class)
+                                .hasMessage("VALIDATION_ERROR: scenario defaultConsumption must be positive");
 
-        verify(repository, never()).save(any());
-    }
+                verify(repository, never()).save(any());
+        }
 
-    private CreateRealSimulationUseCase realCreateService() {
-        return realCreateService(repository);
-    }
+        private CreateRealSimulationUseCase realCreateService() {
+                return realCreateService(repository);
+        }
 
-    private CreateRealSimulationUseCase realCreateService(SimulationRecordRepositoryPort simulationRepository) {
-        return new CreateSimulationService(
-                simulationRepository,
-                technologyLookupPort,
-                List.of(
-                        new SolarSimulationEngine(resourcePort, new SolarSimulationAssessmentPolicy()),
-                        new WindSimulationEngine(),
-                        new HydroSimulationEngine()),
-                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
-    }
+        private CreateRealSimulationUseCase realCreateService(SimulationRecordRepositoryPort simulationRepository) {
+                return new CreateSimulationService(
+                                simulationRepository,
+                                technologyLookupPort,
+                                List.of(
+                                                new SolarSimulationEngine(resourcePort,
+                                                                new SolarSimulationAssessmentPolicy()),
+                                                new WindSimulationEngine(),
+                                                new HydroSimulationEngine()),
+                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+        }
 
-    private SimulationRecordRepositoryPort inMemoryPersistenceRepository(JpaSimulationRepository jpaRepository) {
-        Map<Long, SimulationEntity> store = new HashMap<>();
-        AtomicLong sequence = new AtomicLong(60L);
+        private SimulationRecordRepositoryPort inMemoryPersistenceRepository(JpaSimulationRepository jpaRepository) {
+                Map<Long, SimulationEntity> store = new HashMap<>();
+                AtomicLong sequence = new AtomicLong(60L);
 
-        when(jpaRepository.save(any(SimulationEntity.class))).thenAnswer(invocation -> {
-            SimulationEntity entity = invocation.getArgument(0);
-            SimulationEntity stored = copyEntity(entity);
-            if (stored.getId() == null) {
-                stored.setId(sequence.getAndIncrement());
-            }
-            store.put(stored.getId(), stored);
-            return copyEntity(stored);
-        });
-        when(jpaRepository.findById(any(Long.class))).thenAnswer(invocation -> {
-            Long id = invocation.getArgument(0);
-            SimulationEntity stored = store.get(id);
-            return Optional.ofNullable(stored == null ? null : copyEntity(stored));
-        });
-        when(jpaRepository.findByCreatedByOrderByCreatedAtDesc("alice")).thenAnswer(invocation ->
-                store.values().stream()
-                        .filter(entity -> "alice".equals(entity.getCreatedBy()))
-                        .sorted((left, right) -> right.getCreatedAt().compareTo(left.getCreatedAt()))
-                        .map(this::copyEntity)
-                        .toList());
+                when(jpaRepository.save(any(SimulationEntity.class))).thenAnswer(invocation -> {
+                        SimulationEntity entity = invocation.getArgument(0);
+                        SimulationEntity stored = copyEntity(entity);
+                        if (stored.getId() == null) {
+                                stored.setId(sequence.getAndIncrement());
+                        }
+                        store.put(stored.getId(), stored);
+                        return copyEntity(stored);
+                });
+                when(jpaRepository.findById(any(Long.class))).thenAnswer(invocation -> {
+                        Long id = invocation.getArgument(0);
+                        SimulationEntity stored = store.get(id);
+                        return Optional.ofNullable(stored == null ? null : copyEntity(stored));
+                });
+                when(jpaRepository.findByCreatedByOrderByCreatedAtDesc("alice")).thenAnswer(invocation -> store.values()
+                                .stream()
+                                .filter(entity -> "alice".equals(entity.getCreatedBy()))
+                                .sorted((left, right) -> right.getCreatedAt().compareTo(left.getCreatedAt()))
+                                .map(this::copyEntity)
+                                .toList());
 
-        return new SimulationRecordRepositoryAdapter(jpaRepository, new ObjectMapper().findAndRegisterModules());
-    }
+                return new SimulationRecordRepositoryAdapter(jpaRepository,
+                                new ObjectMapper().findAndRegisterModules());
+        }
 
-    private SimulationEntity copyEntity(SimulationEntity source) {
-        SimulationEntity copy = new SimulationEntity();
-        copy.setId(source.getId());
-        copy.setName(source.getName());
-        copy.setLocation(source.getLocation());
-        copy.setEnergyType(source.getEnergyType());
-        copy.setLocationLat(source.getLocationLat());
-        copy.setLocationLng(source.getLocationLng());
-        copy.setProjectSize(source.getProjectSize());
-        copy.setBudget(source.getBudget());
-        copy.setEstimatedEnergy(source.getEstimatedEnergy());
-        copy.setClimateData(source.getClimateData());
-        copy.setCreatedBy(source.getCreatedBy());
-        copy.setCreatedAt(source.getCreatedAt());
-        copy.setUpdatedAt(source.getUpdatedAt());
-        copy.setStatus(source.getStatus());
-        copy.setAnnualSavings(source.getAnnualSavings());
-        copy.setNpv(source.getNpv());
-        copy.setIrrPct(source.getIrrPct());
-        copy.setRecommendation(source.getRecommendation());
-        copy.setScenarioId(source.getScenarioId());
-        copy.setInputSnapshot(source.getInputSnapshot());
-        copy.setResultSnapshot(source.getResultSnapshot());
-        copy.setTechnologyIds(source.getTechnologyIds() == null ? List.of() : List.copyOf(source.getTechnologyIds()));
-        return copy;
-    }
+        private SimulationEntity copyEntity(SimulationEntity source) {
+                SimulationEntity copy = new SimulationEntity();
+                copy.setId(source.getId());
+                copy.setName(source.getName());
+                copy.setLocation(source.getLocation());
+                copy.setEnergyType(source.getEnergyType());
+                copy.setLocationLat(source.getLocationLat());
+                copy.setLocationLng(source.getLocationLng());
+                copy.setProjectSize(source.getProjectSize());
+                copy.setBudget(source.getBudget());
+                copy.setEstimatedEnergy(source.getEstimatedEnergy());
+                copy.setClimateData(source.getClimateData());
+                copy.setCreatedBy(source.getCreatedBy());
+                copy.setCreatedAt(source.getCreatedAt());
+                copy.setUpdatedAt(source.getUpdatedAt());
+                copy.setStatus(source.getStatus());
+                copy.setAnnualSavings(source.getAnnualSavings());
+                copy.setNpv(source.getNpv());
+                copy.setIrrPct(source.getIrrPct());
+                copy.setRecommendation(source.getRecommendation());
+                copy.setScenarioId(source.getScenarioId());
+                copy.setInputSnapshot(source.getInputSnapshot());
+                copy.setResultSnapshot(source.getResultSnapshot());
+                copy.setTechnologyIds(
+                                source.getTechnologyIds() == null ? List.of() : List.copyOf(source.getTechnologyIds()));
+                return copy;
+        }
 
-    private ScenarioLookupPort.ScenarioSnapshot scenarioSnapshot() {
-        return new ScenarioLookupPort.ScenarioSnapshot(
-                7L, "Hogar solar - Sevilla", 1L,
-                5.0, 12000.0, "USD", 0.15, 6000.0);
-    }
+        private ScenarioLookupPort.ScenarioSnapshot scenarioSnapshot() {
+                return new ScenarioLookupPort.ScenarioSnapshot(
+                                7L, "Hogar solar - Sevilla", 1L,
+                                5.0, 12000.0, "USD", 0.15, 6000.0);
+        }
 
-    private PvgisSolarResourcePort.PvgisSolarResourceProfile profile() {
-        return new PvgisSolarResourcePort.PvgisSolarResourceProfile(
-                List.of(117.91, 117.78, 140.16, 142.40, 155.64, 154.71, 164.37, 161.96, 145.57, 132.00,
-                        112.14, 112.69),
-                List.of(144.21, 146.57, 177.98, 185.86, 208.58, 212.34, 230.04, 226.42, 197.02, 172.86,
-                        140.05, 137.50),
-                List.of(10.0, 12.0, 15.0, 17.0, 22.0, 27.0, 31.0, 31.0, 27.0, 21.0, 15.0, 11.0),
-                "2005-2020",
-                "PVGIS");
-    }
+        private PvgisSolarResourcePort.PvgisSolarResourceProfile profile() {
+                return new PvgisSolarResourcePort.PvgisSolarResourceProfile(
+                                List.of(117.91, 117.78, 140.16, 142.40, 155.64, 154.71, 164.37, 161.96, 145.57, 132.00,
+                                                112.14, 112.69),
+                                List.of(144.21, 146.57, 177.98, 185.86, 208.58, 212.34, 230.04, 226.42, 197.02, 172.86,
+                                                140.05, 137.50),
+                                List.of(10.0, 12.0, 15.0, 17.0, 22.0, 27.0, 31.0, 31.0, 27.0, 21.0, 15.0, 11.0),
+                                "2005-2020",
+                                "PVGIS");
+        }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
@@ -177,6 +177,35 @@ class RealSimulationServiceTest {
         }
 
         @Test
+        @DisplayName("createSimulation rejects caller supplied technology ids that are duplicated")
+        void createSimulationRejectsCallerSuppliedTechnologyIdsThatAreDuplicated() {
+                CreateSimulationService service = new CreateSimulationService(
+                                repository,
+                                technologyLookupPort,
+                                engines(),
+                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+
+                CreateRealSimulationCommand command = new CreateRealSimulationCommand(
+                                validCommand().name(),
+                                validCommand().technology(),
+                                validCommand().location(),
+                                validCommand().system(),
+                                validCommand().demand(),
+                                validCommand().economics(),
+                                List.of(11L, 11L),
+                                null,
+                                validCommand().createdBy());
+
+                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+
+                assertThatThrownBy(() -> service.createSimulation(command))
+                                .isInstanceOf(BadRequestException.class)
+                                .hasMessage("DUPLICATE_TECHNOLOGY_IDS: technologyIds must not contain duplicates");
+
+                verify(repository, never()).save(any());
+        }
+
+        @Test
         @DisplayName("getSimulationById enforces ownership for non admins")
         void getSimulationByIdEnforcesOwnership() throws Exception {
                 GetSimulationService service = new GetSimulationService(repository,

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
@@ -63,7 +63,8 @@ class RealSimulationServiceTest {
                 CreateRealSimulationCommand command = validCommand();
 
                 when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
-                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
+                                .thenReturn(List.of(1L, 2L));
                 when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
                 when(repository.save(any())).thenAnswer(invocation -> {
                         Simulation sim = invocation.getArgument(0);
@@ -111,6 +112,66 @@ class RealSimulationServiceTest {
                 assertThatThrownBy(() -> service.createSimulation(command))
                                 .isInstanceOf(BadRequestException.class)
                                 .hasMessage("UNSUPPORTED_TECHNOLOGY: 'wind' simulation is not implemented yet");
+
+                verify(repository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("createSimulation rejects caller supplied technology ids that are inactive")
+        void createSimulationRejectsCallerSuppliedTechnologyIdsThatAreInactive() {
+                CreateSimulationService service = new CreateSimulationService(
+                                repository,
+                                technologyLookupPort,
+                                engines(),
+                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+
+                CreateRealSimulationCommand command = new CreateRealSimulationCommand(
+                                validCommand().name(),
+                                validCommand().technology(),
+                                validCommand().location(),
+                                validCommand().system(),
+                                validCommand().demand(),
+                                validCommand().economics(),
+                                List.of(99L),
+                                null,
+                                validCommand().createdBy());
+
+                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(99L)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.createSimulation(command))
+                                .isInstanceOf(BadRequestException.class)
+                                .hasMessage("UNSUPPORTED_TECHNOLOGY_ID: '99' is not registered or is inactive in the technology catalog");
+
+                verify(repository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("createSimulation rejects caller supplied technology ids that do not match the simulation energy type")
+        void createSimulationRejectsCallerSuppliedTechnologyIdsThatDoNotMatchTheSimulationEnergyType() {
+                CreateSimulationService service = new CreateSimulationService(
+                                repository,
+                                technologyLookupPort,
+                                engines(),
+                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+
+                CreateRealSimulationCommand command = new CreateRealSimulationCommand(
+                                validCommand().name(),
+                                validCommand().technology(),
+                                validCommand().location(),
+                                validCommand().system(),
+                                validCommand().demand(),
+                                validCommand().economics(),
+                                List.of(15L),
+                                null,
+                                validCommand().createdBy());
+
+                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(15L)).thenReturn(Optional.of("wind"));
+
+                assertThatThrownBy(() -> service.createSimulation(command))
+                                .isInstanceOf(BadRequestException.class)
+                                .hasMessage("INCOMPATIBLE_TECHNOLOGY_ID: '15' does not belong to energyType 'solar'");
 
                 verify(repository, never()).save(any());
         }

--- a/src/test/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationControllerTest.java
@@ -7,8 +7,9 @@ import com.renewsim.backend.auth_service.infrastructure.security.LoginRateLimiti
 import com.renewsim.backend.config.TestSecurityConfig;
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateSimulationFromScenarioUseCase;
+import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationRequestDTO;
 import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationFromScenarioRequestDTO;
-import com.renewsim.backend.simulation_service.create.web.dto.CreateSolarSimulationRequestDTO;
+import com.renewsim.backend.simulation_service.create.web.dto.SimulationLocationRequestDTO;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletRequest;
@@ -44,97 +45,183 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(TestSecurityConfig.class)
 class CreateSimulationControllerTest {
 
-    private static final String AUTHORIZED_TOKEN = "authorized-token";
-    private static final String ROLE_ONLY_TOKEN = "role-only-token";
+        private static final String AUTHORIZED_TOKEN = "authorized-token";
+        private static final String ROLE_ONLY_TOKEN = "role-only-token";
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+        @Autowired
+        private ObjectMapper objectMapper;
 
-    @MockitoBean
-    private JwtTokenProvider jwtTokenProvider;
+        @MockitoBean
+        private JwtTokenProvider jwtTokenProvider;
 
-    @MockitoBean
-    private LoginRateLimitingFilter loginRateLimitingFilter;
+        @MockitoBean
+        private LoginRateLimitingFilter loginRateLimitingFilter;
 
-    @MockitoBean
-    private CreateRealSimulationUseCase createRealSimulationUseCase;
+        @MockitoBean
+        private CreateRealSimulationUseCase createRealSimulationUseCase;
 
-    @MockitoBean
-    private CreateSimulationFromScenarioUseCase createSimulationFromScenarioUseCase;
+        @MockitoBean
+        private CreateSimulationFromScenarioUseCase createSimulationFromScenarioUseCase;
 
-    @BeforeEach
-    void setUp() throws Exception {
-        doAnswer(invocation -> {
-            invocation.getArgument(0, ServletRequest.class);
-            invocation.getArgument(1, ServletResponse.class);
-            invocation.getArgument(2, FilterChain.class).doFilter(
-                    invocation.getArgument(0), invocation.getArgument(1));
-            return null;
-        }).when(loginRateLimitingFilter).doFilter(any(), any(), any());
+        @BeforeEach
+        void setUp() throws Exception {
+                doAnswer(invocation -> {
+                        invocation.getArgument(0, ServletRequest.class);
+                        invocation.getArgument(1, ServletResponse.class);
+                        invocation.getArgument(2, FilterChain.class).doFilter(
+                                        invocation.getArgument(0), invocation.getArgument(1));
+                        return null;
+                }).when(loginRateLimitingFilter).doFilter(any(), any(), any());
 
-        when(jwtTokenProvider.validate(AUTHORIZED_TOKEN))
-                .thenReturn(Optional.of(new AuthenticatedUser(
-                        "alice",
-                        Set.of("USER"),
-                        Set.of("write:simulations", "read:simulations"))));
+                when(jwtTokenProvider.validate(AUTHORIZED_TOKEN))
+                                .thenReturn(Optional.of(new AuthenticatedUser(
+                                                "alice",
+                                                Set.of("USER"),
+                                                Set.of("write:simulations", "read:simulations"))));
 
-        when(jwtTokenProvider.validate(ROLE_ONLY_TOKEN))
-                .thenReturn(Optional.of(new AuthenticatedUser(
-                        "bob",
-                        Set.of("USER"),
-                        Set.of("read:simulations"))));
-    }
+                when(jwtTokenProvider.validate(ROLE_ONLY_TOKEN))
+                                .thenReturn(Optional.of(new AuthenticatedUser(
+                                                "bob",
+                                                Set.of("USER"),
+                                                Set.of("read:simulations"))));
+        }
 
-    @Test
-    @DisplayName("createSimulationFromScenario returns 201 for a user with write scope")
-    void createSimulationFromScenarioReturns201ForUserWithWriteScope() throws Exception {
-        when(createSimulationFromScenarioUseCase.createSimulationFromScenario(any())).thenReturn(sampleResult());
+        @Test
+        @DisplayName("createSimulation returns 201 for a user with write scope")
+        void createSimulationReturns201ForUserWithWriteScope() throws Exception {
+                when(createRealSimulationUseCase.createSimulation(any())).thenReturn(sampleResult());
 
-        mockMvc.perform(post("/api/v1/simulations/from-scenario")
-                        .header(HttpHeaders.AUTHORIZATION, bearer(AUTHORIZED_TOKEN))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new CreateSimulationFromScenarioRequestDTO(
-                                7L,
-                                null,
-                                new CreateSolarSimulationRequestDTO.LocationDTO(
-                                        "Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", "ES")))))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value("55"))
-                .andExpect(jsonPath("$.technical.annualGenerationKwh").value(457200));
+                mockMvc.perform(post("/api/v1/simulations")
+                                .header(HttpHeaders.AUTHORIZATION, bearer(AUTHORIZED_TOKEN))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(new CreateSimulationRequestDTO(
+                                                "Solar - Sevilla",
+                                                "solar",
+                                                new SimulationLocationRequestDTO(
+                                                                "Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                                                "ES"),
+                                                new CreateSimulationRequestDTO.SystemDTO(
+                                                                300, 0.81, 0.5, 99,
+                                                                new CreateSimulationRequestDTO.LossesPctDTO(2, 6, 1, 3,
+                                                                                1)),
+                                                new CreateSimulationRequestDTO.DemandDTO(
+                                                                120000,
+                                                                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
+                                                                                10000d, 10000d, 10000d, 10000d, 10000d,
+                                                                                10000d)),
+                                                new CreateSimulationRequestDTO.EconomicsDTO(
+                                                                "EUR", 315000, 7200, 0.18, 0.07, 8, 20),
+                                                List.of(11L, 12L)))))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$.id").value("55"));
 
-        verify(createSimulationFromScenarioUseCase).createSimulationFromScenario(any());
-    }
+                verify(createRealSimulationUseCase).createSimulation(any());
+        }
 
-    @Test
-    @DisplayName("createSimulationFromScenario returns 403 for a role-only user without write scope")
-    void createSimulationFromScenarioReturns403ForRoleOnlyUserWithoutWriteScope() throws Exception {
-        mockMvc.perform(post("/api/v1/simulations/from-scenario")
-                        .header(HttpHeaders.AUTHORIZATION, bearer(ROLE_ONLY_TOKEN))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new CreateSimulationFromScenarioRequestDTO(
-                                7L,
-                                null,
-                                new CreateSolarSimulationRequestDTO.LocationDTO(
-                                        "Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", "ES")))))
-                .andExpect(status().isForbidden());
-    }
+        @Test
+        @DisplayName("createSimulation returns 403 for a role-only user without write scope")
+        void createSimulationReturns403ForRoleOnlyUserWithoutWriteScope() throws Exception {
+                mockMvc.perform(post("/api/v1/simulations")
+                                .header(HttpHeaders.AUTHORIZATION, bearer(ROLE_ONLY_TOKEN))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(new CreateSimulationRequestDTO(
+                                                "Solar - Sevilla",
+                                                "solar",
+                                                new SimulationLocationRequestDTO(
+                                                                "Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                                                "ES"),
+                                                new CreateSimulationRequestDTO.SystemDTO(
+                                                                300, 0.81, 0.5, 99,
+                                                                new CreateSimulationRequestDTO.LossesPctDTO(2, 6, 1, 3,
+                                                                                1)),
+                                                new CreateSimulationRequestDTO.DemandDTO(
+                                                                120000,
+                                                                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
+                                                                                10000d, 10000d, 10000d, 10000d, 10000d,
+                                                                                10000d)),
+                                                new CreateSimulationRequestDTO.EconomicsDTO(
+                                                                "EUR", 315000, 7200, 0.18, 0.07, 8, 20),
+                                                List.of(11L, 12L)))))
+                                .andExpect(status().isForbidden());
+        }
 
-    private static String bearer(String token) {
-        return "Bearer " + token;
-    }
+        @Test
+        @DisplayName("createSimulationFromScenario returns 201 for a user with write scope")
+        void createSimulationFromScenarioReturns201ForUserWithWriteScope() throws Exception {
+                when(createSimulationFromScenarioUseCase.createSimulationFromScenario(any()))
+                                .thenReturn(sampleResult());
 
-    private SimulationDetailsResult sampleResult() {
-        return new SimulationDetailsResult(
-                "55", "completed", "2026-06-30T14:00:00Z", "2026-06-30T14:00:00Z", "solar-spain-v1", "solar",
-                new SimulationDetailsResult.ResolvedLocation("Sevilla, Andalucia, ES", "Sevilla", "Andalucia", "Spain", "ES", 37.3891, -5.9845, "Europe/Madrid"),
-                new SimulationDetailsResult.Summary("viable_with_reservations", "headline", "summary", List.of(new SimulationDetailsResult.RecommendationReason("resource", "positive", "msg"))),
-                new SimulationDetailsResult.Input("Solar - Sevilla", "solar", new SimulationDetailsResult.Location("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", "ES"), new SimulationDetailsResult.SystemSpec(300, 0.81, 0.5, 99, new SimulationDetailsResult.LossesPct(2, 6, 1, 3, 1)), new SimulationDetailsResult.Demand(120000, List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d)), new SimulationDetailsResult.Economics("EUR", 315000, 7200, 0.18, 0.07, 8, 20)),
-                new SimulationDetailsResult.Technical(457200, List.of(24800d, 29100d), 1524, 0.81, 17.4, 72.3, 31.5, new SimulationDetailsResult.ResourceSeries("PVGIS", "2005-2020", List.of(71d), List.of(10d)), new SimulationDetailsResult.LossesSummary(2, 6, 1, 3, 1, 13), List.of(new SimulationDetailsResult.MonthlyEnergyBalanceItem("Jan", 24800, 10000, 10000, 14800, 0))),
-                new SimulationDetailsResult.Financial("EUR", 68700, 8800, 70300, 6.9, 8.7, 121500, 11.4, 0.071, List.of(new SimulationDetailsResult.FinancialYearItem(0, 0, 0, 0, 0, -315000, -315000, -315000))),
-                new SimulationDetailsResult.Assumptions(8, 20, 0.5, 0.18, 0.07, "PVGIS", "2005-2020"),
-                List.of(new SimulationDetailsResult.SimulationWarning("info", "MONTHLY_PROFILE_USER_SUPPLIED", "warning")));
-    }
+                mockMvc.perform(post("/api/v1/simulations/from-scenario")
+                                .header(HttpHeaders.AUTHORIZATION, bearer(AUTHORIZED_TOKEN))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(new CreateSimulationFromScenarioRequestDTO(
+                                                7L,
+                                                null,
+                                                new SimulationLocationRequestDTO(
+                                                                "Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                                                "ES")))))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$.id").value("55"))
+                                .andExpect(jsonPath("$.technical.annualGenerationKwh").value(457200));
+
+                verify(createSimulationFromScenarioUseCase).createSimulationFromScenario(any());
+        }
+
+        @Test
+        @DisplayName("createSimulationFromScenario returns 403 for a role-only user without write scope")
+        void createSimulationFromScenarioReturns403ForRoleOnlyUserWithoutWriteScope() throws Exception {
+                mockMvc.perform(post("/api/v1/simulations/from-scenario")
+                                .header(HttpHeaders.AUTHORIZATION, bearer(ROLE_ONLY_TOKEN))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(new CreateSimulationFromScenarioRequestDTO(
+                                                7L,
+                                                null,
+                                                new SimulationLocationRequestDTO(
+                                                                "Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                                                "ES")))))
+                                .andExpect(status().isForbidden());
+        }
+
+        private static String bearer(String token) {
+                return "Bearer " + token;
+        }
+
+        private SimulationDetailsResult sampleResult() {
+                return new SimulationDetailsResult(
+                                "55", "completed", "2026-06-30T14:00:00Z", "2026-06-30T14:00:00Z", "solar-spain-v1",
+                                "solar",
+                                new SimulationDetailsResult.ResolvedLocation("Sevilla, Andalucia, ES", "Sevilla",
+                                                "Andalucia", "Spain", "ES", 37.3891, -5.9845, "Europe/Madrid"),
+                                new SimulationDetailsResult.Summary("viable_with_reservations", "headline", "summary",
+                                                List.of(new SimulationDetailsResult.RecommendationReason("resource",
+                                                                "positive", "msg"))),
+                                new SimulationDetailsResult.Input("Solar - Sevilla", "solar",
+                                                new SimulationDetailsResult.Location("Sevilla, Andalucia, ES", 37.3891,
+                                                                -5.9845, "Spain", "ES"),
+                                                new SimulationDetailsResult.SystemSpec(300, 0.81, 0.5, 99,
+                                                                new SimulationDetailsResult.LossesPct(2, 6, 1, 3, 1)),
+                                                new SimulationDetailsResult.Demand(120000,
+                                                                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
+                                                                                10000d, 10000d, 10000d, 10000d, 10000d,
+                                                                                10000d)),
+                                                new SimulationDetailsResult.Economics("EUR", 315000, 7200, 0.18, 0.07,
+                                                                8, 20)),
+                                new SimulationDetailsResult.Technical(457200, List.of(24800d, 29100d), 1524, 0.81, 17.4,
+                                                72.3, 31.5,
+                                                new SimulationDetailsResult.ResourceSeries("PVGIS", "2005-2020",
+                                                                List.of(71d), List.of(10d)),
+                                                new SimulationDetailsResult.LossesSummary(2, 6, 1, 3, 1, 13),
+                                                List.of(new SimulationDetailsResult.MonthlyEnergyBalanceItem("Jan",
+                                                                24800, 10000, 10000, 14800, 0))),
+                                new SimulationDetailsResult.Financial("EUR", 68700, 8800, 70300, 6.9, 8.7, 121500, 11.4,
+                                                0.071,
+                                                List.of(new SimulationDetailsResult.FinancialYearItem(0, 0, 0, 0, 0,
+                                                                -315000, -315000, -315000))),
+                                new SimulationDetailsResult.Assumptions(8, 20, 0.5, 0.18, 0.07, "PVGIS", "2005-2020"),
+                                List.of(new SimulationDetailsResult.SimulationWarning("info",
+                                                "MONTHLY_PROFILE_USER_SUPPLIED", "warning")));
+        }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationControllerTest.java
@@ -149,6 +149,56 @@ class CreateSimulationControllerTest {
         }
 
         @Test
+        @DisplayName("createSimulation returns 400 when technologyIds contains null values")
+        void createSimulationReturns400WhenTechnologyIdsContainsNullValues() throws Exception {
+                mockMvc.perform(post("/api/v1/simulations")
+                                .header(HttpHeaders.AUTHORIZATION, bearer(AUTHORIZED_TOKEN))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                                {
+                                                  "name": "Solar - Sevilla",
+                                                  "energyType": "solar",
+                                                  "location": {
+                                                    "label": "Sevilla, Andalucia, ES",
+                                                    "lat": 37.3891,
+                                                    "lon": -5.9845,
+                                                    "country": "Spain",
+                                                    "countryCode": "ES"
+                                                  },
+                                                  "system": {
+                                                    "installedCapacityKw": 300,
+                                                    "performanceRatio": 0.81,
+                                                    "degradationRateAnnualPct": 0.5,
+                                                    "availabilityPct": 99,
+                                                    "lossesPct": {
+                                                      "inverter": 2,
+                                                      "temperature": 6,
+                                                      "wiring": 1,
+                                                      "soiling": 3,
+                                                      "other": 1
+                                                    }
+                                                  },
+                                                  "demand": {
+                                                    "annualConsumptionKwh": 120000,
+                                                    "monthlyConsumptionKwh": [10000,10000,10000,10000,10000,10000,10000,10000,10000,10000,10000,10000]
+                                                  },
+                                                  "economics": {
+                                                    "currency": "EUR",
+                                                    "capexTotal": 315000,
+                                                    "opexAnnual": 7200,
+                                                    "electricityPurchasePricePerKwh": 0.18,
+                                                    "exportPricePerKwh": 0.07,
+                                                    "discountRatePct": 8,
+                                                    "projectLifetimeYears": 20
+                                                  },
+                                                  "technologyIds": [null]
+                                                }
+                                                """))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.fieldErrors").exists());
+        }
+
+        @Test
         @DisplayName("createSimulationFromScenario returns 201 for a user with write scope")
         void createSimulationFromScenarioReturns201ForUserWithWriteScope() throws Exception {
                 when(createSimulationFromScenarioUseCase.createSimulationFromScenario(any()))

--- a/src/test/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationWebMapperTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationWebMapperTest.java
@@ -1,6 +1,7 @@
 package com.renewsim.backend.simulation_service.create.web;
 
-import com.renewsim.backend.simulation_service.create.web.dto.CreateSolarSimulationRequestDTO;
+import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationRequestDTO;
+import com.renewsim.backend.simulation_service.create.web.dto.SimulationLocationRequestDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,7 @@ class CreateSimulationWebMapperTest {
     @Test
     @DisplayName("toCommand maps request DTO into application command")
     void toCommandMapsRequestDtoIntoApplicationCommand() {
-        CreateSolarSimulationRequestDTO request = request();
+        CreateSimulationRequestDTO request = request();
 
         var command = mapper.toCommand(request, "alice");
 
@@ -25,18 +26,21 @@ class CreateSimulationWebMapperTest {
         assertThat(command.system().installedCapacityKw()).isEqualTo(300.0);
         assertThat(command.demand().annualConsumptionKwh()).isEqualTo(120000.0);
         assertThat(command.economics().currency().value()).isEqualTo("EUR");
+        assertThat(command.technologyIds()).containsExactly(11L, 12L);
         assertThat(command.createdBy()).isEqualTo("alice");
     }
 
-    private CreateSolarSimulationRequestDTO request() {
-        return new CreateSolarSimulationRequestDTO(
+    private CreateSimulationRequestDTO request() {
+        return new CreateSimulationRequestDTO(
                 "Solar - Sevilla",
-                new CreateSolarSimulationRequestDTO.LocationDTO("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", "ES"),
-                new CreateSolarSimulationRequestDTO.SolarSystemDTO(300, 0.81, 0.5, 99,
-                        new CreateSolarSimulationRequestDTO.LossesPctDTO(2, 6, 1, 3, 1)),
-                new CreateSolarSimulationRequestDTO.DemandDTO(120000,
+                "solar",
+                new SimulationLocationRequestDTO("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain", "ES"),
+                new CreateSimulationRequestDTO.SystemDTO(300, 0.81, 0.5, 99,
+                        new CreateSimulationRequestDTO.LossesPctDTO(2, 6, 1, 3, 1)),
+                new CreateSimulationRequestDTO.DemandDTO(120000,
                         List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
                                 10000d)),
-                new CreateSolarSimulationRequestDTO.EconomicsDTO("EUR", 315000, 7200, 0.18, 0.07, 8, 20));
+                new CreateSimulationRequestDTO.EconomicsDTO("EUR", 315000, 7200, 0.18, 0.07, 8, 20),
+                List.of(11L, 12L));
     }
 }


### PR DESCRIPTION
## What changed
- replaces the solar-only manual request DTO with a generic manual simulation contract that accepts `energyType`
- extracts `SimulationLocationRequestDTO` so the manual and scenario contracts share location shape without coupling one request to the other
- validates caller-supplied `technologyIds` before persistence, rejecting inactive ids and ids incompatible with the requested `energyType`
- updates the web/controller tests and mapper tests for the manual creation flow

## Why
Closes #182.

Phase 7 restored the correct simulation model (`energyType`, `technologyIds`, `scenarioId`), but the manual HTTP contract was still solar-only and allowed internal callers to pass arbitrary `technologyIds`. This PR aligns the manual entry point with the restored model.

## Validation
- `mvn -Dtest=CreateSimulationWebMapperTest,CreateSimulationControllerTest,RealSimulationServiceTest test`

## Notes for reviewers
- `wind` and `hydro` remain not implemented by the engines, so the contract now accepts `energyType` explicitly but still returns `UNSUPPORTED_TECHNOLOGY` for those flows until their engines are implemented.
- This PR has 3 commits ordered by work unit: contract, validation, tests.