### PR TITLE
refactor(simulation): split mixed-responsibility simulation services

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioService.java
@@ -5,13 +5,6 @@ import com.renewsim.backend.simulation_service.create.application.command.Create
 import com.renewsim.backend.simulation_service.create.application.command.CreateSimulationFromScenarioCommand;
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateSimulationFromScenarioUseCase;
-import com.renewsim.backend.simulation_service.domain.exception.InvalidConsumptionProfileException;
-import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
-import com.renewsim.backend.simulation_service.domain.model.vo.Currency;
-import com.renewsim.backend.simulation_service.domain.model.vo.ProjectLifetime;
-import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomics;
-import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
-import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.shared.application.port.out.ScenarioLookupPort;
 import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
@@ -19,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -27,81 +19,28 @@ import java.util.List;
 @Transactional
 public class CreateSimulationFromScenarioService implements CreateSimulationFromScenarioUseCase {
 
-    private static final double DEFAULT_PERFORMANCE_RATIO = 0.81;
-    private static final double DEFAULT_DEGRADATION_RATE_ANNUAL_PCT = 0.5;
-    private static final double DEFAULT_AVAILABILITY_PCT = 99.0;
-    private static final int DEFAULT_PROJECT_LIFETIME_YEARS = 20;
-    private static final double DEFAULT_OPEX_ANNUAL = 0.0;
-    private static final double DEFAULT_EXPORT_PRICE_PER_KWH = 0.07;
-    private static final double DEFAULT_DISCOUNT_RATE_PCT = 8.0;
-    private static final String SUPPORTED_SIMULATION_CURRENCY = "EUR";
+        private final ScenarioLookupPort scenarioLookupPort;
+        private final TechnologyLookupPort technologyLookupPort;
+        private final CreateRealSimulationUseCase createRealSimulationUseCase;
+        private final ScenarioSimulationCommandFactory scenarioSimulationCommandFactory;
 
-    private final ScenarioLookupPort scenarioLookupPort;
-    private final TechnologyLookupPort technologyLookupPort;
-    private final CreateRealSimulationUseCase createRealSimulationUseCase;
+        @Override
+        public SimulationDetailsResult createSimulationFromScenario(CreateSimulationFromScenarioCommand command) {
+                ScenarioLookupPort.ScenarioSnapshot scenario = scenarioLookupPort
+                                .findActiveScenarioById(command.scenarioId())
+                                .orElseThrow(() -> new ScenarioNotFoundException(command.scenarioId()));
 
-    @Override
-    public SimulationDetailsResult createSimulationFromScenario(CreateSimulationFromScenarioCommand command) {
-        ScenarioLookupPort.ScenarioSnapshot scenario = scenarioLookupPort.findActiveScenarioById(command.scenarioId())
-                .orElseThrow(() -> new ScenarioNotFoundException(command.scenarioId()));
+                String energyType = technologyLookupPort.findActiveEnergyTypeByTechnologyId(scenario.technologyId())
+                                .orElseThrow(() -> new ScenarioNotFoundException(command.scenarioId()));
 
-        String energyType = technologyLookupPort.findActiveEnergyTypeByTechnologyId(scenario.technologyId())
-                .orElseThrow(() -> new ScenarioNotFoundException(command.scenarioId()));
+                List<Long> technologyIds = technologyLookupPort.recommendActiveTechnologyIdsByEnergyType(energyType);
 
-        List<Long> technologyIds = technologyLookupPort.recommendActiveTechnologyIdsByEnergyType(energyType);
+                CreateRealSimulationCommand realCommand = scenarioSimulationCommandFactory.fromScenario(
+                                command,
+                                scenario,
+                                energyType,
+                                technologyIds);
 
-        CreateRealSimulationCommand realCommand = new CreateRealSimulationCommand(
-                resolveSimulationName(command.name(), scenario.name()),
-                Technology.of(energyType),
-                command.location(),
-                buildSystem(scenario),
-                buildDemand(scenario),
-                buildEconomics(scenario),
-                technologyIds,
-                scenario.id(),
-                command.createdBy());
-
-        return createRealSimulationUseCase.createSimulation(realCommand);
-    }
-
-    private String resolveSimulationName(String requestedName, String scenarioName) {
-        return requestedName == null || requestedName.isBlank() ? scenarioName : requestedName;
-    }
-
-    private SimulationSystem buildSystem(ScenarioLookupPort.ScenarioSnapshot scenario) {
-        return new SimulationSystem(
-                scenario.defaultCapacityKw(),
-                DEFAULT_PERFORMANCE_RATIO,
-                DEFAULT_DEGRADATION_RATE_ANNUAL_PCT,
-                DEFAULT_AVAILABILITY_PCT,
-                new SimulationSystem.LossesPct(2.0, 6.0, 1.0, 3.0, 1.0));
-    }
-
-    private ConsumptionProfile buildDemand(ScenarioLookupPort.ScenarioSnapshot scenario) {
-        if (scenario.defaultConsumption() <= 0) {
-            throw new InvalidConsumptionProfileException(
-                    "VALIDATION_ERROR: scenario defaultConsumption must be positive");
+                return createRealSimulationUseCase.createSimulation(realCommand);
         }
-        double monthly = scenario.defaultConsumption() / 12.0;
-        List<Double> monthlyConsumption = new ArrayList<>();
-        for (int i = 0; i < 12; i++) {
-            monthlyConsumption.add(monthly);
-        }
-        return ConsumptionProfile.of(scenario.defaultConsumption(), monthlyConsumption);
-    }
-
-    private SimulationEconomics buildEconomics(ScenarioLookupPort.ScenarioSnapshot scenario) {
-        return new SimulationEconomics(
-                Currency.of(resolveSimulationCurrency(scenario.defaultInvestmentCurrency())),
-                scenario.defaultInvestmentAmount(),
-                DEFAULT_OPEX_ANNUAL,
-                scenario.defaultTariff(),
-                DEFAULT_EXPORT_PRICE_PER_KWH,
-                DEFAULT_DISCOUNT_RATE_PCT,
-                ProjectLifetime.of(DEFAULT_PROJECT_LIFETIME_YEARS));
-    }
-
-    private String resolveSimulationCurrency(String scenarioCurrency) {
-        return SUPPORTED_SIMULATION_CURRENCY;
-    }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/ScenarioSimulationCommandFactory.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/ScenarioSimulationCommandFactory.java
@@ -1,0 +1,87 @@
+package com.renewsim.backend.simulation_service.create.application;
+
+import com.renewsim.backend.simulation_service.create.application.command.CreateRealSimulationCommand;
+import com.renewsim.backend.simulation_service.create.application.command.CreateSimulationFromScenarioCommand;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidConsumptionProfileException;
+import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
+import com.renewsim.backend.simulation_service.domain.model.vo.Currency;
+import com.renewsim.backend.simulation_service.domain.model.vo.ProjectLifetime;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomics;
+import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
+import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
+import com.renewsim.backend.simulation_service.shared.application.port.out.ScenarioLookupPort;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ScenarioSimulationCommandFactory {
+
+    private static final double DEFAULT_PERFORMANCE_RATIO = 0.81;
+    private static final double DEFAULT_DEGRADATION_RATE_ANNUAL_PCT = 0.5;
+    private static final double DEFAULT_AVAILABILITY_PCT = 99.0;
+    private static final int DEFAULT_PROJECT_LIFETIME_YEARS = 20;
+    private static final double DEFAULT_OPEX_ANNUAL = 0.0;
+    private static final double DEFAULT_EXPORT_PRICE_PER_KWH = 0.07;
+    private static final double DEFAULT_DISCOUNT_RATE_PCT = 8.0;
+    private static final String SUPPORTED_SIMULATION_CURRENCY = "EUR";
+
+    public CreateRealSimulationCommand fromScenario(
+            CreateSimulationFromScenarioCommand command,
+            ScenarioLookupPort.ScenarioSnapshot scenario,
+            String energyType,
+            List<Long> technologyIds) {
+        return new CreateRealSimulationCommand(
+                resolveSimulationName(command.name(), scenario.name()),
+                Technology.of(energyType),
+                command.location(),
+                buildSystem(scenario),
+                buildDemand(scenario),
+                buildEconomics(scenario),
+                technologyIds,
+                scenario.id(),
+                command.createdBy());
+    }
+
+    private String resolveSimulationName(String requestedName, String scenarioName) {
+        return requestedName == null || requestedName.isBlank() ? scenarioName : requestedName;
+    }
+
+    private SimulationSystem buildSystem(ScenarioLookupPort.ScenarioSnapshot scenario) {
+        return new SimulationSystem(
+                scenario.defaultCapacityKw(),
+                DEFAULT_PERFORMANCE_RATIO,
+                DEFAULT_DEGRADATION_RATE_ANNUAL_PCT,
+                DEFAULT_AVAILABILITY_PCT,
+                new SimulationSystem.LossesPct(2.0, 6.0, 1.0, 3.0, 1.0));
+    }
+
+    private ConsumptionProfile buildDemand(ScenarioLookupPort.ScenarioSnapshot scenario) {
+        if (scenario.defaultConsumption() <= 0) {
+            throw new InvalidConsumptionProfileException(
+                    "VALIDATION_ERROR: scenario defaultConsumption must be positive");
+        }
+        double monthly = scenario.defaultConsumption() / 12.0;
+        List<Double> monthlyConsumption = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            monthlyConsumption.add(monthly);
+        }
+        return ConsumptionProfile.of(scenario.defaultConsumption(), monthlyConsumption);
+    }
+
+    private SimulationEconomics buildEconomics(ScenarioLookupPort.ScenarioSnapshot scenario) {
+        return new SimulationEconomics(
+                Currency.of(resolveSimulationCurrency(scenario.defaultInvestmentCurrency())),
+                scenario.defaultInvestmentAmount(),
+                DEFAULT_OPEX_ANNUAL,
+                scenario.defaultTariff(),
+                DEFAULT_EXPORT_PRICE_PER_KWH,
+                DEFAULT_DISCOUNT_RATE_PCT,
+                ProjectLifetime.of(DEFAULT_PROJECT_LIFETIME_YEARS));
+    }
+
+    private String resolveSimulationCurrency(String scenarioCurrency) {
+        return SUPPORTED_SIMULATION_CURRENCY;
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
@@ -1,16 +1,14 @@
 package com.renewsim.backend.simulation_service.dashboard.application;
 
-import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
-import com.renewsim.backend.simulation_service.domain.policy.SimulationRecommendationReviewPolicy;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.ScenarioSnapshot;
+import com.renewsim.backend.simulation_service.dashboard.application.ScenarioSnapshotMetricsResolver.ScenarioSnapshotMetrics;
+import com.renewsim.backend.simulation_service.dashboard.application.ScenarioSnapshotNarrativeResolver.ScenarioSnapshotNarrative;
 import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationResultSnapshotReaderPort;
-import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Locale;
 
 /**
@@ -20,10 +18,10 @@ import java.util.Locale;
 @RequiredArgsConstructor
 public final class ScenarioSnapshotAssembler {
 
-        private final TechnologyLookupPort technologyLookupPort;
         private final SimulationResultSnapshotReaderPort snapshotReader;
         private final PortfolioScenarioScoringPolicy scoringPolicy;
-        private final SimulationRecommendationReviewPolicy reviewPolicy = new SimulationRecommendationReviewPolicy();
+        private final ScenarioSnapshotMetricsResolver metricsResolver;
+        private final ScenarioSnapshotNarrativeResolver narrativeResolver;
 
         public ScenarioSnapshot toSnapshot(Simulation simulation) {
                 SimulationDetailsResult details = readDetails(simulation.getResultSnapshot());
@@ -31,39 +29,10 @@ public final class ScenarioSnapshotAssembler {
                 SimulationDetailsResult.Technical technical = details != null ? details.technical() : null;
                 SimulationDetailsResult.Summary summary = details != null ? details.summary() : null;
                 boolean hasCompleteDetails = financial != null && technical != null && summary != null;
-                Double capex = simulation.getEconomics() != null ? simulation.getEconomics().capexTotal() : null;
-                Double annualSavings = financial != null ? Double.valueOf(financial.annualSavings())
-                                : simulation.getAnnualSavings();
-                Double annualBenefit = financial != null ? Double.valueOf(financial.netAnnualBenefit())
-                                : simulation.getAnnualSavings();
-                Double paybackYears = financial != null ? financial.paybackYears() : null;
-                Double roiPercent = roiPercent(capex, annualBenefit);
-                double annualGeneration = technical != null ? technical.annualGenerationKwh()
-                                : defaultNumber(simulation.getAnnualGenerationKwh());
-                double co2SavedKg = annualGeneration > 0.0 && simulation.getTechnology() != null
-                                ? technologyLookupPort
-                                                .findActiveCo2ReductionFactorByEnergyType(
-                                                                simulation.getTechnology().value())
-                                                .map(factor -> annualGeneration * factor)
-                                                .orElse(0.0)
-                                : 0.0;
-                String recommendation = summary != null && summary.recommendation() != null
-                                ? summary.recommendation()
-                                : "review_required";
-                SimulationRecommendation normalizedRecommendation = SimulationRecommendation
-                                .fromWireValue(recommendation);
-                List<String> drivers = summary != null && summary.reasons() != null
-                                ? summary.reasons().stream()
-                                                .map(SimulationDetailsResult.RecommendationReason::message)
-                                                .filter(message -> message != null && !message.isBlank())
-                                                .limit(3)
-                                                .toList()
-                                : List.of("El escenario todavia no tiene salida financiera consolidada.");
-                if (drivers.isEmpty()) {
-                        drivers = List.of("El escenario todavia no tiene salida financiera consolidada.");
-                }
+                ScenarioSnapshotMetrics metrics = metricsResolver.resolve(simulation, details);
+                ScenarioSnapshotNarrative narrative = narrativeResolver.resolve(details);
 
-                int score = scoringPolicy.computeScore(details, roiPercent, paybackYears);
+                int score = scoringPolicy.computeScore(details, metrics.roiPercent(), metrics.paybackYears());
 
                 return new ScenarioSnapshot(
                                 String.valueOf(simulation.getId().value()),
@@ -73,42 +42,27 @@ public final class ScenarioSnapshotAssembler {
                                 normalizeLabel(simulation.getStatus() != null ? simulation.getStatus().name()
                                                 : "draft"),
                                 simulation.getLocation().label(),
-                                roiPercent,
-                                paybackYears,
-                                capex,
-                                annualSavings,
-                                round(annualGeneration),
-                                round(co2SavedKg),
-                                summary != null && summary.headline() != null
-                                                ? summary.headline()
-                                                : "El escenario necesita completar datos antes de priorizarse.",
-                                drivers,
-                                scoringPolicy.resolveMainRisk(details, paybackYears, roiPercent),
-                                reviewPolicy.nextStepFor(normalizedRecommendation),
+                                metrics.roiPercent(),
+                                metrics.paybackYears(),
+                                metrics.capex(),
+                                metrics.annualSavings(),
+                                round(metrics.annualGeneration()),
+                                round(metrics.co2SavedKg()),
+                                narrative.headline(),
+                                narrative.drivers(),
+                                scoringPolicy.resolveMainRisk(details, metrics.paybackYears(), metrics.roiPercent()),
+                                narrative.nextStep(),
                                 scoringPolicy.priorityFor(score, hasCompleteDetails),
                                 score,
                                 simulation.getCreatedAt(),
                                 !hasCompleteDetails,
-                                reviewPolicy.needsReview(
-                                                normalizedRecommendation,
-                                                details != null && details.warnings() != null
-                                                                && details.warnings().stream().anyMatch(
-                                                                                warning -> "warning".equalsIgnoreCase(
-                                                                                                warning.severity())),
-                                                hasCompleteDetails),
-                                scoringPolicy.hasNegativeRoi(roiPercent),
-                                scoringPolicy.hasLongPayback(paybackYears));
+                                narrativeResolver.needsReview(narrative, hasCompleteDetails),
+                                scoringPolicy.hasNegativeRoi(metrics.roiPercent()),
+                                scoringPolicy.hasLongPayback(metrics.paybackYears()));
         }
 
         private SimulationDetailsResult readDetails(String raw) {
                 return snapshotReader.read(raw);
-        }
-
-        private Double roiPercent(Double capex, Double annualBenefit) {
-                if (capex == null || annualBenefit == null || capex <= 0.0) {
-                        return null;
-                }
-                return round((annualBenefit / capex) * 100.0);
         }
 
         private String normalizeLabel(String value) {
@@ -119,7 +73,4 @@ public final class ScenarioSnapshotAssembler {
                 return Math.round(value * 100.0) / 100.0;
         }
 
-        private double defaultNumber(Double value) {
-                return value == null ? 0.0 : value;
-        }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotMetricsResolver.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotMetricsResolver.java
@@ -1,0 +1,62 @@
+package com.renewsim.backend.simulation_service.dashboard.application;
+
+import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public final class ScenarioSnapshotMetricsResolver {
+
+    private final TechnologyLookupPort technologyLookupPort;
+
+    public ScenarioSnapshotMetrics resolve(Simulation simulation, SimulationDetailsResult details) {
+        SimulationDetailsResult.Financial financial = details != null ? details.financial() : null;
+        SimulationDetailsResult.Technical technical = details != null ? details.technical() : null;
+
+        Double capex = simulation.getEconomics() != null ? simulation.getEconomics().capexTotal() : null;
+        Double annualSavings = financial != null ? Double.valueOf(financial.annualSavings())
+                : simulation.getAnnualSavings();
+        Double annualBenefit = financial != null ? Double.valueOf(financial.netAnnualBenefit())
+                : simulation.getAnnualSavings();
+        Double paybackYears = financial != null ? financial.paybackYears() : null;
+        Double roiPercent = roiPercent(capex, annualBenefit);
+        double annualGeneration = technical != null ? technical.annualGenerationKwh()
+                : defaultNumber(simulation.getAnnualGenerationKwh());
+        double co2SavedKg = annualGeneration > 0.0 && simulation.getTechnology() != null
+                ? technologyLookupPort.findActiveCo2ReductionFactorByEnergyType(simulation.getTechnology().value())
+                        .map(factor -> annualGeneration * factor)
+                        .orElse(0.0)
+                : 0.0;
+
+        return new ScenarioSnapshotMetrics(capex, annualSavings, annualBenefit, paybackYears, roiPercent,
+                annualGeneration, co2SavedKg);
+    }
+
+    private Double roiPercent(Double capex, Double annualBenefit) {
+        if (capex == null || annualBenefit == null || capex <= 0.0) {
+            return null;
+        }
+        return round((annualBenefit / capex) * 100.0);
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    private double defaultNumber(Double value) {
+        return value == null ? 0.0 : value;
+    }
+
+    public record ScenarioSnapshotMetrics(
+            Double capex,
+            Double annualSavings,
+            Double annualBenefit,
+            Double paybackYears,
+            Double roiPercent,
+            double annualGeneration,
+            double co2SavedKg) {
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotNarrativeResolver.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotNarrativeResolver.java
@@ -1,0 +1,58 @@
+package com.renewsim.backend.simulation_service.dashboard.application;
+
+import com.renewsim.backend.simulation_service.domain.model.SimulationRecommendation;
+import com.renewsim.backend.simulation_service.domain.policy.SimulationRecommendationReviewPolicy;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public final class ScenarioSnapshotNarrativeResolver {
+
+        private final SimulationRecommendationReviewPolicy reviewPolicy = new SimulationRecommendationReviewPolicy();
+
+        public ScenarioSnapshotNarrative resolve(SimulationDetailsResult details) {
+                SimulationDetailsResult.Summary summary = details != null ? details.summary() : null;
+                String recommendation = summary != null && summary.recommendation() != null
+                                ? summary.recommendation()
+                                : "review_required";
+                SimulationRecommendation normalizedRecommendation = SimulationRecommendation
+                                .fromWireValue(recommendation);
+
+                List<String> drivers = summary != null && summary.reasons() != null
+                                ? summary.reasons().stream()
+                                                .map(SimulationDetailsResult.RecommendationReason::message)
+                                                .filter(message -> message != null && !message.isBlank())
+                                                .limit(3)
+                                                .toList()
+                                : List.of("El escenario todavia no tiene salida financiera consolidada.");
+                if (drivers.isEmpty()) {
+                        drivers = List.of("El escenario todavia no tiene salida financiera consolidada.");
+                }
+
+                String headline = summary != null && summary.headline() != null
+                                ? summary.headline()
+                                : "El escenario necesita completar datos antes de priorizarse.";
+
+                boolean hasWarnings = details != null && details.warnings() != null
+                                && details.warnings().stream()
+                                                .anyMatch(warning -> "warning".equalsIgnoreCase(warning.severity()));
+
+                return new ScenarioSnapshotNarrative(normalizedRecommendation, drivers, headline, hasWarnings,
+                                reviewPolicy.nextStepFor(normalizedRecommendation));
+        }
+
+        public boolean needsReview(ScenarioSnapshotNarrative narrative, boolean hasCompleteDetails) {
+                return reviewPolicy.needsReview(narrative.recommendation(), narrative.hasWarnings(),
+                                hasCompleteDetails);
+        }
+
+        public record ScenarioSnapshotNarrative(
+                        SimulationRecommendation recommendation,
+                        List<String> drivers,
+                        String headline,
+                        boolean hasWarnings,
+                        String nextStep) {
+        }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodec.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotCodec.java
@@ -2,10 +2,8 @@ package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persi
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
-import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -15,9 +13,15 @@ import java.util.List;
 final class SimulationInputSnapshotCodec {
 
     private final ObjectMapper objectMapper;
+    private final SimulationInputSnapshotNormalizer normalizer;
 
     SimulationInputSnapshotCodec(ObjectMapper objectMapper) {
+        this(objectMapper, new SimulationInputSnapshotNormalizer());
+    }
+
+    SimulationInputSnapshotCodec(ObjectMapper objectMapper, SimulationInputSnapshotNormalizer normalizer) {
         this.objectMapper = objectMapper;
+        this.normalizer = normalizer;
     }
 
     String write(Simulation simulation) {
@@ -48,38 +52,7 @@ final class SimulationInputSnapshotCodec {
     }
 
     SimulationInputData readNormalized(String json, SimulationEntity entity) {
-        SimulationInputData input = read(json);
-        String normalizedCountryCode = normalizeCountryCode(input.locationCountryCode(), entity.getLocation());
-        String normalizedCountry = deriveCountry(normalizedCountryCode);
-
-        double annualConsumption = input.annualConsumptionKwh() > 0
-                ? input.annualConsumptionKwh()
-                : Math.max(defaultNumber(entity.getEstimatedEnergy()), 1.0);
-
-        List<Double> monthlyConsumption = input.monthlyConsumptionKwh() != null
-                && input.monthlyConsumptionKwh().size() == 12
-                        ? input.monthlyConsumptionKwh()
-                        : evenMonthlyProfile(annualConsumption);
-
-        return new SimulationInputData(
-                normalizedCountry,
-                normalizedCountryCode,
-                input.performanceRatio() > 0 ? input.performanceRatio() : 0.81,
-                input.degradationRateAnnualPct() >= 0 ? input.degradationRateAnnualPct() : 0.5,
-                input.availabilityPct() > 0 ? input.availabilityPct() : 99.0,
-                Math.max(input.lossesInverter(), 0.0),
-                Math.max(input.lossesTemperature(), 0.0),
-                Math.max(input.lossesWiring(), 0.0),
-                Math.max(input.lossesSoiling(), 0.0),
-                Math.max(input.lossesOther(), 0.0),
-                annualConsumption,
-                monthlyConsumption,
-                isBlank(input.currency()) ? "EUR" : input.currency(),
-                Math.max(input.opexAnnual(), 0.0),
-                Math.max(input.electricityPurchasePricePerKwh(), 0.0),
-                Math.max(input.exportPricePerKwh(), 0.0),
-                Math.max(input.discountRatePct(), 0.0),
-                input.projectLifetimeYears() >= 5 ? input.projectLifetimeYears() : 20);
+        return normalizer.normalize(read(json), entity);
     }
 
     private SimulationInputData read(String json) {
@@ -91,41 +64,6 @@ final class SimulationInputSnapshotCodec {
         } catch (Exception ex) {
             throw new IllegalStateException("Failed to deserialize input snapshot", ex);
         }
-    }
-
-    private String deriveCountryCode(String locationLabel) {
-        if (locationLabel != null) {
-            String[] parts = locationLabel.split(",");
-            String candidate = parts[parts.length - 1].trim();
-            if (candidate.length() == 2) {
-                return candidate.toUpperCase();
-            }
-        }
-        return "ES";
-    }
-
-    private String normalizeCountryCode(String snapshotCountryCode, String locationLabel) {
-        String candidate = isBlank(snapshotCountryCode)
-                ? deriveCountryCode(locationLabel)
-                : snapshotCountryCode.trim().toUpperCase();
-        return CountryCode.isSupported(candidate) ? candidate : "ES";
-    }
-
-    private String deriveCountry(String countryCode) {
-        return "ES".equalsIgnoreCase(countryCode) ? "Spain" : countryCode;
-    }
-
-    private List<Double> evenMonthlyProfile(double annualConsumption) {
-        double monthly = annualConsumption / 12.0;
-        return Collections.nCopies(12, monthly);
-    }
-
-    private boolean isBlank(String value) {
-        return value == null || value.isBlank();
-    }
-
-    private double defaultNumber(Double value) {
-        return value == null ? 0.0 : value;
     }
 
     record SimulationInputData(

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotNormalizer.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/persistence/SimulationInputSnapshotNormalizer.java
@@ -1,0 +1,80 @@
+package com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence;
+
+import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.SimulationInputSnapshotCodec.SimulationInputData;
+import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.entity.SimulationEntity;
+
+import java.util.Collections;
+import java.util.List;
+
+final class SimulationInputSnapshotNormalizer {
+
+    SimulationInputData normalize(SimulationInputData input, SimulationEntity entity) {
+        String normalizedCountryCode = normalizeCountryCode(input.locationCountryCode(), entity.getLocation());
+        String normalizedCountry = deriveCountry(normalizedCountryCode);
+
+        double annualConsumption = input.annualConsumptionKwh() > 0
+                ? input.annualConsumptionKwh()
+                : Math.max(defaultNumber(entity.getEstimatedEnergy()), 1.0);
+
+        List<Double> monthlyConsumption = input.monthlyConsumptionKwh() != null
+                && input.monthlyConsumptionKwh().size() == 12
+                        ? input.monthlyConsumptionKwh()
+                        : evenMonthlyProfile(annualConsumption);
+
+        return new SimulationInputData(
+                normalizedCountry,
+                normalizedCountryCode,
+                input.performanceRatio() > 0 ? input.performanceRatio() : 0.81,
+                input.degradationRateAnnualPct() >= 0 ? input.degradationRateAnnualPct() : 0.5,
+                input.availabilityPct() > 0 ? input.availabilityPct() : 99.0,
+                Math.max(input.lossesInverter(), 0.0),
+                Math.max(input.lossesTemperature(), 0.0),
+                Math.max(input.lossesWiring(), 0.0),
+                Math.max(input.lossesSoiling(), 0.0),
+                Math.max(input.lossesOther(), 0.0),
+                annualConsumption,
+                monthlyConsumption,
+                isBlank(input.currency()) ? "EUR" : input.currency(),
+                Math.max(input.opexAnnual(), 0.0),
+                Math.max(input.electricityPurchasePricePerKwh(), 0.0),
+                Math.max(input.exportPricePerKwh(), 0.0),
+                Math.max(input.discountRatePct(), 0.0),
+                input.projectLifetimeYears() >= 5 ? input.projectLifetimeYears() : 20);
+    }
+
+    private String deriveCountryCode(String locationLabel) {
+        if (locationLabel != null) {
+            String[] parts = locationLabel.split(",");
+            String candidate = parts[parts.length - 1].trim();
+            if (candidate.length() == 2) {
+                return candidate.toUpperCase();
+            }
+        }
+        return "ES";
+    }
+
+    private String normalizeCountryCode(String snapshotCountryCode, String locationLabel) {
+        String candidate = isBlank(snapshotCountryCode)
+                ? deriveCountryCode(locationLabel)
+                : snapshotCountryCode.trim().toUpperCase();
+        return CountryCode.isSupported(candidate) ? candidate : "ES";
+    }
+
+    private String deriveCountry(String countryCode) {
+        return "ES".equalsIgnoreCase(countryCode) ? "Spain" : countryCode;
+    }
+
+    private List<Double> evenMonthlyProfile(double annualConsumption) {
+        double monthly = annualConsumption / 12.0;
+        return Collections.nCopies(12, monthly);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private double defaultNumber(Double value) {
+        return value == null ? 0.0 : value;
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationDetailsWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationDetailsWebMapper.java
@@ -14,125 +14,147 @@ public final class SimulationDetailsWebMapper {
                                 result.updatedAt(),
                                 result.modelVersion(),
                                 result.technology(),
-                                new SimulationDetailsResponseDTO.ResolvedLocationDTO(
-                                                result.location().label(),
-                                                result.location().name(),
-                                                result.location().adminRegion(),
-                                                result.location().country(),
-                                                result.location().countryCode(),
-                                                result.location().lat(),
-                                                result.location().lon(),
-                                                result.location().timezone()),
-                                new SimulationDetailsResponseDTO.SummaryDTO(
-                                                result.summary().recommendation(),
-                                                result.summary().headline(),
-                                                result.summary().summary(),
-                                                result.summary().reasons().stream()
-                                                                .map(reason -> new SimulationDetailsResponseDTO.RecommendationReasonDTO(
-                                                                                reason.area(),
-                                                                                reason.severity(),
-                                                                                reason.message()))
-                                                                .toList()),
-                                new SimulationInputSnapshotDTO(
-                                                result.input().name(),
-                                                result.input().technology(),
-                                                new SimulationInputSnapshotDTO.LocationDTO(
-                                                                result.input().location().label(),
-                                                                result.input().location().lat(),
-                                                                result.input().location().lon(),
-                                                                result.input().location().country(),
-                                                                result.input().location().countryCode()),
-                                                new SimulationInputSnapshotDTO.SystemDTO(
-                                                                result.input().system().installedCapacityKw(),
-                                                                result.input().system().performanceRatio(),
-                                                                result.input().system().degradationRateAnnualPct(),
-                                                                result.input().system().availabilityPct(),
-                                                                new SimulationInputSnapshotDTO.LossesPctDTO(
-                                                                                result.input().system().lossesPct()
-                                                                                                .inverter(),
-                                                                                result.input().system().lossesPct()
-                                                                                                .temperature(),
-                                                                                result.input().system().lossesPct()
-                                                                                                .wiring(),
-                                                                                result.input().system().lossesPct()
-                                                                                                .soiling(),
-                                                                                result.input().system().lossesPct()
-                                                                                                .other())),
-                                                new SimulationInputSnapshotDTO.DemandDTO(
-                                                                result.input().demand().annualConsumptionKwh(),
-                                                                result.input().demand().monthlyConsumptionKwh()),
-                                                new SimulationInputSnapshotDTO.EconomicsDTO(
-                                                                result.input().economics().currency(),
-                                                                result.input().economics().capexTotal(),
-                                                                result.input().economics().opexAnnual(),
-                                                                result.input().economics()
-                                                                                .electricityPurchasePricePerKwh(),
-                                                                result.input().economics().exportPricePerKwh(),
-                                                                result.input().economics().discountRatePct(),
-                                                                result.input().economics().projectLifetimeYears())),
-                                new SimulationDetailsResponseDTO.TechnicalDTO(
-                                                result.technical().annualGenerationKwh(),
-                                                result.technical().monthlyGenerationKwh(),
-                                                result.technical().specificYieldKwhPerKwp(),
-                                                result.technical().performanceRatio(),
-                                                result.technical().capacityFactorPct(),
-                                                result.technical().selfConsumptionRatePct(),
-                                                result.technical().coverageRatePct(),
-                                                new SimulationDetailsResponseDTO.ResourceSeriesDTO(
-                                                                result.technical().resource().source(),
-                                                                result.technical().resource().period(),
-                                                                result.technical().resource().monthlyIrradianceKwhM2(),
-                                                                result.technical().resource().monthlyTemperatureC()),
-                                                new SimulationDetailsResponseDTO.LossesSummaryDTO(
-                                                                result.technical().lossesPct().inverter(),
-                                                                result.technical().lossesPct().temperature(),
-                                                                result.technical().lossesPct().wiring(),
-                                                                result.technical().lossesPct().soiling(),
-                                                                result.technical().lossesPct().other(),
-                                                                result.technical().lossesPct().total()),
-                                                result.technical().balanceByMonth().stream()
-                                                                .map(item -> new SimulationDetailsResponseDTO.MonthlyEnergyBalanceItemDTO(
-                                                                                item.month(),
-                                                                                item.generationKwh(),
-                                                                                item.consumptionKwh(),
-                                                                                item.selfConsumedKwh(),
-                                                                                item.exportedKwh(),
-                                                                                item.importedKwh()))
-                                                                .toList()),
-                                new SimulationDetailsResponseDTO.FinancialDTO(
-                                                result.financial().currency(),
-                                                result.financial().annualSavings(),
-                                                result.financial().annualExportRevenue(),
-                                                result.financial().netAnnualBenefit(),
-                                                result.financial().paybackYears(),
-                                                result.financial().discountedPaybackYears(),
-                                                result.financial().npv(),
-                                                result.financial().irrPct(),
-                                                result.financial().lcoePerKwh(),
-                                                result.financial().yearlyCashFlows().stream()
-                                                                .map(item -> new SimulationDetailsResponseDTO.FinancialYearItemDTO(
-                                                                                item.year(),
-                                                                                item.savings(),
-                                                                                item.exportRevenue(),
-                                                                                item.opex(),
-                                                                                item.replacementCost(),
-                                                                                item.netCashFlow(),
-                                                                                item.discountedCashFlow(),
-                                                                                item.cumulativeCashFlow()))
-                                                                .toList()),
-                                new SimulationDetailsResponseDTO.AssumptionsDTO(
-                                                result.assumptions().discountRatePct(),
-                                                result.assumptions().projectLifetimeYears(),
-                                                result.assumptions().degradationRateAnnualPct(),
-                                                result.assumptions().electricityPurchasePricePerKwh(),
-                                                result.assumptions().exportPricePerKwh(),
-                                                result.assumptions().climateSource(),
-                                                result.assumptions().climatePeriod()),
-                                result.warnings().stream()
-                                                .map(warning -> new SimulationDetailsResponseDTO.SimulationWarningDTO(
-                                                                warning.severity(),
-                                                                warning.code(),
-                                                                warning.message()))
+                                toResolvedLocation(result),
+                                toSummary(result),
+                                toInput(result),
+                                toTechnical(result),
+                                toFinancial(result),
+                                toAssumptions(result),
+                                toWarnings(result));
+        }
+
+        private SimulationDetailsResponseDTO.ResolvedLocationDTO toResolvedLocation(SimulationDetailsResult result) {
+                return new SimulationDetailsResponseDTO.ResolvedLocationDTO(
+                                result.location().label(),
+                                result.location().name(),
+                                result.location().adminRegion(),
+                                result.location().country(),
+                                result.location().countryCode(),
+                                result.location().lat(),
+                                result.location().lon(),
+                                result.location().timezone());
+        }
+
+        private SimulationDetailsResponseDTO.SummaryDTO toSummary(SimulationDetailsResult result) {
+                return new SimulationDetailsResponseDTO.SummaryDTO(
+                                result.summary().recommendation(),
+                                result.summary().headline(),
+                                result.summary().summary(),
+                                result.summary().reasons().stream()
+                                                .map(reason -> new SimulationDetailsResponseDTO.RecommendationReasonDTO(
+                                                                reason.area(),
+                                                                reason.severity(),
+                                                                reason.message()))
                                                 .toList());
+        }
+
+        private SimulationInputSnapshotDTO toInput(SimulationDetailsResult result) {
+                return new SimulationInputSnapshotDTO(
+                                result.input().name(),
+                                result.input().technology(),
+                                new SimulationInputSnapshotDTO.LocationDTO(
+                                                result.input().location().label(),
+                                                result.input().location().lat(),
+                                                result.input().location().lon(),
+                                                result.input().location().country(),
+                                                result.input().location().countryCode()),
+                                new SimulationInputSnapshotDTO.SystemDTO(
+                                                result.input().system().installedCapacityKw(),
+                                                result.input().system().performanceRatio(),
+                                                result.input().system().degradationRateAnnualPct(),
+                                                result.input().system().availabilityPct(),
+                                                new SimulationInputSnapshotDTO.LossesPctDTO(
+                                                                result.input().system().lossesPct().inverter(),
+                                                                result.input().system().lossesPct().temperature(),
+                                                                result.input().system().lossesPct().wiring(),
+                                                                result.input().system().lossesPct().soiling(),
+                                                                result.input().system().lossesPct().other())),
+                                new SimulationInputSnapshotDTO.DemandDTO(
+                                                result.input().demand().annualConsumptionKwh(),
+                                                result.input().demand().monthlyConsumptionKwh()),
+                                new SimulationInputSnapshotDTO.EconomicsDTO(
+                                                result.input().economics().currency(),
+                                                result.input().economics().capexTotal(),
+                                                result.input().economics().opexAnnual(),
+                                                result.input().economics().electricityPurchasePricePerKwh(),
+                                                result.input().economics().exportPricePerKwh(),
+                                                result.input().economics().discountRatePct(),
+                                                result.input().economics().projectLifetimeYears()));
+        }
+
+        private SimulationDetailsResponseDTO.TechnicalDTO toTechnical(SimulationDetailsResult result) {
+                return new SimulationDetailsResponseDTO.TechnicalDTO(
+                                result.technical().annualGenerationKwh(),
+                                result.technical().monthlyGenerationKwh(),
+                                result.technical().specificYieldKwhPerKwp(),
+                                result.technical().performanceRatio(),
+                                result.technical().capacityFactorPct(),
+                                result.technical().selfConsumptionRatePct(),
+                                result.technical().coverageRatePct(),
+                                new SimulationDetailsResponseDTO.ResourceSeriesDTO(
+                                                result.technical().resource().source(),
+                                                result.technical().resource().period(),
+                                                result.technical().resource().monthlyIrradianceKwhM2(),
+                                                result.technical().resource().monthlyTemperatureC()),
+                                new SimulationDetailsResponseDTO.LossesSummaryDTO(
+                                                result.technical().lossesPct().inverter(),
+                                                result.technical().lossesPct().temperature(),
+                                                result.technical().lossesPct().wiring(),
+                                                result.technical().lossesPct().soiling(),
+                                                result.technical().lossesPct().other(),
+                                                result.technical().lossesPct().total()),
+                                result.technical().balanceByMonth().stream()
+                                                .map(item -> new SimulationDetailsResponseDTO.MonthlyEnergyBalanceItemDTO(
+                                                                item.month(),
+                                                                item.generationKwh(),
+                                                                item.consumptionKwh(),
+                                                                item.selfConsumedKwh(),
+                                                                item.exportedKwh(),
+                                                                item.importedKwh()))
+                                                .toList());
+        }
+
+        private SimulationDetailsResponseDTO.FinancialDTO toFinancial(SimulationDetailsResult result) {
+                return new SimulationDetailsResponseDTO.FinancialDTO(
+                                result.financial().currency(),
+                                result.financial().annualSavings(),
+                                result.financial().annualExportRevenue(),
+                                result.financial().netAnnualBenefit(),
+                                result.financial().paybackYears(),
+                                result.financial().discountedPaybackYears(),
+                                result.financial().npv(),
+                                result.financial().irrPct(),
+                                result.financial().lcoePerKwh(),
+                                result.financial().yearlyCashFlows().stream()
+                                                .map(item -> new SimulationDetailsResponseDTO.FinancialYearItemDTO(
+                                                                item.year(),
+                                                                item.savings(),
+                                                                item.exportRevenue(),
+                                                                item.opex(),
+                                                                item.replacementCost(),
+                                                                item.netCashFlow(),
+                                                                item.discountedCashFlow(),
+                                                                item.cumulativeCashFlow()))
+                                                .toList());
+        }
+
+        private SimulationDetailsResponseDTO.AssumptionsDTO toAssumptions(SimulationDetailsResult result) {
+                return new SimulationDetailsResponseDTO.AssumptionsDTO(
+                                result.assumptions().discountRatePct(),
+                                result.assumptions().projectLifetimeYears(),
+                                result.assumptions().degradationRateAnnualPct(),
+                                result.assumptions().electricityPurchasePricePerKwh(),
+                                result.assumptions().exportPricePerKwh(),
+                                result.assumptions().climateSource(),
+                                result.assumptions().climatePeriod());
+        }
+
+        private java.util.List<SimulationDetailsResponseDTO.SimulationWarningDTO> toWarnings(SimulationDetailsResult result) {
+                return result.warnings().stream()
+                                .map(warning -> new SimulationDetailsResponseDTO.SimulationWarningDTO(
+                                                warning.severity(),
+                                                warning.code(),
+                                                warning.message()))
+                                .toList();
         }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
@@ -55,13 +55,16 @@ class CreateSimulationFromScenarioServiceTest {
         @Mock
         private PvgisSolarResourcePort resourcePort;
 
+        private final ScenarioSimulationCommandFactory scenarioSimulationCommandFactory = new ScenarioSimulationCommandFactory();
+
         @Test
         @DisplayName("createSimulationFromScenario resolves scenario defaults and delegates to the real flow")
         void createSimulationFromScenarioResolvesScenarioDefaultsAndDelegates() {
                 CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
                                 scenarioLookupPort,
                                 technologyLookupPort,
-                                realCreateService());
+                                realCreateService(),
+                                scenarioSimulationCommandFactory);
 
                 when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
                 when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
@@ -106,7 +109,8 @@ class CreateSimulationFromScenarioServiceTest {
                 CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
                                 scenarioLookupPort,
                                 technologyLookupPort,
-                                realCreateService());
+                                realCreateService(),
+                                scenarioSimulationCommandFactory);
 
                 when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
                 when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
@@ -139,7 +143,8 @@ class CreateSimulationFromScenarioServiceTest {
                 CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
                                 scenarioLookupPort,
                                 technologyLookupPort,
-                                realCreateService(persistenceRepository));
+                                realCreateService(persistenceRepository),
+                                scenarioSimulationCommandFactory);
 
                 when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(
                                 Optional.of(scenarioSnapshot()),
@@ -193,7 +198,8 @@ class CreateSimulationFromScenarioServiceTest {
                 CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
                                 scenarioLookupPort,
                                 technologyLookupPort,
-                                realCreateService());
+                                realCreateService(),
+                                scenarioSimulationCommandFactory);
 
                 when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
                 when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
@@ -224,7 +230,8 @@ class CreateSimulationFromScenarioServiceTest {
                 CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
                                 scenarioLookupPort,
                                 technologyLookupPort,
-                                realCreateService());
+                                realCreateService(),
+                                scenarioSimulationCommandFactory);
 
                 when(scenarioLookupPort.findActiveScenarioById(99L)).thenReturn(Optional.empty());
 
@@ -247,7 +254,8 @@ class CreateSimulationFromScenarioServiceTest {
                 CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
                                 scenarioLookupPort,
                                 technologyLookupPort,
-                                realCreateService());
+                                realCreateService(),
+                                scenarioSimulationCommandFactory);
 
                 when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(scenarioSnapshot()));
                 when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.empty());
@@ -270,7 +278,8 @@ class CreateSimulationFromScenarioServiceTest {
                 CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
                                 scenarioLookupPort,
                                 technologyLookupPort,
-                                realCreateService());
+                                realCreateService(),
+                                scenarioSimulationCommandFactory);
 
                 when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(
                                 new ScenarioLookupPort.ScenarioSnapshot(7L, "Hogar solar - Sevilla", 1L,

--- a/src/test/java/com/renewsim/backend/simulation_service/support/SimulationServiceTestFixtures.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/support/SimulationServiceTestFixtures.java
@@ -8,7 +8,10 @@ import com.renewsim.backend.simulation_service.create.application.technology.hyd
 import com.renewsim.backend.simulation_service.create.application.technology.solar.SolarSimulationAssessmentPolicy;
 import com.renewsim.backend.simulation_service.create.application.technology.solar.SolarSimulationEngine;
 import com.renewsim.backend.simulation_service.create.application.technology.wind.WindSimulationEngine;
+import com.renewsim.backend.simulation_service.dashboard.application.PortfolioDashboardAggregator;
 import com.renewsim.backend.simulation_service.dashboard.application.PortfolioScenarioScoringPolicy;
+import com.renewsim.backend.simulation_service.dashboard.application.ScenarioSnapshotMetricsResolver;
+import com.renewsim.backend.simulation_service.dashboard.application.ScenarioSnapshotNarrativeResolver;
 import com.renewsim.backend.simulation_service.dashboard.application.ScenarioSnapshotAssembler;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationStatus;
@@ -164,8 +167,13 @@ public final class SimulationServiceTestFixtures {
 
         public static ScenarioSnapshotAssembler snapshotAssembler(TechnologyLookupPort technologyLookupPort) {
                 return new ScenarioSnapshotAssembler(
-                                technologyLookupPort,
                                 snapshotReader(),
-                                new PortfolioScenarioScoringPolicy());
+                                new PortfolioScenarioScoringPolicy(),
+                                new ScenarioSnapshotMetricsResolver(technologyLookupPort),
+                                new ScenarioSnapshotNarrativeResolver());
+        }
+
+        public static PortfolioDashboardAggregator dashboardAggregator() {
+                return new PortfolioDashboardAggregator();
         }
 }


### PR DESCRIPTION
## What changed
- extracts `ScenarioSimulationCommandFactory` so `CreateSimulationFromScenarioService` stops mixing translation defaults with use-case orchestration
- separates legacy normalization from `SimulationInputSnapshotCodec` into `SimulationInputSnapshotNormalizer`
- splits dashboard snapshot responsibilities by introducing dedicated metrics and narrative resolvers used by `ScenarioSnapshotAssembler`
- fragments `SimulationDetailsWebMapper` into internal section helpers (`location`, `summary`, `input`, `technical`, `financial`, `assumptions`, `warnings`) so the mapper no longer carries one monolithic conversion block

## Why
Closes #189.

This is stage 3 of the `simulation_service` architecture hardening plan from #184. The goal is to reduce SRP violations in classes that were mixing orchestration, normalization, parsing, enrichment and oversized mapping concerns.

## Validation
- `mvn -Dtest=CreateSimulationFromScenarioServiceTest,SimulationInputSnapshotCodecTest,GetPortfolioDashboardServiceTest,GetSimulationServiceTest,CreateSimulationServiceTest,ListSimulationsServiceTest test`
- `mvn -Dtest=SimulationDetailsWebMapperTest,CreateSimulationControllerTest,SimulationDetailControllerTest test`

## Notes for reviewers
- This PR intentionally keeps functional behavior stable; it only redistributes responsibilities across collaborators.
- The previous test umbrella split was done separately so this PR can stay focused on SRP cleanup.