### PR TITLE
refactor(simulation): harden reliability and cross-context contracts

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/ScenarioSimulationCommandFactory.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/ScenarioSimulationCommandFactory.java
@@ -3,6 +3,7 @@ package com.renewsim.backend.simulation_service.create.application;
 import com.renewsim.backend.simulation_service.create.application.command.CreateRealSimulationCommand;
 import com.renewsim.backend.simulation_service.create.application.command.CreateSimulationFromScenarioCommand;
 import com.renewsim.backend.simulation_service.domain.exception.InvalidConsumptionProfileException;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationCurrencyException;
 import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
 import com.renewsim.backend.simulation_service.domain.model.vo.Currency;
 import com.renewsim.backend.simulation_service.domain.model.vo.ProjectLifetime;
@@ -82,6 +83,10 @@ public class ScenarioSimulationCommandFactory {
     }
 
     private String resolveSimulationCurrency(String scenarioCurrency) {
+        if (!SUPPORTED_SIMULATION_CURRENCY.equalsIgnoreCase(scenarioCurrency)) {
+            throw new InvalidSimulationCurrencyException(
+                    "VALIDATION_ERROR: scenario defaultInvestmentCurrency must be " + SUPPORTED_SIMULATION_CURRENCY);
+        }
         return SUPPORTED_SIMULATION_CURRENCY;
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/ScenarioSimulationCommandFactory.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/ScenarioSimulationCommandFactory.java
@@ -83,7 +83,7 @@ public class ScenarioSimulationCommandFactory {
     }
 
     private String resolveSimulationCurrency(String scenarioCurrency) {
-        if (!SUPPORTED_SIMULATION_CURRENCY.equalsIgnoreCase(scenarioCurrency)) {
+        if (!SUPPORTED_SIMULATION_CURRENCY.equalsIgnoreCase(scenarioCurrency == null ? null : scenarioCurrency.trim())) {
             throw new InvalidSimulationCurrencyException(
                     "VALIDATION_ERROR: scenario defaultInvestmentCurrency must be " + SUPPORTED_SIMULATION_CURRENCY);
         }

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/ScenarioSnapshotAssembler.java
@@ -62,7 +62,11 @@ public final class ScenarioSnapshotAssembler {
         }
 
         private SimulationDetailsResult readDetails(String raw) {
-                return snapshotReader.read(raw);
+                try {
+                        return snapshotReader.read(raw);
+                } catch (IllegalStateException ex) {
+                        return null;
+                }
         }
 
         private String normalizeLabel(String value) {

--- a/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
@@ -25,7 +25,11 @@ public class GetSimulationService implements GetRealSimulationUseCase {
         if (!simulation.hasResult()) {
             throw new SimulationNotFoundException(id);
         }
-        return snapshotReader.read(simulation.getResultSnapshot());
+        try {
+            return snapshotReader.read(simulation.getResultSnapshot());
+        } catch (IllegalStateException ex) {
+            throw new SimulationNotFoundException(id);
+        }
     }
 
     private Simulation getAccessibleSimulation(Long id, String requesterUsername, boolean isAdmin) {

--- a/src/main/resources/db/migration/V27__align_scenario_currency_with_simulation_contract.sql
+++ b/src/main/resources/db/migration/V27__align_scenario_currency_with_simulation_contract.sql
@@ -1,0 +1,8 @@
+-- =====================================================
+-- V27: Align scenario currency with simulation contract
+-- simulation_service currently supports EUR-only economics snapshots
+-- =====================================================
+
+UPDATE scenarios
+SET default_investment_currency = 'EUR'
+WHERE default_investment_currency = 'USD';

--- a/src/main/resources/db/migration/V27__align_scenario_currency_with_simulation_contract.sql
+++ b/src/main/resources/db/migration/V27__align_scenario_currency_with_simulation_contract.sql
@@ -5,4 +5,9 @@
 
 UPDATE scenarios
 SET default_investment_currency = 'EUR'
-WHERE default_investment_currency = 'USD';
+WHERE default_investment_currency = 'USD'
+  AND name IN (
+    'Hogar con paneles solares - clima soleado',
+    'PyME con turbinas eolicas - zona costera',
+    'Microcentral hidroelectrica - zona rural con rio'
+  );

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
@@ -328,6 +328,39 @@ class CreateSimulationFromScenarioServiceTest {
                                 .hasMessage("VALIDATION_ERROR: scenario defaultInvestmentCurrency must be EUR");
         }
 
+        @Test
+        @DisplayName("createSimulationFromScenario accepts supported scenario currency with surrounding whitespace")
+        void createSimulationFromScenarioAcceptsSupportedScenarioCurrencyWithWhitespace() {
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService(),
+                                scenarioSimulationCommandFactory);
+
+                when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(
+                                new ScenarioLookupPort.ScenarioSnapshot(7L, "Hogar solar - Sevilla", 1L,
+                                                5.0, 12000.0, " EUR ", 0.15, 6000.0)));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(2L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
+                                .thenReturn(List.of(1L, 2L));
+                when(resourcePort.fetchProfile(37.3891, -5.9845, 13.0)).thenReturn(profile());
+                when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+                service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, null,
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain", CountryCode.of("ES")),
+                                                "alice"));
+
+                ArgumentCaptor<Simulation> captor = ArgumentCaptor.forClass(Simulation.class);
+                verify(repository, atLeastOnce()).save(captor.capture());
+                assertThat(captor.getAllValues().get(captor.getAllValues().size() - 1).getEconomics().currency().value())
+                                .isEqualTo("EUR");
+        }
+
         private CreateRealSimulationUseCase realCreateService() {
                 return realCreateService(repository);
         }

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
@@ -11,6 +11,7 @@ import com.renewsim.backend.simulation_service.create.application.technology.sol
 import com.renewsim.backend.simulation_service.create.application.technology.wind.WindSimulationEngine;
 import com.renewsim.backend.simulation_service.create.application.port.out.PvgisSolarResourcePort;
 import com.renewsim.backend.simulation_service.domain.exception.InvalidConsumptionProfileException;
+import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationCurrencyException;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.shared.application.port.out.ScenarioLookupPort;
 import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
@@ -150,7 +151,7 @@ class CreateSimulationFromScenarioServiceTest {
                                 Optional.of(scenarioSnapshot()),
                                 Optional.of(new ScenarioLookupPort.ScenarioSnapshot(
                                                 7L, "Hogar solar - Sevilla", 1L,
-                                                8.0, 18000.0, "USD", 0.21, 9000.0)));
+                                                8.0, 18000.0, "EUR", 0.21, 9000.0)));
                 when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
                 when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(2L)).thenReturn(Optional.of("solar"));
                 when(technologyLookupPort.existsActiveByEnergyType("solar")).thenReturn(true);
@@ -301,6 +302,32 @@ class CreateSimulationFromScenarioServiceTest {
                 verify(repository, never()).save(any());
         }
 
+        @Test
+        @DisplayName("createSimulationFromScenario rejects scenario currencies outside the supported simulation contract")
+        void createSimulationFromScenarioRejectsUnsupportedScenarioCurrency() {
+                CreateSimulationFromScenarioService service = new CreateSimulationFromScenarioService(
+                                scenarioLookupPort,
+                                technologyLookupPort,
+                                realCreateService(),
+                                scenarioSimulationCommandFactory);
+
+                when(scenarioLookupPort.findActiveScenarioById(7L)).thenReturn(Optional.of(
+                                new ScenarioLookupPort.ScenarioSnapshot(7L, "Hogar solar - Sevilla", 1L,
+                                                5.0, 12000.0, "USD", 0.15, 6000.0)));
+                when(technologyLookupPort.findActiveEnergyTypeByTechnologyId(1L)).thenReturn(Optional.of("solar"));
+                when(technologyLookupPort.recommendActiveTechnologyIdsByEnergyType("solar"))
+                                .thenReturn(List.of(1L, 2L));
+
+                assertThatThrownBy(() -> service.createSimulationFromScenario(
+                                new CreateSimulationFromScenarioCommand(
+                                                7L, null,
+                                                SimulationLocation.of("Sevilla, Andalucia, ES", 37.3891, -5.9845,
+                                                                "Spain", CountryCode.of("ES")),
+                                                "alice")))
+                                .isInstanceOf(InvalidSimulationCurrencyException.class)
+                                .hasMessage("VALIDATION_ERROR: scenario defaultInvestmentCurrency must be EUR");
+        }
+
         private CreateRealSimulationUseCase realCreateService() {
                 return realCreateService(repository);
         }
@@ -377,7 +404,7 @@ class CreateSimulationFromScenarioServiceTest {
         private ScenarioLookupPort.ScenarioSnapshot scenarioSnapshot() {
                 return new ScenarioLookupPort.ScenarioSnapshot(
                                 7L, "Hogar solar - Sevilla", 1L,
-                                5.0, 12000.0, "USD", 0.15, 6000.0);
+                                5.0, 12000.0, "EUR", 0.15, 6000.0);
         }
 
         private PvgisSolarResourcePort.PvgisSolarResourceProfile profile() {

--- a/src/test/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardServiceTest.java
@@ -123,4 +123,24 @@ class GetPortfolioDashboardServiceTest {
         assertThat(response.prioritizedScenarios()).hasSize(1);
         assertThat(response.prioritizedScenarios().getFirst().priority()).isEqualTo("REVIEW");
     }
+
+    @Test
+    @DisplayName("getDashboard tolerates malformed historical snapshots")
+    void getDashboardToleratesMalformedHistoricalSnapshots() {
+        GetPortfolioDashboardService service = new GetPortfolioDashboardService(
+                repository,
+                snapshotAssembler(technologyLookupPort),
+                new PortfolioDashboardAggregator());
+
+        Simulation malformed = completedSimulation(59L, "alice", "{ bad json");
+
+        when(repository.findByCreatedByOrderByCreatedAtDesc("alice")).thenReturn(List.of(malformed));
+
+        PortfolioDashboardResult response = service.getDashboard("alice");
+
+        assertThat(response.summary().totalSimulations()).isEqualTo(1);
+        assertThat(response.summary().atRiskCount()).isEqualTo(1);
+        assertThat(response.prioritizedScenarios()).hasSize(1);
+        assertThat(response.prioritizedScenarios().getFirst().priority()).isEqualTo("REVIEW");
+    }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
@@ -50,4 +50,15 @@ class GetSimulationServiceTest {
         assertThatThrownBy(() -> service.getSimulationById(55L, "alice", false))
                 .isInstanceOf(SimulationNotFoundException.class);
     }
+
+    @Test
+    @DisplayName("getSimulationById degrades invalid snapshots to not found")
+    void getSimulationByIdDegradesInvalidSnapshotsToNotFound() {
+        GetSimulationService service = new GetSimulationService(repository, snapshotReader());
+        var simulation = completedSimulation(55L, "alice", "{ bad json");
+        when(repository.findById(55L)).thenReturn(Optional.of(simulation));
+
+        assertThatThrownBy(() -> service.getSimulationById(55L, "alice", false))
+                .isInstanceOf(SimulationNotFoundException.class);
+    }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/persistence/SimulationMigrationAssertions.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/persistence/SimulationMigrationAssertions.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 final class SimulationMigrationAssertions {
 
-    static final String EXPECTED_FLYWAY_VERSION = "15";
+    static final String EXPECTED_FLYWAY_VERSION = "27";
 
     private SimulationMigrationAssertions() {
     }
@@ -22,11 +22,11 @@ final class SimulationMigrationAssertions {
     static void assertFlywayVersionApplied(Connection connection, String expectedVersion) throws Exception {
         try (PreparedStatement statement = connection.prepareStatement(
                 """
-                SELECT COUNT(*)
-                FROM flyway_schema_history
-                WHERE version = ?
-                  AND success = 1
-                """)) {
+                        SELECT COUNT(*)
+                        FROM flyway_schema_history
+                        WHERE version = ?
+                          AND success = 1
+                        """)) {
             statement.setString(1, expectedVersion);
             try (ResultSet rs = statement.executeQuery()) {
                 assertThat(rs.next()).isTrue();
@@ -38,12 +38,12 @@ final class SimulationMigrationAssertions {
     private static int countMatchingColumns(Connection connection) throws Exception {
         try (PreparedStatement statement = connection.prepareStatement(
                 """
-                SELECT COUNT(*)
-                FROM information_schema.columns
-                WHERE table_schema = DATABASE()
-                  AND table_name = 'simulations'
-                  AND column_name IN ('location', 'energy_type', 'project_size', 'budget', 'estimated_energy', 'created_by')
-                """)) {
+                        SELECT COUNT(*)
+                        FROM information_schema.columns
+                        WHERE table_schema = DATABASE()
+                          AND table_name = 'simulations'
+                          AND column_name IN ('location', 'energy_type', 'project_size', 'budget', 'estimated_energy', 'created_by')
+                        """)) {
             try (ResultSet rs = statement.executeQuery()) {
                 assertThat(rs.next()).isTrue();
                 return rs.getInt(1);
@@ -54,11 +54,11 @@ final class SimulationMigrationAssertions {
     private static boolean tableExists(Connection connection, String tableName) throws Exception {
         try (PreparedStatement statement = connection.prepareStatement(
                 """
-                SELECT COUNT(*)
-                FROM information_schema.tables
-                WHERE table_schema = DATABASE()
-                  AND table_name = ?
-                """)) {
+                        SELECT COUNT(*)
+                        FROM information_schema.tables
+                        WHERE table_schema = DATABASE()
+                          AND table_name = ?
+                        """)) {
             statement.setString(1, tableName);
             try (ResultSet rs = statement.executeQuery()) {
                 assertThat(rs.next()).isTrue();
@@ -70,12 +70,12 @@ final class SimulationMigrationAssertions {
     private static boolean hasSimulationTechnologiesToSimulationsForeignKey(Connection connection) throws Exception {
         try (PreparedStatement statement = connection.prepareStatement(
                 """
-                SELECT COUNT(*)
-                FROM information_schema.referential_constraints
-                WHERE constraint_schema = DATABASE()
-                  AND table_name = 'simulation_technologies'
-                  AND referenced_table_name = 'simulations'
-                """)) {
+                        SELECT COUNT(*)
+                        FROM information_schema.referential_constraints
+                        WHERE constraint_schema = DATABASE()
+                          AND table_name = 'simulation_technologies'
+                          AND referenced_table_name = 'simulations'
+                        """)) {
             try (ResultSet rs = statement.executeQuery()) {
                 assertThat(rs.next()).isTrue();
                 return rs.getInt(1) == 1;


### PR DESCRIPTION
## What changed
- makes the scenario currency contract explicit by rejecting non-EUR scenario snapshots and aligning legacy seeded scenario currency through a Flyway migration
- degrades malformed `result_snapshot` payloads safely instead of propagating opaque 500s through detail/dashboard flows
- adds regression coverage for malformed snapshots and unsupported scenario currencies

## Why
Closes #191.

This is stage 4 of the `simulation_service` hardening plan from #184. The goal is to reduce runtime surprises from cross-context contract drift and corrupted historical data.

## Validation
- `mvn -Dtest=CreateSimulationFromScenarioServiceTest,GetSimulationServiceTest,GetPortfolioDashboardServiceTest,SimulationSchemaMigrationTest test`

## Notes for reviewers
- This PR makes the currency contract explicit: `simulation_service` accepts EUR-only scenario economics, and the seeded/legacy scenarios are aligned through migration `V27`.
- Detail degrades malformed snapshots to `SimulationNotFoundException`, while dashboard treats malformed snapshots as incomplete/reviewable instead of failing the whole portfolio.