### PR TITLE
refactor(simulation): split shared details web mappers

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationDetailsWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationDetailsWebMapper.java
@@ -2,9 +2,13 @@ package com.renewsim.backend.simulation_service.shared.web;
 
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
-import com.renewsim.backend.simulation_service.shared.web.dto.SimulationInputSnapshotDTO;
 
 public final class SimulationDetailsWebMapper {
+
+        private final SimulationSummaryWebMapper summaryWebMapper = new SimulationSummaryWebMapper();
+        private final SimulationInputSnapshotWebMapper inputSnapshotWebMapper = new SimulationInputSnapshotWebMapper();
+        private final SimulationTechnicalWebMapper technicalWebMapper = new SimulationTechnicalWebMapper();
+        private final SimulationFinancialWebMapper financialWebMapper = new SimulationFinancialWebMapper();
 
         public SimulationDetailsResponseDTO toWebDetails(SimulationDetailsResult result) {
                 return new SimulationDetailsResponseDTO(
@@ -15,12 +19,12 @@ public final class SimulationDetailsWebMapper {
                                 result.modelVersion(),
                                 result.technology(),
                                 toResolvedLocation(result),
-                                toSummary(result),
-                                toInput(result),
-                                toTechnical(result),
-                                toFinancial(result),
-                                toAssumptions(result),
-                                toWarnings(result));
+                                summaryWebMapper.toSummary(result.summary()),
+                                inputSnapshotWebMapper.toInput(result.input()),
+                                technicalWebMapper.toTechnical(result.technical()),
+                                financialWebMapper.toFinancial(result.financial()),
+                                financialWebMapper.toAssumptions(result.assumptions()),
+                                financialWebMapper.toWarnings(result.warnings()));
         }
 
         private SimulationDetailsResponseDTO.ResolvedLocationDTO toResolvedLocation(SimulationDetailsResult result) {
@@ -35,126 +39,4 @@ public final class SimulationDetailsWebMapper {
                                 result.location().timezone());
         }
 
-        private SimulationDetailsResponseDTO.SummaryDTO toSummary(SimulationDetailsResult result) {
-                return new SimulationDetailsResponseDTO.SummaryDTO(
-                                result.summary().recommendation(),
-                                result.summary().headline(),
-                                result.summary().summary(),
-                                result.summary().reasons().stream()
-                                                .map(reason -> new SimulationDetailsResponseDTO.RecommendationReasonDTO(
-                                                                reason.area(),
-                                                                reason.severity(),
-                                                                reason.message()))
-                                                .toList());
-        }
-
-        private SimulationInputSnapshotDTO toInput(SimulationDetailsResult result) {
-                return new SimulationInputSnapshotDTO(
-                                result.input().name(),
-                                result.input().technology(),
-                                new SimulationInputSnapshotDTO.LocationDTO(
-                                                result.input().location().label(),
-                                                result.input().location().lat(),
-                                                result.input().location().lon(),
-                                                result.input().location().country(),
-                                                result.input().location().countryCode()),
-                                new SimulationInputSnapshotDTO.SystemDTO(
-                                                result.input().system().installedCapacityKw(),
-                                                result.input().system().performanceRatio(),
-                                                result.input().system().degradationRateAnnualPct(),
-                                                result.input().system().availabilityPct(),
-                                                new SimulationInputSnapshotDTO.LossesPctDTO(
-                                                                result.input().system().lossesPct().inverter(),
-                                                                result.input().system().lossesPct().temperature(),
-                                                                result.input().system().lossesPct().wiring(),
-                                                                result.input().system().lossesPct().soiling(),
-                                                                result.input().system().lossesPct().other())),
-                                new SimulationInputSnapshotDTO.DemandDTO(
-                                                result.input().demand().annualConsumptionKwh(),
-                                                result.input().demand().monthlyConsumptionKwh()),
-                                new SimulationInputSnapshotDTO.EconomicsDTO(
-                                                result.input().economics().currency(),
-                                                result.input().economics().capexTotal(),
-                                                result.input().economics().opexAnnual(),
-                                                result.input().economics().electricityPurchasePricePerKwh(),
-                                                result.input().economics().exportPricePerKwh(),
-                                                result.input().economics().discountRatePct(),
-                                                result.input().economics().projectLifetimeYears()));
-        }
-
-        private SimulationDetailsResponseDTO.TechnicalDTO toTechnical(SimulationDetailsResult result) {
-                return new SimulationDetailsResponseDTO.TechnicalDTO(
-                                result.technical().annualGenerationKwh(),
-                                result.technical().monthlyGenerationKwh(),
-                                result.technical().specificYieldKwhPerKwp(),
-                                result.technical().performanceRatio(),
-                                result.technical().capacityFactorPct(),
-                                result.technical().selfConsumptionRatePct(),
-                                result.technical().coverageRatePct(),
-                                new SimulationDetailsResponseDTO.ResourceSeriesDTO(
-                                                result.technical().resource().source(),
-                                                result.technical().resource().period(),
-                                                result.technical().resource().monthlyIrradianceKwhM2(),
-                                                result.technical().resource().monthlyTemperatureC()),
-                                new SimulationDetailsResponseDTO.LossesSummaryDTO(
-                                                result.technical().lossesPct().inverter(),
-                                                result.technical().lossesPct().temperature(),
-                                                result.technical().lossesPct().wiring(),
-                                                result.technical().lossesPct().soiling(),
-                                                result.technical().lossesPct().other(),
-                                                result.technical().lossesPct().total()),
-                                result.technical().balanceByMonth().stream()
-                                                .map(item -> new SimulationDetailsResponseDTO.MonthlyEnergyBalanceItemDTO(
-                                                                item.month(),
-                                                                item.generationKwh(),
-                                                                item.consumptionKwh(),
-                                                                item.selfConsumedKwh(),
-                                                                item.exportedKwh(),
-                                                                item.importedKwh()))
-                                                .toList());
-        }
-
-        private SimulationDetailsResponseDTO.FinancialDTO toFinancial(SimulationDetailsResult result) {
-                return new SimulationDetailsResponseDTO.FinancialDTO(
-                                result.financial().currency(),
-                                result.financial().annualSavings(),
-                                result.financial().annualExportRevenue(),
-                                result.financial().netAnnualBenefit(),
-                                result.financial().paybackYears(),
-                                result.financial().discountedPaybackYears(),
-                                result.financial().npv(),
-                                result.financial().irrPct(),
-                                result.financial().lcoePerKwh(),
-                                result.financial().yearlyCashFlows().stream()
-                                                .map(item -> new SimulationDetailsResponseDTO.FinancialYearItemDTO(
-                                                                item.year(),
-                                                                item.savings(),
-                                                                item.exportRevenue(),
-                                                                item.opex(),
-                                                                item.replacementCost(),
-                                                                item.netCashFlow(),
-                                                                item.discountedCashFlow(),
-                                                                item.cumulativeCashFlow()))
-                                                .toList());
-        }
-
-        private SimulationDetailsResponseDTO.AssumptionsDTO toAssumptions(SimulationDetailsResult result) {
-                return new SimulationDetailsResponseDTO.AssumptionsDTO(
-                                result.assumptions().discountRatePct(),
-                                result.assumptions().projectLifetimeYears(),
-                                result.assumptions().degradationRateAnnualPct(),
-                                result.assumptions().electricityPurchasePricePerKwh(),
-                                result.assumptions().exportPricePerKwh(),
-                                result.assumptions().climateSource(),
-                                result.assumptions().climatePeriod());
-        }
-
-        private java.util.List<SimulationDetailsResponseDTO.SimulationWarningDTO> toWarnings(SimulationDetailsResult result) {
-                return result.warnings().stream()
-                                .map(warning -> new SimulationDetailsResponseDTO.SimulationWarningDTO(
-                                                warning.severity(),
-                                                warning.code(),
-                                                warning.message()))
-                                .toList();
-        }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationFinancialWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationFinancialWebMapper.java
@@ -1,0 +1,54 @@
+package com.renewsim.backend.simulation_service.shared.web;
+
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
+
+import java.util.List;
+
+final class SimulationFinancialWebMapper {
+
+        SimulationDetailsResponseDTO.FinancialDTO toFinancial(SimulationDetailsResult.Financial financial) {
+                return new SimulationDetailsResponseDTO.FinancialDTO(
+                                financial.currency(),
+                                financial.annualSavings(),
+                                financial.annualExportRevenue(),
+                                financial.netAnnualBenefit(),
+                                financial.paybackYears(),
+                                financial.discountedPaybackYears(),
+                                financial.npv(),
+                                financial.irrPct(),
+                                financial.lcoePerKwh(),
+                                financial.yearlyCashFlows().stream()
+                                                .map(item -> new SimulationDetailsResponseDTO.FinancialYearItemDTO(
+                                                                item.year(),
+                                                                item.savings(),
+                                                                item.exportRevenue(),
+                                                                item.opex(),
+                                                                item.replacementCost(),
+                                                                item.netCashFlow(),
+                                                                item.discountedCashFlow(),
+                                                                item.cumulativeCashFlow()))
+                                                .toList());
+        }
+
+        SimulationDetailsResponseDTO.AssumptionsDTO toAssumptions(SimulationDetailsResult.Assumptions assumptions) {
+                return new SimulationDetailsResponseDTO.AssumptionsDTO(
+                                assumptions.discountRatePct(),
+                                assumptions.projectLifetimeYears(),
+                                assumptions.degradationRateAnnualPct(),
+                                assumptions.electricityPurchasePricePerKwh(),
+                                assumptions.exportPricePerKwh(),
+                                assumptions.climateSource(),
+                                assumptions.climatePeriod());
+        }
+
+        List<SimulationDetailsResponseDTO.SimulationWarningDTO> toWarnings(
+                        List<SimulationDetailsResult.SimulationWarning> warnings) {
+                return warnings.stream()
+                                .map(warning -> new SimulationDetailsResponseDTO.SimulationWarningDTO(
+                                                warning.severity(),
+                                                warning.code(),
+                                                warning.message()))
+                                .toList();
+        }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationInputSnapshotWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationInputSnapshotWebMapper.java
@@ -1,0 +1,41 @@
+package com.renewsim.backend.simulation_service.shared.web;
+
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.web.dto.SimulationInputSnapshotDTO;
+
+final class SimulationInputSnapshotWebMapper {
+
+        SimulationInputSnapshotDTO toInput(SimulationDetailsResult.Input input) {
+                return new SimulationInputSnapshotDTO(
+                                input.name(),
+                                input.technology(),
+                                new SimulationInputSnapshotDTO.LocationDTO(
+                                                input.location().label(),
+                                                input.location().lat(),
+                                                input.location().lon(),
+                                                input.location().country(),
+                                                input.location().countryCode()),
+                                new SimulationInputSnapshotDTO.SystemDTO(
+                                                input.system().installedCapacityKw(),
+                                                input.system().performanceRatio(),
+                                                input.system().degradationRateAnnualPct(),
+                                                input.system().availabilityPct(),
+                                                new SimulationInputSnapshotDTO.LossesPctDTO(
+                                                                input.system().lossesPct().inverter(),
+                                                                input.system().lossesPct().temperature(),
+                                                                input.system().lossesPct().wiring(),
+                                                                input.system().lossesPct().soiling(),
+                                                                input.system().lossesPct().other())),
+                                new SimulationInputSnapshotDTO.DemandDTO(
+                                                input.demand().annualConsumptionKwh(),
+                                                input.demand().monthlyConsumptionKwh()),
+                                new SimulationInputSnapshotDTO.EconomicsDTO(
+                                                input.economics().currency(),
+                                                input.economics().capexTotal(),
+                                                input.economics().opexAnnual(),
+                                                input.economics().electricityPurchasePricePerKwh(),
+                                                input.economics().exportPricePerKwh(),
+                                                input.economics().discountRatePct(),
+                                                input.economics().projectLifetimeYears()));
+        }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationSummaryWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationSummaryWebMapper.java
@@ -1,0 +1,20 @@
+package com.renewsim.backend.simulation_service.shared.web;
+
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
+
+final class SimulationSummaryWebMapper {
+
+        SimulationDetailsResponseDTO.SummaryDTO toSummary(SimulationDetailsResult.Summary summary) {
+                return new SimulationDetailsResponseDTO.SummaryDTO(
+                                summary.recommendation(),
+                                summary.headline(),
+                                summary.summary(),
+                                summary.reasons().stream()
+                                                .map(reason -> new SimulationDetailsResponseDTO.RecommendationReasonDTO(
+                                                                reason.area(),
+                                                                reason.severity(),
+                                                                reason.message()))
+                                                .toList());
+        }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationTechnicalWebMapper.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/web/SimulationTechnicalWebMapper.java
@@ -1,0 +1,39 @@
+package com.renewsim.backend.simulation_service.shared.web;
+
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.web.dto.SimulationDetailsResponseDTO;
+
+final class SimulationTechnicalWebMapper {
+
+        SimulationDetailsResponseDTO.TechnicalDTO toTechnical(SimulationDetailsResult.Technical technical) {
+                return new SimulationDetailsResponseDTO.TechnicalDTO(
+                                technical.annualGenerationKwh(),
+                                technical.monthlyGenerationKwh(),
+                                technical.specificYieldKwhPerKwp(),
+                                technical.performanceRatio(),
+                                technical.capacityFactorPct(),
+                                technical.selfConsumptionRatePct(),
+                                technical.coverageRatePct(),
+                                new SimulationDetailsResponseDTO.ResourceSeriesDTO(
+                                                technical.resource().source(),
+                                                technical.resource().period(),
+                                                technical.resource().monthlyIrradianceKwhM2(),
+                                                technical.resource().monthlyTemperatureC()),
+                                new SimulationDetailsResponseDTO.LossesSummaryDTO(
+                                                technical.lossesPct().inverter(),
+                                                technical.lossesPct().temperature(),
+                                                technical.lossesPct().wiring(),
+                                                technical.lossesPct().soiling(),
+                                                technical.lossesPct().other(),
+                                                technical.lossesPct().total()),
+                                technical.balanceByMonth().stream()
+                                                .map(item -> new SimulationDetailsResponseDTO.MonthlyEnergyBalanceItemDTO(
+                                                                item.month(),
+                                                                item.generationKwh(),
+                                                                item.consumptionKwh(),
+                                                                item.selfConsumedKwh(),
+                                                                item.exportedKwh(),
+                                                                item.importedKwh()))
+                                                .toList());
+        }
+}


### PR DESCRIPTION
## What changed
- splits `SimulationDetailsWebMapper` into focused section mappers
- keeps the top-level mapper as a thin orchestrator over summary, input snapshot, technical and financial mapping
- reduces the amount of nested DTO translation logic concentrated in one shared web mapper

## Why
Follow-up for #193.

Stage 5 already reduced `shared` ambiguity with shared security context and separated numeric vs formatting helpers. This PR finishes the shared web cleanup by shrinking the last large shared mapper into smaller, more focused collaborators.

## Validation
- `mvn -Dtest=SimulationDetailsWebMapperTest,CreateSimulationControllerTest,SimulationDetailControllerTest test`

## Notes for reviewers
- This is intentionally a small follow-up PR on top of the stage-5 shared cleanup already merged.
- No behavior change is intended; this is a mapper decomposition only.