### PR TITLE
refactor(simulation): decouple snapshot parsing from application services

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardService.java
@@ -1,12 +1,10 @@
 package com.renewsim.backend.simulation_service.dashboard.application;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.dashboard.application.port.out.PortfolioDashboardQueryPort;
 import com.renewsim.backend.simulation_service.dashboard.application.port.in.GetPortfolioDashboardUseCase;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardResult;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.ScenarioSnapshot;
-import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,33 +15,13 @@ import java.util.List;
  * Application service that orchestrates dashboard retrieval and ranking.
  */
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GetPortfolioDashboardService implements GetPortfolioDashboardUseCase {
 
         private final PortfolioDashboardQueryPort repository;
         private final ScenarioSnapshotAssembler snapshotAssembler;
         private final PortfolioDashboardAggregator dashboardAggregator;
-
-        @Autowired
-        public GetPortfolioDashboardService(
-                        PortfolioDashboardQueryPort repository,
-                        TechnologyLookupPort technologyLookupPort,
-                        ObjectMapper objectMapper) {
-                this(repository, new ScenarioSnapshotAssembler(
-                                technologyLookupPort,
-                                objectMapper,
-                                new PortfolioScenarioScoringPolicy()),
-                                new PortfolioDashboardAggregator());
-        }
-
-        GetPortfolioDashboardService(
-                        PortfolioDashboardQueryPort repository,
-                        ScenarioSnapshotAssembler snapshotAssembler,
-                        PortfolioDashboardAggregator dashboardAggregator) {
-                this.repository = repository;
-                this.snapshotAssembler = snapshotAssembler;
-                this.dashboardAggregator = dashboardAggregator;
-        }
 
         @Override
         public PortfolioDashboardResult getDashboard(String username) {

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioDashboardAggregator.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioDashboardAggregator.java
@@ -9,6 +9,8 @@ import com.renewsim.backend.simulation_service.dashboard.application.projection.
 import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardRiskAlert;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardSummary;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.ScenarioSnapshot;
+import org.springframework.stereotype.Component;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -18,9 +20,10 @@ import java.util.Map;
 /**
  * Aggregates ranked scenario snapshots into the portfolio dashboard view model.
  */
-final class PortfolioDashboardAggregator {
+@Component
+public final class PortfolioDashboardAggregator {
 
-    PortfolioDashboardResult buildDashboard(List<ScenarioSnapshot> snapshots, List<ScenarioSnapshot> rankedSnapshots) {
+    public PortfolioDashboardResult buildDashboard(List<ScenarioSnapshot> snapshots, List<ScenarioSnapshot> rankedSnapshots) {
         return new PortfolioDashboardResult(
                 buildSummary(snapshots),
                 buildRecommendedScenario(rankedSnapshots),

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/PortfolioScenarioScoringPolicy.java
@@ -5,13 +5,15 @@ import com.renewsim.backend.simulation_service.domain.policy.SimulationFinancial
 import com.renewsim.backend.simulation_service.domain.policy.SimulationPortfolioPriorityPolicy;
 import com.renewsim.backend.simulation_service.domain.policy.SimulationRecommendationReviewPolicy;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 /**
  * Encapsulates portfolio prioritization and risk scoring rules.
  */
-final class PortfolioScenarioScoringPolicy {
+@Component
+public final class PortfolioScenarioScoringPolicy {
 
     private final SimulationRecommendationReviewPolicy reviewPolicy = new SimulationRecommendationReviewPolicy();
     private final SimulationFinancialRiskPolicy financialRiskPolicy = new SimulationFinancialRiskPolicy();

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
@@ -1,12 +1,14 @@
 package com.renewsim.backend.simulation_service.dashboard.application;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
 import com.renewsim.backend.simulation_service.domain.policy.SimulationRecommendationReviewPolicy;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.ScenarioSnapshot;
+import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationResultSnapshotReaderPort;
 import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Locale;
@@ -14,118 +16,110 @@ import java.util.Locale;
 /**
  * Translates stored simulations into normalized dashboard snapshots.
  */
-final class ScenarioSnapshotAssembler {
+@Component
+@RequiredArgsConstructor
+public final class ScenarioSnapshotAssembler {
 
-    private final TechnologyLookupPort technologyLookupPort;
-    private final ObjectMapper objectMapper;
-    private final PortfolioScenarioScoringPolicy scoringPolicy;
-    private final SimulationRecommendationReviewPolicy reviewPolicy;
+        private final TechnologyLookupPort technologyLookupPort;
+        private final SimulationResultSnapshotReaderPort snapshotReader;
+        private final PortfolioScenarioScoringPolicy scoringPolicy;
+        private final SimulationRecommendationReviewPolicy reviewPolicy = new SimulationRecommendationReviewPolicy();
 
-    ScenarioSnapshotAssembler(
-            TechnologyLookupPort technologyLookupPort,
-            ObjectMapper objectMapper,
-            PortfolioScenarioScoringPolicy scoringPolicy) {
-        this.technologyLookupPort = technologyLookupPort;
-        this.objectMapper = objectMapper;
-        this.scoringPolicy = scoringPolicy;
-        this.reviewPolicy = new SimulationRecommendationReviewPolicy();
-    }
+        public ScenarioSnapshot toSnapshot(Simulation simulation) {
+                SimulationDetailsResult details = readDetails(simulation.getResultSnapshot());
+                SimulationDetailsResult.Financial financial = details != null ? details.financial() : null;
+                SimulationDetailsResult.Technical technical = details != null ? details.technical() : null;
+                SimulationDetailsResult.Summary summary = details != null ? details.summary() : null;
+                boolean hasCompleteDetails = financial != null && technical != null && summary != null;
+                Double capex = simulation.getEconomics() != null ? simulation.getEconomics().capexTotal() : null;
+                Double annualSavings = financial != null ? Double.valueOf(financial.annualSavings())
+                                : simulation.getAnnualSavings();
+                Double annualBenefit = financial != null ? Double.valueOf(financial.netAnnualBenefit())
+                                : simulation.getAnnualSavings();
+                Double paybackYears = financial != null ? financial.paybackYears() : null;
+                Double roiPercent = roiPercent(capex, annualBenefit);
+                double annualGeneration = technical != null ? technical.annualGenerationKwh()
+                                : defaultNumber(simulation.getAnnualGenerationKwh());
+                double co2SavedKg = annualGeneration > 0.0 && simulation.getTechnology() != null
+                                ? technologyLookupPort
+                                                .findActiveCo2ReductionFactorByEnergyType(
+                                                                simulation.getTechnology().value())
+                                                .map(factor -> annualGeneration * factor)
+                                                .orElse(0.0)
+                                : 0.0;
+                String recommendation = summary != null && summary.recommendation() != null
+                                ? summary.recommendation()
+                                : "review_required";
+                SimulationRecommendation normalizedRecommendation = SimulationRecommendation
+                                .fromWireValue(recommendation);
+                List<String> drivers = summary != null && summary.reasons() != null
+                                ? summary.reasons().stream()
+                                                .map(SimulationDetailsResult.RecommendationReason::message)
+                                                .filter(message -> message != null && !message.isBlank())
+                                                .limit(3)
+                                                .toList()
+                                : List.of("El escenario todavia no tiene salida financiera consolidada.");
+                if (drivers.isEmpty()) {
+                        drivers = List.of("El escenario todavia no tiene salida financiera consolidada.");
+                }
 
-    ScenarioSnapshot toSnapshot(Simulation simulation) {
-        SimulationDetailsResult details = readDetails(simulation.getResultSnapshot());
-        SimulationDetailsResult.Financial financial = details != null ? details.financial() : null;
-        SimulationDetailsResult.Technical technical = details != null ? details.technical() : null;
-        SimulationDetailsResult.Summary summary = details != null ? details.summary() : null;
-        boolean hasCompleteDetails = financial != null && technical != null && summary != null;
-        Double capex = simulation.getEconomics() != null ? simulation.getEconomics().capexTotal() : null;
-        Double annualSavings = financial != null ? Double.valueOf(financial.annualSavings())
-                : simulation.getAnnualSavings();
-        Double annualBenefit = financial != null ? Double.valueOf(financial.netAnnualBenefit())
-                : simulation.getAnnualSavings();
-        Double paybackYears = financial != null ? financial.paybackYears() : null;
-        Double roiPercent = roiPercent(capex, annualBenefit);
-        double annualGeneration = technical != null ? technical.annualGenerationKwh()
-                : defaultNumber(simulation.getAnnualGenerationKwh());
-        double co2SavedKg = annualGeneration > 0.0 && simulation.getTechnology() != null
-                ? technologyLookupPort.findActiveCo2ReductionFactorByEnergyType(simulation.getTechnology().value())
-                        .map(factor -> annualGeneration * factor)
-                        .orElse(0.0)
-                : 0.0;
-        String recommendation = summary != null && summary.recommendation() != null
-                ? summary.recommendation()
-                : "review_required";
-        SimulationRecommendation normalizedRecommendation = SimulationRecommendation.fromWireValue(recommendation);
-        List<String> drivers = summary != null && summary.reasons() != null
-                ? summary.reasons().stream()
-                        .map(SimulationDetailsResult.RecommendationReason::message)
-                        .filter(message -> message != null && !message.isBlank())
-                        .limit(3)
-                        .toList()
-                : List.of("El escenario todavia no tiene salida financiera consolidada.");
-        if (drivers.isEmpty()) {
-            drivers = List.of("El escenario todavia no tiene salida financiera consolidada.");
+                int score = scoringPolicy.computeScore(details, roiPercent, paybackYears);
+
+                return new ScenarioSnapshot(
+                                String.valueOf(simulation.getId().value()),
+                                simulation.getName(),
+                                normalizeLabel(simulation.getTechnology() != null ? simulation.getTechnology().value()
+                                                : "unknown"),
+                                normalizeLabel(simulation.getStatus() != null ? simulation.getStatus().name()
+                                                : "draft"),
+                                simulation.getLocation().label(),
+                                roiPercent,
+                                paybackYears,
+                                capex,
+                                annualSavings,
+                                round(annualGeneration),
+                                round(co2SavedKg),
+                                summary != null && summary.headline() != null
+                                                ? summary.headline()
+                                                : "El escenario necesita completar datos antes de priorizarse.",
+                                drivers,
+                                scoringPolicy.resolveMainRisk(details, paybackYears, roiPercent),
+                                reviewPolicy.nextStepFor(normalizedRecommendation),
+                                scoringPolicy.priorityFor(score, hasCompleteDetails),
+                                score,
+                                simulation.getCreatedAt(),
+                                !hasCompleteDetails,
+                                reviewPolicy.needsReview(
+                                                normalizedRecommendation,
+                                                details != null && details.warnings() != null
+                                                                && details.warnings().stream().anyMatch(
+                                                                                warning -> "warning".equalsIgnoreCase(
+                                                                                                warning.severity())),
+                                                hasCompleteDetails),
+                                scoringPolicy.hasNegativeRoi(roiPercent),
+                                scoringPolicy.hasLongPayback(paybackYears));
         }
 
-        int score = scoringPolicy.computeScore(details, roiPercent, paybackYears);
-
-        return new ScenarioSnapshot(
-                String.valueOf(simulation.getId().value()),
-                simulation.getName(),
-                normalizeLabel(simulation.getTechnology() != null ? simulation.getTechnology().value() : "unknown"),
-                normalizeLabel(simulation.getStatus() != null ? simulation.getStatus().name() : "draft"),
-                simulation.getLocation().label(),
-                roiPercent,
-                paybackYears,
-                capex,
-                annualSavings,
-                round(annualGeneration),
-                round(co2SavedKg),
-                summary != null && summary.headline() != null
-                        ? summary.headline()
-                        : "El escenario necesita completar datos antes de priorizarse.",
-                drivers,
-                scoringPolicy.resolveMainRisk(details, paybackYears, roiPercent),
-                reviewPolicy.nextStepFor(normalizedRecommendation),
-                scoringPolicy.priorityFor(score, hasCompleteDetails),
-                score,
-                simulation.getCreatedAt(),
-                !hasCompleteDetails,
-                reviewPolicy.needsReview(
-                        normalizedRecommendation,
-                        details != null && details.warnings() != null
-                                && details.warnings().stream().anyMatch(warning -> "warning".equalsIgnoreCase(warning.severity())),
-                        hasCompleteDetails),
-                scoringPolicy.hasNegativeRoi(roiPercent),
-                scoringPolicy.hasLongPayback(paybackYears));
-    }
-
-    private SimulationDetailsResult readDetails(String raw) {
-        if (raw == null || raw.isBlank()) {
-            return null;
+        private SimulationDetailsResult readDetails(String raw) {
+                return snapshotReader.read(raw);
         }
-        try {
-            return objectMapper.readValue(raw, SimulationDetailsResult.class);
-        } catch (Exception ex) {
-            throw new IllegalStateException("Failed to deserialize simulation payload", ex);
+
+        private Double roiPercent(Double capex, Double annualBenefit) {
+                if (capex == null || annualBenefit == null || capex <= 0.0) {
+                        return null;
+                }
+                return round((annualBenefit / capex) * 100.0);
         }
-    }
 
-    private Double roiPercent(Double capex, Double annualBenefit) {
-        if (capex == null || annualBenefit == null || capex <= 0.0) {
-            return null;
+        private String normalizeLabel(String value) {
+                return value == null ? "UNKNOWN" : value.trim().toUpperCase(Locale.ROOT);
         }
-        return round((annualBenefit / capex) * 100.0);
-    }
 
-    private String normalizeLabel(String value) {
-        return value == null ? "UNKNOWN" : value.trim().toUpperCase(Locale.ROOT);
-    }
+        private double round(double value) {
+                return Math.round(value * 100.0) / 100.0;
+        }
 
-    private double round(double value) {
-        return Math.round(value * 100.0) / 100.0;
-    }
-
-    private double defaultNumber(Double value) {
-        return value == null ? 0.0 : value;
-    }
+        private double defaultNumber(Double value) {
+                return value == null ? 0.0 : value;
+        }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
@@ -1,9 +1,9 @@
 package com.renewsim.backend.simulation_service.detail.application;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.detail.application.port.in.GetRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.detail.application.port.out.SimulationDetailQueryPort;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationResultSnapshotReaderPort;
 import com.renewsim.backend.simulation_service.domain.exception.SimulationNotFoundException;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetSimulationService implements GetRealSimulationUseCase {
 
     private final SimulationDetailQueryPort repository;
-    private final ObjectMapper objectMapper;
+    private final SimulationResultSnapshotReaderPort snapshotReader;
 
     @Override
     public SimulationDetailsResult getSimulationById(Long id, String requesterUsername, boolean isAdmin) {
@@ -25,7 +25,7 @@ public class GetSimulationService implements GetRealSimulationUseCase {
         if (!simulation.hasResult()) {
             throw new SimulationNotFoundException(id);
         }
-        return readJson(simulation.getResultSnapshot(), SimulationDetailsResult.class);
+        return snapshotReader.read(simulation.getResultSnapshot());
     }
 
     private Simulation getAccessibleSimulation(Long id, String requesterUsername, boolean isAdmin) {
@@ -35,13 +35,5 @@ public class GetSimulationService implements GetRealSimulationUseCase {
             throw new AccessDeniedException("Not owner of simulation");
         }
         return simulation;
-    }
-
-    private <T> T readJson(String raw, Class<T> type) {
-        try {
-            return objectMapper.readValue(raw, type);
-        } catch (Exception ex) {
-            throw new IllegalStateException("Failed to deserialize simulation payload", ex);
-        }
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationResultSnapshotJacksonReader.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationResultSnapshotJacksonReader.java
@@ -1,0 +1,26 @@
+package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationResultSnapshotReaderPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SimulationResultSnapshotJacksonReader implements SimulationResultSnapshotReaderPort {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public SimulationDetailsResult read(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(raw, SimulationDetailsResult.class);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to deserialize simulation payload", ex);
+        }
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/application/port/out/SimulationResultSnapshotReaderPort.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/application/port/out/SimulationResultSnapshotReaderPort.java
@@ -1,0 +1,8 @@
+package com.renewsim.backend.simulation_service.shared.application.port.out;
+
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+
+public interface SimulationResultSnapshotReaderPort {
+
+    SimulationDetailsResult read(String raw);
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
@@ -2,475 +2,204 @@ package com.renewsim.backend.simulation_service.create.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.shared.exception.BadRequestException;
-import com.renewsim.backend.simulation_service.create.application.technology.hydro.HydroSimulationEngine;
-import com.renewsim.backend.simulation_service.create.application.technology.solar.SolarSimulationAssessmentPolicy;
-import com.renewsim.backend.simulation_service.create.application.technology.solar.SolarSimulationEngine;
-import com.renewsim.backend.simulation_service.create.application.technology.wind.WindSimulationEngine;
-import com.renewsim.backend.simulation_service.create.application.port.out.CreateSimulationRepositoryPort;
-import com.renewsim.backend.simulation_service.dashboard.application.GetPortfolioDashboardService;
-import com.renewsim.backend.simulation_service.dashboard.application.port.out.PortfolioDashboardQueryPort;
 import com.renewsim.backend.simulation_service.create.application.command.CreateRealSimulationCommand;
-import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardRiskAlert;
-import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardResult;
-import com.renewsim.backend.simulation_service.detail.application.GetSimulationService;
-import com.renewsim.backend.simulation_service.detail.application.port.out.SimulationDetailQueryPort;
-import com.renewsim.backend.simulation_service.history.application.ListSimulationsService;
-import com.renewsim.backend.simulation_service.history.application.port.out.SimulationHistoryQueryPort;
-import com.renewsim.backend.simulation_service.history.application.result.UserSimulationListResult;
+import com.renewsim.backend.simulation_service.create.application.port.out.CreateSimulationRepositoryPort;
 import com.renewsim.backend.simulation_service.create.application.port.out.PvgisSolarResourcePort;
-import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
-import com.renewsim.backend.simulation_service.domain.exception.SimulationNotFoundException;
+import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationId;
-import com.renewsim.backend.simulation_service.domain.model.SimulationStatus;
-import com.renewsim.backend.simulation_service.domain.model.vo.*;
+import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
+import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.access.AccessDeniedException;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.engines;
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.profile;
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.validCommand;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
-class RealSimulationServiceTest {
+class CreateSimulationServiceTest {
 
-        private interface SimulationRepositoryPorts extends CreateSimulationRepositoryPort, SimulationDetailQueryPort,
-                        SimulationHistoryQueryPort, PortfolioDashboardQueryPort {
-        }
+    @Mock
+    private CreateSimulationRepositoryPort repository;
+    @Mock
+    private PvgisSolarResourcePort resourcePort;
+    @Mock
+    private TechnologyLookupPort technologyLookupPort;
 
-        @Mock
-        private SimulationRepositoryPorts repository;
-        @Mock
-        private PvgisSolarResourcePort resourcePort;
-        @Mock
-        private TechnologyLookupPort technologyLookupPort;
+    @Test
+    @DisplayName("createSimulation computes and stores the real contract snapshots")
+    void createSimulationComputesAndStoresRealContractSnapshots() {
+        CreateSimulationService service = new CreateSimulationService(
+                repository,
+                technologyLookupPort,
+                engines(resourcePort),
+                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+        CreateRealSimulationCommand command = validCommand();
 
-        @Test
-        @DisplayName("createSimulation computes and stores the real contract snapshots")
-        void createSimulationComputesAndStoresRealContractSnapshots() {
-                CreateSimulationService service = new CreateSimulationService(
-                                repository,
-                                technologyLookupPort,
-                                engines(),
-                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
-                CreateRealSimulationCommand command = validCommand();
+        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+        when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar")).thenReturn(List.of(1L, 2L));
+        when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+        when(repository.save(any())).thenAnswer(invocation -> {
+            Simulation sim = invocation.getArgument(0);
+            if (sim.getId() == null) {
+                sim.assignId(SimulationId.of(55L));
+            }
+            return sim;
+        });
 
-                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
-                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
-                                .thenReturn(List.of(1L, 2L));
-                when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
-                when(repository.save(any())).thenAnswer(invocation -> {
-                        Simulation sim = invocation.getArgument(0);
-                        if (sim.getId() == null) {
-                                sim.assignId(SimulationId.of(55L));
-                        }
-                        return sim;
-                });
+        SimulationDetailsResult response = service.createSimulation(command);
 
-                SimulationDetailsResult response = service.createSimulation(command);
+        assertThat(response.id()).isEqualTo("55");
+        assertThat(response.modelVersion()).isEqualTo("solar-spain-v1");
+        assertThat(response.technical().annualGenerationKwh()).isGreaterThan(400000);
 
-                assertThat(response.id()).isEqualTo("55");
-                assertThat(response.modelVersion()).isEqualTo("solar-spain-v1");
-                assertThat(response.technical().annualGenerationKwh()).isGreaterThan(400000);
+        ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
+        verify(repository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues().get(1).getResultSnapshot()).isNotBlank();
+        assertThat(captor.getAllValues().get(1).getTechnologyIds()).containsExactly(1L, 2L);
+        verify(technologyLookupPort).recommendActiveTechnologyIdsByEnergyType("solar");
+    }
 
-                ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
-                verify(repository, times(2)).save(captor.capture());
-                assertThat(captor.getAllValues().get(1).getResultSnapshot()).isNotBlank();
-                assertThat(captor.getAllValues().get(1).getTechnologyIds()).containsExactly(1L, 2L);
-                verify(technologyLookupPort).recommendActiveTechnologyIdsByEnergyType("solar");
-        }
+    @Test
+    @DisplayName("createSimulation rejects not-yet-implemented wind before persisting a draft")
+    void createSimulationRejectsNotImplementedWindBeforePersisting() {
+        CreateSimulationService service = new CreateSimulationService(
+                repository,
+                technologyLookupPort,
+                engines(resourcePort),
+                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
 
-        @Test
-        @DisplayName("createSimulation rejects not-yet-implemented wind before persisting a draft")
-        void createSimulationRejectsNotImplementedWindBeforePersisting() {
-                CreateSimulationService service = new CreateSimulationService(
-                                repository,
-                                technologyLookupPort,
-                                engines(),
-                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+        CreateRealSimulationCommand command = new CreateRealSimulationCommand(
+                validCommand().name(),
+                Technology.of("wind"),
+                validCommand().location(),
+                validCommand().system(),
+                validCommand().demand(),
+                validCommand().economics(),
+                validCommand().technologyIds(),
+                validCommand().scenarioId(),
+                validCommand().createdBy());
 
-                CreateRealSimulationCommand command = new CreateRealSimulationCommand(
-                                validCommand().name(),
-                                Technology.of("wind"),
-                                validCommand().location(),
-                                validCommand().system(),
-                                validCommand().demand(),
-                                validCommand().economics(),
-                                validCommand().technologyIds(),
-                                validCommand().scenarioId(),
-                                validCommand().createdBy());
+        when(technologyLookupPort.existsActiveByEnergyType("wind")).thenReturn(true);
 
-                when(technologyLookupPort.existsActiveByEnergyType("wind")).thenReturn(true);
+        assertThatThrownBy(() -> service.createSimulation(command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("UNSUPPORTED_TECHNOLOGY: 'wind' simulation is not implemented yet");
 
-                assertThatThrownBy(() -> service.createSimulation(command))
-                                .isInstanceOf(BadRequestException.class)
-                                .hasMessage("UNSUPPORTED_TECHNOLOGY: 'wind' simulation is not implemented yet");
+        verify(repository, never()).save(any());
+    }
 
-                verify(repository, never()).save(any());
-        }
+    @Test
+    @DisplayName("createSimulation rejects caller supplied technology ids that are inactive")
+    void createSimulationRejectsCallerSuppliedTechnologyIdsThatAreInactive() {
+        CreateSimulationService service = new CreateSimulationService(
+                repository,
+                technologyLookupPort,
+                engines(resourcePort),
+                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
 
-        @Test
-        @DisplayName("createSimulation rejects caller supplied technology ids that are inactive")
-        void createSimulationRejectsCallerSuppliedTechnologyIdsThatAreInactive() {
-                CreateSimulationService service = new CreateSimulationService(
-                                repository,
-                                technologyLookupPort,
-                                engines(),
-                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+        CreateRealSimulationCommand command = new CreateRealSimulationCommand(
+                validCommand().name(),
+                validCommand().technology(),
+                validCommand().location(),
+                validCommand().system(),
+                validCommand().demand(),
+                validCommand().economics(),
+                List.of(99L),
+                null,
+                validCommand().createdBy());
 
-                CreateRealSimulationCommand command = new CreateRealSimulationCommand(
-                                validCommand().name(),
-                                validCommand().technology(),
-                                validCommand().location(),
-                                validCommand().system(),
-                                validCommand().demand(),
-                                validCommand().economics(),
-                                List.of(99L),
-                                null,
-                                validCommand().createdBy());
+        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(99L)).thenReturn(Optional.empty());
 
-                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
-                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(99L)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.createSimulation(command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("UNSUPPORTED_TECHNOLOGY_ID: '99' is not registered or is inactive in the technology catalog");
 
-                assertThatThrownBy(() -> service.createSimulation(command))
-                                .isInstanceOf(BadRequestException.class)
-                                .hasMessage("UNSUPPORTED_TECHNOLOGY_ID: '99' is not registered or is inactive in the technology catalog");
+        verify(repository, never()).save(any());
+    }
 
-                verify(repository, never()).save(any());
-        }
+    @Test
+    @DisplayName("createSimulation rejects caller supplied technology ids that do not match the simulation energy type")
+    void createSimulationRejectsCallerSuppliedTechnologyIdsThatDoNotMatchTheSimulationEnergyType() {
+        CreateSimulationService service = new CreateSimulationService(
+                repository,
+                technologyLookupPort,
+                engines(resourcePort),
+                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
 
-        @Test
-        @DisplayName("createSimulation rejects caller supplied technology ids that do not match the simulation energy type")
-        void createSimulationRejectsCallerSuppliedTechnologyIdsThatDoNotMatchTheSimulationEnergyType() {
-                CreateSimulationService service = new CreateSimulationService(
-                                repository,
-                                technologyLookupPort,
-                                engines(),
-                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+        CreateRealSimulationCommand command = new CreateRealSimulationCommand(
+                validCommand().name(),
+                validCommand().technology(),
+                validCommand().location(),
+                validCommand().system(),
+                validCommand().demand(),
+                validCommand().economics(),
+                List.of(15L),
+                null,
+                validCommand().createdBy());
 
-                CreateRealSimulationCommand command = new CreateRealSimulationCommand(
-                                validCommand().name(),
-                                validCommand().technology(),
-                                validCommand().location(),
-                                validCommand().system(),
-                                validCommand().demand(),
-                                validCommand().economics(),
-                                List.of(15L),
-                                null,
-                                validCommand().createdBy());
+        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+        when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(15L)).thenReturn(Optional.of("wind"));
 
-                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
-                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(15L)).thenReturn(Optional.of("wind"));
+        assertThatThrownBy(() -> service.createSimulation(command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("INCOMPATIBLE_TECHNOLOGY_ID: '15' does not belong to energyType 'solar'");
 
-                assertThatThrownBy(() -> service.createSimulation(command))
-                                .isInstanceOf(BadRequestException.class)
-                                .hasMessage("INCOMPATIBLE_TECHNOLOGY_ID: '15' does not belong to energyType 'solar'");
+        verify(repository, never()).save(any());
+    }
 
-                verify(repository, never()).save(any());
-        }
+    @Test
+    @DisplayName("createSimulation rejects caller supplied technology ids that are duplicated")
+    void createSimulationRejectsCallerSuppliedTechnologyIdsThatAreDuplicated() {
+        CreateSimulationService service = new CreateSimulationService(
+                repository,
+                technologyLookupPort,
+                engines(resourcePort),
+                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
 
-        @Test
-        @DisplayName("createSimulation rejects caller supplied technology ids that are duplicated")
-        void createSimulationRejectsCallerSuppliedTechnologyIdsThatAreDuplicated() {
-                CreateSimulationService service = new CreateSimulationService(
-                                repository,
-                                technologyLookupPort,
-                                engines(),
-                                new SimulationCompletionMapper(new ObjectMapper().findAndRegisterModules()));
+        CreateRealSimulationCommand command = new CreateRealSimulationCommand(
+                validCommand().name(),
+                validCommand().technology(),
+                validCommand().location(),
+                validCommand().system(),
+                validCommand().demand(),
+                validCommand().economics(),
+                List.of(11L, 11L),
+                null,
+                validCommand().createdBy());
 
-                CreateRealSimulationCommand command = new CreateRealSimulationCommand(
-                                validCommand().name(),
-                                validCommand().technology(),
-                                validCommand().location(),
-                                validCommand().system(),
-                                validCommand().demand(),
-                                validCommand().economics(),
-                                List.of(11L, 11L),
-                                null,
-                                validCommand().createdBy());
+        when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
 
-                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+        assertThatThrownBy(() -> service.createSimulation(command))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("DUPLICATE_TECHNOLOGY_IDS: technologyIds must not contain duplicates");
 
-                assertThatThrownBy(() -> service.createSimulation(command))
-                                .isInstanceOf(BadRequestException.class)
-                                .hasMessage("DUPLICATE_TECHNOLOGY_IDS: technologyIds must not contain duplicates");
+        verify(repository, never()).save(any());
+    }
 
-                verify(repository, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("getSimulationById enforces ownership for non admins")
-        void getSimulationByIdEnforcesOwnership() throws Exception {
-                GetSimulationService service = new GetSimulationService(repository,
-                                new ObjectMapper().findAndRegisterModules());
-                SimulationDetailsResult result = minimalResult();
-                Simulation simulation = completedSimulation(55L, "alice",
-                                new ObjectMapper().writeValueAsString(result));
-                when(repository.findById(55L)).thenReturn(Optional.of(simulation));
-
-                assertThatThrownBy(() -> service.getSimulationById(55L, "bob", false))
-                                .isInstanceOf(AccessDeniedException.class);
-                assertThat(service.getSimulationById(55L, "alice", false).id()).isEqualTo("55");
-        }
-
-        @Test
-        @DisplayName("getUserSimulations maps stored summary columns for scenario-created simulations")
-        void getUserSimulationsMapsStoredSummaryColumnsForScenarioCreatedSimulations() {
-                ListSimulationsService service = new ListSimulationsService(repository);
-                Simulation simulation = completedSimulation(55L, "alice", null);
-                simulation.assignScenarioId(42L);
-                simulation.assignTechnologyIds(List.of(11L, 12L));
-                when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(simulation));
-
-                UserSimulationListResult response = service.getUserSimulations("alice");
-
-                assertThat(response.total()).isEqualTo(1);
-                assertThat(response.items().getFirst().annualSavings()).isEqualTo(68700.0);
-                assertThat(response.items().getFirst().technology()).isEqualTo("solar");
-        }
-
-        @Test
-        @DisplayName("getDashboard aggregates portfolio KPIs, recommendation and alerts")
-        void getDashboardAggregatesPortfolioData() throws Exception {
-                GetPortfolioDashboardService service = new GetPortfolioDashboardService(
-                                repository,
-                                technologyLookupPort,
-                                new ObjectMapper().findAndRegisterModules());
-
-                Simulation best = completedSimulation(55L, "alice",
-                                new ObjectMapper().writeValueAsString(resultWithMetrics(
-                                                "55", "recommended", 82000, 9100, 6.2, 1820, List.of())));
-                best.assignScenarioId(42L);
-                best.assignTechnologyIds(List.of(11L, 12L));
-                Simulation risky = completedSimulation(56L, "alice",
-                                new ObjectMapper().writeValueAsString(resultWithMetrics(
-                                                "56", "not_recommended", 12000, -5000, 12.4, 980,
-                                                List.of(new SimulationDetailsResult.SimulationWarning("warning",
-                                                                "LOW_AVAILABILITY_ASSUMPTION",
-                                                                "Availability assumption is below 95% and may materially reduce annual output.")))));
-                risky.assignScenarioId(43L);
-                risky.assignTechnologyIds(List.of(12L, 13L));
-                Simulation draft = Simulation.create(
-                                "Solar - Draft",
-                                Technology.solar(),
-                                SimulationLocation.of("Cordoba, Andalucia, ES", 37.8882, -4.7794, "Spain",
-                                                CountryCode.of("ES")),
-                                new SimulationSystem(120, 0.81, 0.5, 99.0,
-                                                new SimulationSystem.LossesPct(2, 6, 1, 3, 1)),
-                                ConsumptionProfile.of(48000,
-                                                List.of(4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d,
-                                                                4000d, 4000d, 4000d)),
-                                new SimulationEconomics(Currency.of("EUR"), 110000.0, 3000.0, 0.18, 0.07, 8,
-                                                ProjectLifetime.of(20)),
-                                List.of(),
-                                null,
-                                "alice");
-                draft.assignId(SimulationId.of(57L));
-                draft.assignScenarioId(44L);
-                draft.assignTechnologyIds(List.of(11L));
-
-                when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(best, risky, draft));
-                when(technologyLookupPort.findActiveCo2ReductionFactorByEnergyType("solar"))
-                                .thenReturn(Optional.of(0.45));
-
-                PortfolioDashboardResult response = service.getDashboard("alice");
-
-                assertThat(response.summary().totalSimulations()).isEqualTo(3);
-                assertThat(response.summary().atRiskCount()).isEqualTo(2);
-                assertThat(response.recommendedScenario()).isNotNull();
-                assertThat(response.recommendedScenario().id()).isEqualTo("55");
-                assertThat(response.prioritizedScenarios()).hasSize(3);
-                assertThat(response.riskAlerts()).extracting(PortfolioDashboardRiskAlert::type)
-                                .contains("NEGATIVE_ROI", "LONG_PAYBACK", "INCOMPLETE_DATA", "REQUIRES_REVIEW");
-                assertThat(response.distribution().byTechnology().getFirst().label()).isEqualTo("SOLAR");
-        }
-
-        @Test
-        @DisplayName("getDashboard tolerates partial historical snapshots")
-        void getDashboardToleratesPartialHistoricalSnapshots() throws Exception {
-                GetPortfolioDashboardService service = new GetPortfolioDashboardService(
-                                repository,
-                                technologyLookupPort,
-                                new ObjectMapper().findAndRegisterModules());
-
-                Simulation partial = completedSimulation(58L, "alice", """
-                                {
-                                  "id": "58",
-                                  "status": "completed",
-                                  "summary": null,
-                                  "technical": null,
-                                  "financial": null,
-                                  "warnings": null
-                                }
-                                """);
-
-                when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(partial));
-
-                PortfolioDashboardResult response = service.getDashboard("alice");
-
-                assertThat(response.summary().totalSimulations()).isEqualTo(1);
-                assertThat(response.summary().atRiskCount()).isEqualTo(1);
-                assertThat(response.prioritizedScenarios()).hasSize(1);
-                assertThat(response.prioritizedScenarios().getFirst().priority()).isEqualTo("REVIEW");
-        }
-
-        @Test
-        @DisplayName("ConsumptionProfile rejects annual demand mismatches at domain level")
-        void consumptionProfileRejectsAnnualDemandMismatch() {
-                assertThatThrownBy(() -> ConsumptionProfile.of(999999,
-                                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
-                                                10000d, 10000d)))
-                                .isInstanceOf(BadRequestException.class);
-        }
-
-        @Test
-        @DisplayName("getSimulationById fails when snapshot is missing")
-        void getSimulationByIdFailsWhenSnapshotMissing() {
-                GetSimulationService service = new GetSimulationService(repository,
-                                new ObjectMapper().findAndRegisterModules());
-                Simulation simulation = completedSimulation(55L, "alice", null);
-                when(repository.findById(55L)).thenReturn(Optional.of(simulation));
-
-                assertThatThrownBy(() -> service.getSimulationById(55L, "alice", false))
-                                .isInstanceOf(SimulationNotFoundException.class);
-        }
-
-        private CreateRealSimulationCommand validCommand() {
-                return new CreateRealSimulationCommand(
-                                "Solar - Sevilla",
-                                Technology.solar(),
-                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                                CountryCode.of("ES")),
-                                new SimulationSystem(300, 0.81, 0.5, 99, new SimulationSystem.LossesPct(2, 6, 1, 3, 1)),
-                                ConsumptionProfile.of(120000,
-                                                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
-                                                                10000d, 10000d, 10000d, 10000d)),
-                                new SimulationEconomics(Currency.of("EUR"), 315000, 7200, 0.18, 0.07, 8,
-                                                ProjectLifetime.of(20)),
-                                List.of(),
-                                null,
-                                "alice");
-        }
-
-        private List<SimulationEngine> engines() {
-                return List.of(
-                                new SolarSimulationEngine(resourcePort, new SolarSimulationAssessmentPolicy()),
-                                new WindSimulationEngine(),
-                                new HydroSimulationEngine());
-        }
-
-        private Simulation completedSimulation(Long id, String owner, String resultJson) {
-                SimulationLocation location = SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
-                                CountryCode.of("ES"));
-                SimulationSystem system = new SimulationSystem(300.0, 0.81, 0.5, 99.0,
-                                new SimulationSystem.LossesPct(2.0, 6.0, 1.0, 3.0, 1.0));
-                SimulationEconomics economics = new SimulationEconomics(Currency.of("EUR"), 315000.0, 7200.0, 0.18,
-                                0.07, 8, ProjectLifetime.of(20));
-
-                return Simulation.reconstitute(
-                                id, "Solar - Sevilla", Technology.solar(),
-                                location, system,
-                                ConsumptionProfile.of(120000,
-                                                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
-                                                                10000d, 10000d, 10000d, 10000d)),
-                                economics,
-                                SimulationStatus.COMPLETED, resultJson,
-                                457200.0, 68700.0, 121500.0, 11.4, "viable_with_reservations",
-                                List.of(11L, 12L),
-                                null,
-                                owner, LocalDateTime.parse("2026-06-30T14:00:00"),
-                                LocalDateTime.parse("2026-06-30T14:00:00"));
-        }
-
-        private PvgisSolarResourcePort.PvgisSolarResourceProfile profile() {
-                return new PvgisSolarResourcePort.PvgisSolarResourceProfile(
-                                List.of(117.91, 117.78, 140.16, 142.40, 155.64, 154.71, 164.37, 161.96, 145.57, 132.00,
-                                                112.14, 112.69),
-                                List.of(144.21, 146.57, 177.98, 185.86, 208.58, 212.34, 230.04, 226.42, 197.02, 172.86,
-                                                140.05, 137.50),
-                                List.of(10.0, 12.0, 15.0, 17.0, 22.0, 27.0, 31.0, 31.0, 27.0, 21.0, 15.0, 11.0),
-                                "2005-2020",
-                                "PVGIS");
-        }
-
-        private SimulationDetailsResult minimalResult() {
-                return new SimulationDetailsResult(
-                                "55", "completed", "2026-06-30T14:00:00Z", "2026-06-30T14:00:00Z", "solar-spain-v1",
-                                "solar",
-                                new SimulationDetailsResult.ResolvedLocation("Sevilla, Andalucia, ES", "Sevilla",
-                                                "Andalucia", "Spain", "ES", 37.3891, -5.9845, "Europe/Madrid"),
-                                new SimulationDetailsResult.Summary("viable_with_reservations", "headline", "summary",
-                                                List.of()),
-                                new SimulationDetailsResult.Input("Solar - Sevilla", "solar",
-                                                new SimulationDetailsResult.Location("Sevilla, Andalucia, ES", 37.3891,
-                                                                -5.9845, "Spain", "ES"),
-                                                new SimulationDetailsResult.SystemSpec(300, 0.81, 0.5, 99,
-                                                                new SimulationDetailsResult.LossesPct(2, 6, 1, 3, 1)),
-                                                new SimulationDetailsResult.Demand(120000, List.of()),
-                                                new SimulationDetailsResult.Economics("EUR", 315000, 7200, 0.18, 0.07,
-                                                                8, 20)),
-                                new SimulationDetailsResult.Technical(457200, List.of(), 1524, 0.81, 17.4, 72.3, 31.5,
-                                                new SimulationDetailsResult.ResourceSeries("PVGIS", "2005-2020",
-                                                                List.of(), List.of()),
-                                                new SimulationDetailsResult.LossesSummary(2, 6, 1, 3, 1, 13),
-                                                List.of()),
-                                new SimulationDetailsResult.Financial("EUR", 68700, 8800, 70300, 6.9, 8.7, 121500, 11.4,
-                                                0.071, List.of()),
-                                new SimulationDetailsResult.Assumptions(8, 20, 0.5, 0.18, 0.07, "PVGIS", "2005-2020"),
-                                List.of());
-        }
-
-        private SimulationDetailsResult resultWithMetrics(
-                        String id,
-                        String recommendation,
-                        double annualSavings,
-                        double netAnnualBenefit,
-                        double paybackYears,
-                        double specificYield,
-                        List<SimulationDetailsResult.SimulationWarning> warnings) {
-                return new SimulationDetailsResult(
-                                id,
-                                "completed",
-                                "2026-06-30T14:00:00Z",
-                                "2026-06-30T14:00:00Z",
-                                "solar-spain-v1",
-                                "solar",
-                                new SimulationDetailsResult.ResolvedLocation("Sevilla, Andalucia, ES", "Sevilla",
-                                                "Andalucia", "Spain", "ES", 37.3891, -5.9845, "Europe/Madrid"),
-                                new SimulationDetailsResult.Summary(recommendation, "headline", "summary",
-                                                List.of(new SimulationDetailsResult.RecommendationReason("economics",
-                                                                "positive", "Driver"))),
-                                new SimulationDetailsResult.Input("Solar - Sevilla", "solar",
-                                                new SimulationDetailsResult.Location("Sevilla, Andalucia, ES", 37.3891,
-                                                                -5.9845, "Spain", "ES"),
-                                                new SimulationDetailsResult.SystemSpec(300, 0.81, 0.5, 99,
-                                                                new SimulationDetailsResult.LossesPct(2, 6, 1, 3, 1)),
-                                                new SimulationDetailsResult.Demand(120000, List.of()),
-                                                new SimulationDetailsResult.Economics("EUR", 315000, 7200, 0.18, 0.07,
-                                                                8, 20)),
-                                new SimulationDetailsResult.Technical(457200, List.of(), specificYield, 0.81, 17.4,
-                                                72.3, 31.5,
-                                                new SimulationDetailsResult.ResourceSeries("PVGIS", "2005-2020",
-                                                                List.of(), List.of()),
-                                                new SimulationDetailsResult.LossesSummary(2, 6, 1, 3, 1, 13),
-                                                List.of()),
-                                new SimulationDetailsResult.Financial("EUR", annualSavings, 8800, netAnnualBenefit,
-                                                paybackYears, 8.7, 121500, 11.4, 0.071, List.of()),
-                                new SimulationDetailsResult.Assumptions(8, 20, 0.5, 0.18, 0.07, "PVGIS", "2005-2020"),
-                                warnings);
-        }
+    @Test
+    @DisplayName("ConsumptionProfile rejects annual demand mismatches at domain level")
+    void consumptionProfileRejectsAnnualDemandMismatch() {
+        assertThatThrownBy(() -> ConsumptionProfile.of(999999,
+                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
+                        10000d, 10000d)))
+                .isInstanceOf(BadRequestException.class);
+    }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardServiceTest.java
@@ -1,0 +1,126 @@
+package com.renewsim.backend.simulation_service.dashboard.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.simulation_service.dashboard.application.port.out.PortfolioDashboardQueryPort;
+import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardRiskAlert;
+import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardResult;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
+import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import com.renewsim.backend.simulation_service.domain.model.SimulationId;
+import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
+import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
+import com.renewsim.backend.simulation_service.domain.model.vo.Currency;
+import com.renewsim.backend.simulation_service.domain.model.vo.ProjectLifetime;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomics;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
+import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.completedSimulation;
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.resultWithMetrics;
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.snapshotAssembler;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetPortfolioDashboardServiceTest {
+
+    @Mock
+    private PortfolioDashboardQueryPort repository;
+    @Mock
+    private TechnologyLookupPort technologyLookupPort;
+
+    @Test
+    @DisplayName("getDashboard aggregates portfolio KPIs, recommendation and alerts")
+    void getDashboardAggregatesPortfolioData() throws Exception {
+        GetPortfolioDashboardService service = new GetPortfolioDashboardService(
+                repository,
+                snapshotAssembler(technologyLookupPort),
+                new PortfolioDashboardAggregator());
+
+        Simulation best = completedSimulation(55L, "alice",
+                new ObjectMapper().findAndRegisterModules().writeValueAsString(resultWithMetrics(
+                        "55", "recommended", 82000, 9100, 6.2, 1820, List.of())));
+        best.assignScenarioId(42L);
+        best.assignTechnologyIds(List.of(11L, 12L));
+        Simulation risky = completedSimulation(56L, "alice",
+                new ObjectMapper().findAndRegisterModules().writeValueAsString(resultWithMetrics(
+                        "56", "not_recommended", 12000, -5000, 12.4, 980,
+                        List.of(new SimulationDetailsResult.SimulationWarning("warning",
+                                "LOW_AVAILABILITY_ASSUMPTION",
+                                "Availability assumption is below 95% and may materially reduce annual output.")))));
+        risky.assignScenarioId(43L);
+        risky.assignTechnologyIds(List.of(12L, 13L));
+        Simulation draft = Simulation.create(
+                "Solar - Draft",
+                Technology.solar(),
+                SimulationLocation.of("Cordoba, Andalucia, ES", 37.8882, -4.7794, "Spain",
+                        CountryCode.of("ES")),
+                new SimulationSystem(120, 0.81, 0.5, 99.0,
+                        new SimulationSystem.LossesPct(2, 6, 1, 3, 1)),
+                ConsumptionProfile.of(48000,
+                        List.of(4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d, 4000d,
+                                4000d, 4000d, 4000d)),
+                new SimulationEconomics(Currency.of("EUR"), 110000.0, 3000.0, 0.18, 0.07, 8,
+                        ProjectLifetime.of(20)),
+                List.of(),
+                null,
+                "alice");
+        draft.assignId(SimulationId.of(57L));
+        draft.assignScenarioId(44L);
+        draft.assignTechnologyIds(List.of(11L));
+
+        when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(best, risky, draft));
+        when(technologyLookupPort.findActiveCo2ReductionFactorByEnergyType("solar"))
+                .thenReturn(Optional.of(0.45));
+
+        PortfolioDashboardResult response = service.getDashboard("alice");
+
+        assertThat(response.summary().totalSimulations()).isEqualTo(3);
+        assertThat(response.summary().atRiskCount()).isEqualTo(2);
+        assertThat(response.recommendedScenario()).isNotNull();
+        assertThat(response.recommendedScenario().id()).isEqualTo("55");
+        assertThat(response.prioritizedScenarios()).hasSize(3);
+        assertThat(response.riskAlerts()).extracting(PortfolioDashboardRiskAlert::type)
+                .contains("NEGATIVE_ROI", "LONG_PAYBACK", "INCOMPLETE_DATA", "REQUIRES_REVIEW");
+        assertThat(response.distribution().byTechnology().getFirst().label()).isEqualTo("SOLAR");
+    }
+
+    @Test
+    @DisplayName("getDashboard tolerates partial historical snapshots")
+    void getDashboardToleratesPartialHistoricalSnapshots() throws Exception {
+        GetPortfolioDashboardService service = new GetPortfolioDashboardService(
+                repository,
+                snapshotAssembler(technologyLookupPort),
+                new PortfolioDashboardAggregator());
+
+        Simulation partial = completedSimulation(58L, "alice", """
+                {
+                  "id": "58",
+                  "status": "completed",
+                  "summary": null,
+                  "technical": null,
+                  "financial": null,
+                  "warnings": null
+                }
+                """);
+
+        when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(partial));
+
+        PortfolioDashboardResult response = service.getDashboard("alice");
+
+        assertThat(response.summary().totalSimulations()).isEqualTo(1);
+        assertThat(response.summary().atRiskCount()).isEqualTo(1);
+        assertThat(response.prioritizedScenarios()).hasSize(1);
+        assertThat(response.prioritizedScenarios().getFirst().priority()).isEqualTo("REVIEW");
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
@@ -1,0 +1,53 @@
+package com.renewsim.backend.simulation_service.detail.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.simulation_service.detail.application.port.out.SimulationDetailQueryPort;
+import com.renewsim.backend.simulation_service.domain.exception.SimulationNotFoundException;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.Optional;
+
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.completedSimulation;
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.minimalResult;
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.snapshotReader;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetSimulationServiceTest {
+
+    @Mock
+    private SimulationDetailQueryPort repository;
+
+    @Test
+    @DisplayName("getSimulationById enforces ownership for non admins")
+    void getSimulationByIdEnforcesOwnership() throws Exception {
+        GetSimulationService service = new GetSimulationService(repository, snapshotReader());
+        SimulationDetailsResult result = minimalResult();
+        var simulation = completedSimulation(55L, "alice",
+                new ObjectMapper().findAndRegisterModules().writeValueAsString(result));
+        when(repository.findById(55L)).thenReturn(Optional.of(simulation));
+
+        assertThatThrownBy(() -> service.getSimulationById(55L, "bob", false))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThat(service.getSimulationById(55L, "alice", false).id()).isEqualTo("55");
+    }
+
+    @Test
+    @DisplayName("getSimulationById fails when snapshot is missing")
+    void getSimulationByIdFailsWhenSnapshotMissing() {
+        GetSimulationService service = new GetSimulationService(repository, snapshotReader());
+        var simulation = completedSimulation(55L, "alice", null);
+        when(repository.findById(55L)).thenReturn(Optional.of(simulation));
+
+        assertThatThrownBy(() -> service.getSimulationById(55L, "alice", false))
+                .isInstanceOf(SimulationNotFoundException.class);
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/history/application/ListSimulationsServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/history/application/ListSimulationsServiceTest.java
@@ -1,0 +1,38 @@
+package com.renewsim.backend.simulation_service.history.application;
+
+import com.renewsim.backend.simulation_service.history.application.port.out.SimulationHistoryQueryPort;
+import com.renewsim.backend.simulation_service.history.application.result.UserSimulationListResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.renewsim.backend.simulation_service.support.SimulationServiceTestFixtures.completedSimulation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ListSimulationsServiceTest {
+
+    @Mock
+    private SimulationHistoryQueryPort repository;
+
+    @Test
+    @DisplayName("getUserSimulations maps stored summary columns for scenario-created simulations")
+    void getUserSimulationsMapsStoredSummaryColumnsForScenarioCreatedSimulations() {
+        ListSimulationsService service = new ListSimulationsService(repository);
+        var simulation = completedSimulation(55L, "alice", null);
+        simulation.assignScenarioId(42L);
+        simulation.assignTechnologyIds(List.of(11L, 12L));
+        when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(simulation));
+
+        UserSimulationListResult response = service.getUserSimulations("alice");
+
+        assertThat(response.total()).isEqualTo(1);
+        assertThat(response.items().getFirst().annualSavings()).isEqualTo(68700.0);
+        assertThat(response.items().getFirst().technology()).isEqualTo("solar");
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/support/SimulationServiceTestFixtures.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/support/SimulationServiceTestFixtures.java
@@ -1,0 +1,171 @@
+package com.renewsim.backend.simulation_service.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.simulation_service.create.application.SimulationEngine;
+import com.renewsim.backend.simulation_service.create.application.command.CreateRealSimulationCommand;
+import com.renewsim.backend.simulation_service.create.application.port.out.PvgisSolarResourcePort;
+import com.renewsim.backend.simulation_service.create.application.technology.hydro.HydroSimulationEngine;
+import com.renewsim.backend.simulation_service.create.application.technology.solar.SolarSimulationAssessmentPolicy;
+import com.renewsim.backend.simulation_service.create.application.technology.solar.SolarSimulationEngine;
+import com.renewsim.backend.simulation_service.create.application.technology.wind.WindSimulationEngine;
+import com.renewsim.backend.simulation_service.dashboard.application.PortfolioScenarioScoringPolicy;
+import com.renewsim.backend.simulation_service.dashboard.application.ScenarioSnapshotAssembler;
+import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import com.renewsim.backend.simulation_service.domain.model.SimulationStatus;
+import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
+import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
+import com.renewsim.backend.simulation_service.domain.model.vo.Currency;
+import com.renewsim.backend.simulation_service.domain.model.vo.ProjectLifetime;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomics;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
+import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.SimulationResultSnapshotJacksonReader;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationResultSnapshotReaderPort;
+import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public final class SimulationServiceTestFixtures {
+
+        private SimulationServiceTestFixtures() {
+        }
+
+        public static CreateRealSimulationCommand validCommand() {
+                return new CreateRealSimulationCommand(
+                                "Solar - Sevilla",
+                                Technology.solar(),
+                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                                CountryCode.of("ES")),
+                                new SimulationSystem(300, 0.81, 0.5, 99, new SimulationSystem.LossesPct(2, 6, 1, 3, 1)),
+                                ConsumptionProfile.of(120000,
+                                                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
+                                                                10000d, 10000d, 10000d, 10000d)),
+                                new SimulationEconomics(Currency.of("EUR"), 315000, 7200, 0.18, 0.07, 8,
+                                                ProjectLifetime.of(20)),
+                                List.of(),
+                                null,
+                                "alice");
+        }
+
+        public static List<SimulationEngine> engines(PvgisSolarResourcePort resourcePort) {
+                return List.of(
+                                new SolarSimulationEngine(resourcePort, new SolarSimulationAssessmentPolicy()),
+                                new WindSimulationEngine(),
+                                new HydroSimulationEngine());
+        }
+
+        public static Simulation completedSimulation(Long id, String owner, String resultJson) {
+                SimulationLocation location = SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845, "Spain",
+                                CountryCode.of("ES"));
+                SimulationSystem system = new SimulationSystem(300.0, 0.81, 0.5, 99.0,
+                                new SimulationSystem.LossesPct(2.0, 6.0, 1.0, 3.0, 1.0));
+                SimulationEconomics economics = new SimulationEconomics(Currency.of("EUR"), 315000.0, 7200.0, 0.18,
+                                0.07, 8, ProjectLifetime.of(20));
+
+                return Simulation.reconstitute(
+                                id, "Solar - Sevilla", Technology.solar(),
+                                location, system,
+                                ConsumptionProfile.of(120000,
+                                                List.of(10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d, 10000d,
+                                                                10000d, 10000d, 10000d, 10000d)),
+                                economics,
+                                SimulationStatus.COMPLETED, resultJson,
+                                457200.0, 68700.0, 121500.0, 11.4, "viable_with_reservations",
+                                List.of(11L, 12L),
+                                null,
+                                owner, LocalDateTime.parse("2026-06-30T14:00:00"),
+                                LocalDateTime.parse("2026-06-30T14:00:00"));
+        }
+
+        public static PvgisSolarResourcePort.PvgisSolarResourceProfile profile() {
+                return new PvgisSolarResourcePort.PvgisSolarResourceProfile(
+                                List.of(117.91, 117.78, 140.16, 142.40, 155.64, 154.71, 164.37, 161.96, 145.57, 132.00,
+                                                112.14, 112.69),
+                                List.of(144.21, 146.57, 177.98, 185.86, 208.58, 212.34, 230.04, 226.42, 197.02, 172.86,
+                                                140.05, 137.50),
+                                List.of(10.0, 12.0, 15.0, 17.0, 22.0, 27.0, 31.0, 31.0, 27.0, 21.0, 15.0, 11.0),
+                                "2005-2020",
+                                "PVGIS");
+        }
+
+        public static SimulationDetailsResult minimalResult() {
+                return new SimulationDetailsResult(
+                                "55", "completed", "2026-06-30T14:00:00Z", "2026-06-30T14:00:00Z", "solar-spain-v1",
+                                "solar",
+                                new SimulationDetailsResult.ResolvedLocation("Sevilla, Andalucia, ES", "Sevilla",
+                                                "Andalucia", "Spain", "ES", 37.3891, -5.9845, "Europe/Madrid"),
+                                new SimulationDetailsResult.Summary("viable_with_reservations", "headline", "summary",
+                                                List.of()),
+                                new SimulationDetailsResult.Input("Solar - Sevilla", "solar",
+                                                new SimulationDetailsResult.Location("Sevilla, Andalucia, ES", 37.3891,
+                                                                -5.9845, "Spain", "ES"),
+                                                new SimulationDetailsResult.SystemSpec(300, 0.81, 0.5, 99,
+                                                                new SimulationDetailsResult.LossesPct(2, 6, 1, 3, 1)),
+                                                new SimulationDetailsResult.Demand(120000, List.of()),
+                                                new SimulationDetailsResult.Economics("EUR", 315000, 7200, 0.18, 0.07,
+                                                                8, 20)),
+                                new SimulationDetailsResult.Technical(457200, List.of(), 1524, 0.81, 17.4, 72.3, 31.5,
+                                                new SimulationDetailsResult.ResourceSeries("PVGIS", "2005-2020",
+                                                                List.of(), List.of()),
+                                                new SimulationDetailsResult.LossesSummary(2, 6, 1, 3, 1, 13),
+                                                List.of()),
+                                new SimulationDetailsResult.Financial("EUR", 68700, 8800, 70300, 6.9, 8.7, 121500, 11.4,
+                                                0.071, List.of()),
+                                new SimulationDetailsResult.Assumptions(8, 20, 0.5, 0.18, 0.07, "PVGIS", "2005-2020"),
+                                List.of());
+        }
+
+        public static SimulationDetailsResult resultWithMetrics(
+                        String id,
+                        String recommendation,
+                        double annualSavings,
+                        double netAnnualBenefit,
+                        double paybackYears,
+                        double specificYield,
+                        List<SimulationDetailsResult.SimulationWarning> warnings) {
+                return new SimulationDetailsResult(
+                                id,
+                                "completed",
+                                "2026-06-30T14:00:00Z",
+                                "2026-06-30T14:00:00Z",
+                                "solar-spain-v1",
+                                "solar",
+                                new SimulationDetailsResult.ResolvedLocation("Sevilla, Andalucia, ES", "Sevilla",
+                                                "Andalucia", "Spain", "ES", 37.3891, -5.9845, "Europe/Madrid"),
+                                new SimulationDetailsResult.Summary(recommendation, "headline", "summary",
+                                                List.of(new SimulationDetailsResult.RecommendationReason("economics",
+                                                                "positive", "Driver"))),
+                                new SimulationDetailsResult.Input("Solar - Sevilla", "solar",
+                                                new SimulationDetailsResult.Location("Sevilla, Andalucia, ES", 37.3891,
+                                                                -5.9845, "Spain", "ES"),
+                                                new SimulationDetailsResult.SystemSpec(300, 0.81, 0.5, 99,
+                                                                new SimulationDetailsResult.LossesPct(2, 6, 1, 3, 1)),
+                                                new SimulationDetailsResult.Demand(120000, List.of()),
+                                                new SimulationDetailsResult.Economics("EUR", 315000, 7200, 0.18, 0.07,
+                                                                8, 20)),
+                                new SimulationDetailsResult.Technical(457200, List.of(), specificYield, 0.81, 17.4,
+                                                72.3, 31.5,
+                                                new SimulationDetailsResult.ResourceSeries("PVGIS", "2005-2020",
+                                                                List.of(), List.of()),
+                                                new SimulationDetailsResult.LossesSummary(2, 6, 1, 3, 1, 13),
+                                                List.of()),
+                                new SimulationDetailsResult.Financial("EUR", annualSavings, 8800, netAnnualBenefit,
+                                                paybackYears, 8.7, 121500, 11.4, 0.071, List.of()),
+                                new SimulationDetailsResult.Assumptions(8, 20, 0.5, 0.18, 0.07, "PVGIS", "2005-2020"),
+                                warnings);
+        }
+
+        public static SimulationResultSnapshotReaderPort snapshotReader() {
+                return new SimulationResultSnapshotJacksonReader(new ObjectMapper().findAndRegisterModules());
+        }
+
+        public static ScenarioSnapshotAssembler snapshotAssembler(TechnologyLookupPort technologyLookupPort) {
+                return new ScenarioSnapshotAssembler(
+                                technologyLookupPort,
+                                snapshotReader(),
+                                new PortfolioScenarioScoringPolicy());
+        }
+}


### PR DESCRIPTION
## What changed
- introduces a dedicated `SimulationResultSnapshotReaderPort`
- moves snapshot JSON deserialization behind an infrastructure adapter (`SimulationResultSnapshotJacksonReader`)
- removes direct `ObjectMapper` dependency from `GetSimulationService`
- rewires `GetPortfolioDashboardService` to depend on injected collaborators instead of constructing them with `new`
- makes dashboard snapshot collaborators explicit beans/components
- splits the old cross-feature service test umbrella into feature-focused test classes

## Why
Closes #187.

This is the second implementation slice from the architecture audit in #184. The goal is to remove direct snapshot parsing knowledge from application services and make dashboard collaborators explicit instead of hidden construction details.

## Validation
- `mvn -Dtest=CreateSimulationServiceTest,GetSimulationServiceTest,ListSimulationsServiceTest,GetPortfolioDashboardServiceTest test`
- `mvn -Dtest=CreateSimulationFromScenarioServiceTest,RealSimulationServiceTest,SimulationDeleteControllerTest,SimulationHistoryControllerTest test`

## Notes for reviewers
- This PR intentionally keeps the snapshot format the same; it only moves the parsing boundary.
- The test split (`c39fa43b`) is included first so the application refactor stays reviewable by feature.