### PR TITLE
refactor(simulation): reduce shared surface and cross-feature coupling

### DIFF
--- a/src/main/java/com/renewsim/backend/shared/security/AuthenticatedRequestContext.java
+++ b/src/main/java/com/renewsim/backend/shared/security/AuthenticatedRequestContext.java
@@ -1,0 +1,6 @@
+package com.renewsim.backend.shared.security;
+
+public record AuthenticatedRequestContext(
+        String username,
+        boolean isAdmin) {
+}

--- a/src/main/java/com/renewsim/backend/shared/security/AuthenticatedRequestContextFactory.java
+++ b/src/main/java/com/renewsim/backend/shared/security/AuthenticatedRequestContextFactory.java
@@ -1,17 +1,16 @@
-package com.renewsim.backend.simulation_service.shared.web;
+package com.renewsim.backend.shared.security;
 
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
 import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
 
-/**
- * Extracts the simulation request security context from Spring Authentication.
- */
-public final class SimulationRequestContextFactory {
+@Component
+public class AuthenticatedRequestContextFactory {
 
-    public SimulationRequestContext from(Authentication auth) {
+    public AuthenticatedRequestContext from(Authentication auth) {
         AuthenticatedUser user = (AuthenticatedUser) auth.getPrincipal();
         boolean isAdmin = auth.getAuthorities().stream()
                 .anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
-        return new SimulationRequestContext(user.username(), isAdmin);
+        return new AuthenticatedRequestContext(user.username(), isAdmin);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/FinancialCalculator.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/FinancialCalculator.java
@@ -6,7 +6,7 @@ import com.renewsim.backend.simulation_service.shared.application.SimulationDeta
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.renewsim.backend.simulation_service.shared.application.SimulationMathUtils.round;
+import static com.renewsim.backend.simulation_service.shared.application.SimulationNumericUtils.round;
 
 public final class FinancialCalculator {
 

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/technology/solar/SolarSimulationEngine.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/technology/solar/SolarSimulationEngine.java
@@ -16,11 +16,11 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.renewsim.backend.simulation_service.shared.application.SimulationMathUtils.formatDate;
-import static com.renewsim.backend.simulation_service.shared.application.SimulationMathUtils.round;
-import static com.renewsim.backend.simulation_service.shared.application.SimulationMathUtils.roundList;
-import static com.renewsim.backend.simulation_service.shared.application.SimulationMathUtils.scale;
-import static com.renewsim.backend.simulation_service.shared.application.SimulationMathUtils.sum;
+import static com.renewsim.backend.simulation_service.shared.application.SimulationFormatUtils.formatDate;
+import static com.renewsim.backend.simulation_service.shared.application.SimulationNumericUtils.round;
+import static com.renewsim.backend.simulation_service.shared.application.SimulationNumericUtils.roundList;
+import static com.renewsim.backend.simulation_service.shared.application.SimulationNumericUtils.scale;
+import static com.renewsim.backend.simulation_service.shared.application.SimulationNumericUtils.sum;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/web/CreateSimulationController.java
@@ -2,12 +2,12 @@ package com.renewsim.backend.simulation_service.create.web;
 
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateSimulationFromScenarioUseCase;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContext;
 import com.renewsim.backend.simulation_service.shared.web.SimulationDetailsWebMapper;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContextFactory;
 import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationRequestDTO;
 import com.renewsim.backend.simulation_service.create.web.dto.CreateSimulationFromScenarioRequestDTO;
 import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,7 +34,7 @@ public class CreateSimulationController {
         private final CreateSimulationWebMapper createWebMapper = new CreateSimulationWebMapper();
         private final CreateSimulationFromScenarioWebMapper createFromScenarioWebMapper = new CreateSimulationFromScenarioWebMapper();
         private final SimulationDetailsWebMapper detailsWebMapper = new SimulationDetailsWebMapper();
-        private final SimulationRequestContextFactory requestContextFactory = new SimulationRequestContextFactory();
+        private final AuthenticatedRequestContextFactory requestContextFactory;
 
         @Operation(summary = "Create a new simulation")
         @PreAuthorize("hasAuthority('SCOPE_write:simulations') or hasRole('ADMIN')")
@@ -43,7 +43,7 @@ public class CreateSimulationController {
                         @Valid @RequestBody CreateSimulationRequestDTO request,
                         Authentication auth) {
 
-                SimulationRequestContext requestContext = requestContextFactory.from(auth);
+                AuthenticatedRequestContext requestContext = requestContextFactory.from(auth);
 
                 SimulationDetailsResponseDTO result = detailsWebMapper.toWebDetails(
                                 createRealSimulationUseCase.createSimulation(
@@ -59,7 +59,7 @@ public class CreateSimulationController {
                         @Valid @RequestBody CreateSimulationFromScenarioRequestDTO request,
                         Authentication auth) {
 
-                SimulationRequestContext requestContext = requestContextFactory.from(auth);
+                AuthenticatedRequestContext requestContext = requestContextFactory.from(auth);
 
                 SimulationDetailsResponseDTO result = detailsWebMapper.toWebDetails(
                                 createSimulationFromScenarioUseCase.createSimulationFromScenario(

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/web/SimulationDashboardController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/web/SimulationDashboardController.java
@@ -1,9 +1,9 @@
 package com.renewsim.backend.simulation_service.dashboard.web;
 
 import com.renewsim.backend.simulation_service.dashboard.application.port.in.GetPortfolioDashboardUseCase;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContext;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContextFactory;
 import com.renewsim.backend.simulation_service.dashboard.web.dto.PortfolioDashboardResponseDTO;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,13 +20,13 @@ public class SimulationDashboardController {
 
     private final GetPortfolioDashboardUseCase getPortfolioDashboardUseCase;
     private final SimulationDashboardWebMapper dashboardWebMapper = new SimulationDashboardWebMapper();
-    private final SimulationRequestContextFactory requestContextFactory = new SimulationRequestContextFactory();
+    private final AuthenticatedRequestContextFactory requestContextFactory;
 
     @Operation(summary = "Get executive portfolio dashboard for authenticated user")
     @PreAuthorize("hasAuthority('SCOPE_read:simulations') or hasRole('ADMIN')")
     @GetMapping("/dashboard")
     public ResponseEntity<PortfolioDashboardResponseDTO> getDashboard(Authentication auth) {
-        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+        AuthenticatedRequestContext requestContext = requestContextFactory.from(auth);
 
         return ResponseEntity
                 .ok(dashboardWebMapper.toWebDashboard(getPortfolioDashboardUseCase.getDashboard(requestContext.username())));

--- a/src/main/java/com/renewsim/backend/simulation_service/delete/web/SimulationDeleteController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/delete/web/SimulationDeleteController.java
@@ -1,8 +1,8 @@
 package com.renewsim.backend.simulation_service.delete.web;
 
 import com.renewsim.backend.simulation_service.delete.application.port.in.DeleteRealSimulationUseCase;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContext;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContextFactory;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SimulationDeleteController {
 
     private final DeleteRealSimulationUseCase deleteRealSimulationUseCase;
-    private final SimulationRequestContextFactory requestContextFactory = new SimulationRequestContextFactory();
+    private final AuthenticatedRequestContextFactory requestContextFactory;
 
     @Operation(summary = "Delete simulation by ID")
     @PreAuthorize("hasAuthority('SCOPE_delete:simulations') or hasRole('ADMIN')")
@@ -30,7 +30,7 @@ public class SimulationDeleteController {
             @PathVariable Long id,
             Authentication auth) {
 
-        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+        AuthenticatedRequestContext requestContext = requestContextFactory.from(auth);
 
         deleteRealSimulationUseCase.deleteSimulation(id, requestContext.username(), requestContext.isAdmin());
         log.warn("User {} deleted simulation {}", requestContext.username(), id);
@@ -42,7 +42,7 @@ public class SimulationDeleteController {
     @PreAuthorize("hasAuthority('SCOPE_delete:simulations') or hasRole('ADMIN')")
     @DeleteMapping("/user")
     public ResponseEntity<Void> deleteAllUserSimulations(Authentication auth) {
-        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+        AuthenticatedRequestContext requestContext = requestContextFactory.from(auth);
 
         deleteRealSimulationUseCase.deleteAllUserSimulations(requestContext.username());
         log.warn("User {} deleted all simulations", requestContext.username());

--- a/src/main/java/com/renewsim/backend/simulation_service/detail/web/SimulationDetailController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/detail/web/SimulationDetailController.java
@@ -1,10 +1,10 @@
 package com.renewsim.backend.simulation_service.detail.web;
 
 import com.renewsim.backend.simulation_service.detail.application.port.in.GetRealSimulationUseCase;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContext;
 import com.renewsim.backend.simulation_service.shared.web.SimulationDetailsWebMapper;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContextFactory;
 import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -21,14 +21,14 @@ public class SimulationDetailController {
 
     private final GetRealSimulationUseCase getRealSimulationUseCase;
     private final SimulationDetailsWebMapper detailsWebMapper = new SimulationDetailsWebMapper();
-    private final SimulationRequestContextFactory requestContextFactory = new SimulationRequestContextFactory();
+    private final AuthenticatedRequestContextFactory requestContextFactory;
 
     @GetMapping("/{id:\\d+}")
     @PreAuthorize("hasAuthority('SCOPE_read:simulations') or hasRole('ADMIN')")
     public ResponseEntity<SimulationDetailsResponseDTO> getSimulationById(
             @PathVariable Long id,
             Authentication auth) {
-        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+        AuthenticatedRequestContext requestContext = requestContextFactory.from(auth);
 
         return ResponseEntity.ok(detailsWebMapper.toWebDetails(
                 getRealSimulationUseCase.getSimulationById(

--- a/src/main/java/com/renewsim/backend/simulation_service/history/application/ListSimulationsService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/history/application/ListSimulationsService.java
@@ -11,7 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.renewsim.backend.simulation_service.shared.application.SimulationMathUtils.*;
+import static com.renewsim.backend.simulation_service.shared.application.SimulationFormatUtils.formatDate;
+import static com.renewsim.backend.simulation_service.shared.application.SimulationNumericUtils.defaultNumber;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/renewsim/backend/simulation_service/history/web/SimulationHistoryController.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/history/web/SimulationHistoryController.java
@@ -1,9 +1,9 @@
 package com.renewsim.backend.simulation_service.history.web;
 
 import com.renewsim.backend.simulation_service.history.application.port.in.ListUserRealSimulationsUseCase;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContext;
-import com.renewsim.backend.simulation_service.shared.web.SimulationRequestContextFactory;
 import com.renewsim.backend.simulation_service.history.web.dto.ListUserSimulationsResponseDTO;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,13 +22,13 @@ public class SimulationHistoryController {
 
     private final ListUserRealSimulationsUseCase listUserRealSimulationsUseCase;
     private final SimulationHistoryWebMapper historyWebMapper = new SimulationHistoryWebMapper();
-    private final SimulationRequestContextFactory requestContextFactory = new SimulationRequestContextFactory();
+    private final AuthenticatedRequestContextFactory requestContextFactory;
 
     @Operation(summary = "Get authenticated user simulations with pagination")
     @PreAuthorize("hasAuthority('SCOPE_read:simulations') or hasRole('ADMIN')")
     @GetMapping({ "/user", "/my-simulations" })
     public ResponseEntity<ListUserSimulationsResponseDTO> getMySimulations(Authentication auth) {
-        SimulationRequestContext requestContext = requestContextFactory.from(auth);
+        AuthenticatedRequestContext requestContext = requestContextFactory.from(auth);
 
         ListUserSimulationsResponseDTO history = historyWebMapper.toWebList(
                 listUserRealSimulationsUseCase.getUserSimulations(requestContext.username()));

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationFormatUtils.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationFormatUtils.java
@@ -1,0 +1,20 @@
+package com.renewsim.backend.simulation_service.shared.application;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class SimulationFormatUtils {
+
+    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private SimulationFormatUtils() {
+    }
+
+    public static String firstNonBlank(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    public static String formatDate(LocalDateTime value) {
+        return value == null ? null : ISO_FORMATTER.format(value) + "Z";
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationNumericUtils.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationNumericUtils.java
@@ -1,14 +1,10 @@
 package com.renewsim.backend.simulation_service.shared.application;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-public final class SimulationMathUtils {
+public final class SimulationNumericUtils {
 
-    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
-    private SimulationMathUtils() {
+    private SimulationNumericUtils() {
     }
 
     public static double round(double value, int scale) {
@@ -30,13 +26,5 @@ public final class SimulationMathUtils {
 
     public static double defaultNumber(Double value) {
         return value == null ? 0.0 : value;
-    }
-
-    public static String firstNonBlank(String value, String fallback) {
-        return value == null || value.isBlank() ? fallback : value;
-    }
-
-    public static String formatDate(LocalDateTime value) {
-        return value == null ? null : ISO_FORMATTER.format(value) + "Z";
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationRequestContext.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationRequestContext.java
@@ -1,6 +1,0 @@
-package com.renewsim.backend.simulation_service.shared.web;
-
-public record SimulationRequestContext(
-                String username,
-                boolean isAdmin) {
-}

--- a/src/test/java/com/renewsim/backend/shared/security/AuthenticatedRequestContextFactoryTest.java
+++ b/src/test/java/com/renewsim/backend/shared/security/AuthenticatedRequestContextFactoryTest.java
@@ -1,4 +1,4 @@
-package com.renewsim.backend.simulation_service.shared.web;
+package com.renewsim.backend.shared.security;
 
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
 import org.junit.jupiter.api.DisplayName;
@@ -12,16 +12,16 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class SimulationRequestContextFactoryTest {
+class AuthenticatedRequestContextFactoryTest {
 
-    private final SimulationRequestContextFactory factory = new SimulationRequestContextFactory();
+    private final AuthenticatedRequestContextFactory factory = new AuthenticatedRequestContextFactory();
 
     @Test
     @DisplayName("from extracts username and admin role from authentication")
     void fromExtractsUsernameAndAdminRoleFromAuthentication() {
         Authentication auth = authentication("alice", "ROLE_USER", "ROLE_ADMIN");
 
-        SimulationRequestContext context = factory.from(auth);
+        AuthenticatedRequestContext context = factory.from(auth);
 
         assertThat(context.username()).isEqualTo("alice");
         assertThat(context.isAdmin()).isTrue();
@@ -32,7 +32,7 @@ class SimulationRequestContextFactoryTest {
     void fromMarksNonAdminUsersCorrectly() {
         Authentication auth = authentication("bob", "ROLE_USER");
 
-        SimulationRequestContext context = factory.from(auth);
+        AuthenticatedRequestContext context = factory.from(auth);
 
         assertThat(context.username()).isEqualTo("bob");
         assertThat(context.isAdmin()).isFalse();

--- a/src/test/java/com/renewsim/backend/simulation_service/dashboard/web/SimulationDashboardControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/dashboard/web/SimulationDashboardControllerTest.java
@@ -1,6 +1,8 @@
 package com.renewsim.backend.simulation_service.dashboard.web;
 
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import com.renewsim.backend.simulation_service.dashboard.application.port.in.GetPortfolioDashboardUseCase;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardDistribution;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardDistributionByStatus;
@@ -32,6 +34,8 @@ class SimulationDashboardControllerTest {
 
     @Mock
     private GetPortfolioDashboardUseCase getPortfolioDashboardUseCase;
+    @Mock
+    private AuthenticatedRequestContextFactory requestContextFactory;
 
     @InjectMocks
     private SimulationDashboardController controller;
@@ -40,6 +44,7 @@ class SimulationDashboardControllerTest {
     @DisplayName("getDashboard returns executive portfolio contract")
     void getDashboardReturnsExecutivePortfolioContract() {
         Authentication auth = authentication("alice", "ROLE_USER");
+        when(requestContextFactory.from(auth)).thenReturn(new AuthenticatedRequestContext("alice", false));
         when(getPortfolioDashboardUseCase.getDashboard("alice")).thenReturn(
                 new PortfolioDashboardResult(
                         new PortfolioDashboardSummary(3, 3, 14.2, 6.2, 912300, 410535, 2),

--- a/src/test/java/com/renewsim/backend/simulation_service/delete/web/SimulationDeleteControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/delete/web/SimulationDeleteControllerTest.java
@@ -1,6 +1,8 @@
 package com.renewsim.backend.simulation_service.delete.web;
 
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import com.renewsim.backend.simulation_service.delete.application.port.in.DeleteRealSimulationUseCase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,8 @@ class SimulationDeleteControllerTest {
 
     @Mock
     private DeleteRealSimulationUseCase deleteRealSimulationUseCase;
+    @Mock
+    private AuthenticatedRequestContextFactory requestContextFactory;
 
     @InjectMocks
     private SimulationDeleteController controller;
@@ -30,6 +34,7 @@ class SimulationDeleteControllerTest {
     @DisplayName("deleteSimulation delegates to delete use case with request context")
     void deleteSimulationDelegatesToDeleteUseCaseWithRequestContext() {
         Authentication auth = authentication("alice", "ROLE_USER");
+        org.mockito.Mockito.when(requestContextFactory.from(auth)).thenReturn(new AuthenticatedRequestContext("alice", false));
 
         controller.deleteSimulation(55L, auth);
 
@@ -40,6 +45,7 @@ class SimulationDeleteControllerTest {
     @DisplayName("deleteAllUserSimulations delegates to delete use case with current username")
     void deleteAllUserSimulationsDelegatesToDeleteUseCaseWithCurrentUsername() {
         Authentication auth = authentication("alice", "ROLE_USER");
+        org.mockito.Mockito.when(requestContextFactory.from(auth)).thenReturn(new AuthenticatedRequestContext("alice", false));
 
         controller.deleteAllUserSimulations(auth);
 

--- a/src/test/java/com/renewsim/backend/simulation_service/detail/web/SimulationDetailControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/detail/web/SimulationDetailControllerTest.java
@@ -2,6 +2,8 @@ package com.renewsim.backend.simulation_service.detail.web;
 
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
 import com.renewsim.backend.simulation_service.detail.application.port.in.GetRealSimulationUseCase;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +27,8 @@ class SimulationDetailControllerTest {
 
     @Mock
     private GetRealSimulationUseCase getRealSimulationUseCase;
+    @Mock
+    private AuthenticatedRequestContextFactory requestContextFactory;
 
     @InjectMocks
     private SimulationDetailController controller;
@@ -33,6 +37,7 @@ class SimulationDetailControllerTest {
     @DisplayName("getSimulationById returns the real details contract")
     void getSimulationByIdReturnsRealDetailsContract() {
         Authentication auth = authentication("alice", "ROLE_USER");
+        when(requestContextFactory.from(auth)).thenReturn(new AuthenticatedRequestContext("alice", false));
         when(getRealSimulationUseCase.getSimulationById(55L, "alice", false)).thenReturn(sampleResult());
 
         SimulationDetailsResponseDTO body = controller.getSimulationById(55L, auth).getBody();

--- a/src/test/java/com/renewsim/backend/simulation_service/history/web/SimulationHistoryControllerTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/history/web/SimulationHistoryControllerTest.java
@@ -1,11 +1,13 @@
 package com.renewsim.backend.simulation_service.history.web;
 
 import com.renewsim.backend.auth_service.domain.AuthenticatedUser;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContext;
 import com.renewsim.backend.simulation_service.detail.application.port.in.GetRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.history.application.port.in.ListUserRealSimulationsUseCase;
 import com.renewsim.backend.simulation_service.history.application.result.SimulationHistoryRowResult;
 import com.renewsim.backend.simulation_service.history.application.result.UserSimulationListResult;
 import com.renewsim.backend.simulation_service.detail.web.SimulationDetailController;
+import com.renewsim.backend.shared.security.AuthenticatedRequestContextFactory;
 import com.renewsim.backend.simulation_service.history.web.dto.ListUserSimulationsResponseDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,8 @@ class SimulationHistoryControllerTest {
     private ListUserRealSimulationsUseCase listUserRealSimulationsUseCase;
     @Mock
     private GetRealSimulationUseCase getRealSimulationUseCase;
+    @Mock
+    private AuthenticatedRequestContextFactory requestContextFactory;
 
     @InjectMocks
     private SimulationHistoryController controller;
@@ -46,6 +50,7 @@ class SimulationHistoryControllerTest {
     @DisplayName("getMySimulations returns list projection contract")
     void getMySimulationsReturnsListProjectionContract() {
         Authentication auth = authentication("alice", "ROLE_USER");
+        when(requestContextFactory.from(auth)).thenReturn(new AuthenticatedRequestContext("alice", false));
         when(listUserRealSimulationsUseCase.getUserSimulations("alice")).thenReturn(
                 new UserSimulationListResult(
                         List.of(new SimulationHistoryRowResult("55", "Solar - Sevilla", "solar", "completed",
@@ -64,7 +69,9 @@ class SimulationHistoryControllerTest {
     @DisplayName("get user simulations route does not collide with numeric id mapping")
     void getUserSimulationsRouteDoesNotCollideWithIdRoute() throws Exception {
         Authentication auth = authentication("alice", "ROLE_USER");
-        SimulationDetailController detailController = new SimulationDetailController(getRealSimulationUseCase);
+        when(requestContextFactory.from(auth)).thenReturn(new AuthenticatedRequestContext("alice", false));
+        SimulationDetailController detailController = new SimulationDetailController(getRealSimulationUseCase,
+                new AuthenticatedRequestContextFactory());
         MockMvc mockMvc = MockMvcBuilders.standaloneSetup(controller, detailController).build();
 
         when(listUserRealSimulationsUseCase.getUserSimulations("alice"))


### PR DESCRIPTION
## What changed
- splits `SimulationMathUtils` into `SimulationNumericUtils` and `SimulationFormatUtils` so math helpers and output formatting no longer live in the same shared utility
- extracts `AuthenticatedRequestContext` and `AuthenticatedRequestContextFactory` into `shared.security`
- rewires `simulation_service` controllers to consume that shared authenticated request context instead of depending on simulation-local request context types
- updates the controller/unit tests affected by the shared security context extraction

## Why
Closes #193.

This is stage 5 of the `simulation_service` architecture hardening plan from #184. The goal is to reduce the size and ambiguity of the `shared` surface so that cross-feature dependencies are smaller and more semantically honest.

## Validation
- `mvn -Dtest=AuthenticatedRequestContextFactoryTest,CreateSimulationControllerTest,SimulationDetailControllerTest,SimulationHistoryControllerTest,SimulationDeleteControllerTest,SimulationDashboardControllerTest,ListSimulationsServiceTest test`
- `mvn -Dtest=RealSimulationServiceTest,ListSimulationsServiceTest test`

## Notes for reviewers
- This PR does not try to eliminate `SimulationDetailsResult` yet; it focuses on smaller and safer reductions of `shared` coupling.
- The security-context extraction is intentionally minimal: username + isAdmin only, no business rules.