### PR TITLE
refactor(simulation): add resilience to external climate/resource adapters

### DIFF
--- a/docs/adr/ADR-012-simulation-external-resilience-and-fallbacks.md
+++ b/docs/adr/ADR-012-simulation-external-resilience-and-fallbacks.md
@@ -1,0 +1,96 @@
+# ADR-012: Resiliencia y estrategia de fallbacks para proveedores externos de simulation_service
+
+## Status: Accepted
+## Date: 2026-08-13
+## Deciders: Development Team
+
+## Contexto
+
+`simulation_service` depende de proveedores externos para dos responsabilidades críticas:
+
+- `OpenWeatherMapAdapter` para lookup y enriquecimiento de ubicación
+- `PvgisSolarResourceAdapter` para datos energéticos y de recurso solar
+
+Antes de este slice, el módulo tenía manejo de errores local y ad-hoc, pero no una política explícita de resiliencia ni una decisión documentada sobre cuándo degradar y cuándo fallar de forma controlada.
+
+Además, PVGIS no tenía una política de timeout centralizada en configuración propia del módulo.
+
+## Decisión
+
+Adoptar una política explícita de resiliencia para proveedores externos de `simulation_service` basada en:
+
+1. `Retry` y `CircuitBreaker` con nombres propios por proveedor
+2. configuración externalizada en `application.yml`
+3. timeouts explícitos para PVGIS vía properties dedicadas
+4. estrategia de fallback diferenciada según impacto en el dominio
+
+### Reglas de fallback
+
+#### OpenWeather
+
+Se permite degradación controlada:
+
+- `resolveLocation(...)` puede devolver `ResolvedLocation(..., "Unknown")`
+- `searchLocations(...)` puede devolver lista vacía
+
+Razón: el enriquecimiento de ubicación mejora la experiencia, pero no define el cálculo energético principal.
+
+#### PVGIS
+
+NO se permite fallback con datos sintéticos.
+
+Razón: PVGIS alimenta directamente cálculos energéticos y financieros. Inventar perfiles solares degradaría silenciosamente la calidad del resultado y corrompería el dominio.
+
+En consecuencia, los fallos de PVGIS deben permanecer explícitos como errores de infraestructura controlados.
+
+## Justificación
+
+### Por qué usar resiliencia explícita
+
+- Hace visible el comportamiento operativo frente a fallos externos
+- Evita depender solo de `try/catch` locales sin política clara
+- Permite ajustar thresholds y retries sin reescribir lógica del adapter
+- Mejora la narrativa técnica del módulo más importante del sistema
+
+### Por qué no depender solo de anotaciones proxy-based
+
+En estos adapters la resiliencia necesitaba ejercitarse también en tests directos y en instanciaciones fuera del proxy Spring. Por eso se eligió un uso programático con `CircuitBreakerRegistry` y `RetryRegistry` dentro del adapter.
+
+### Trade-off aceptado conscientemente
+
+- **Se sacrifica**: simplicidad del adapter frente a una implementación sin resiliencia explícita
+- **Se gana**: mejor comportamiento operativo, decisiones de fallback alineadas con el dominio y mayor testabilidad del fallo
+
+## Consecuencias
+
+### Positivas
+
+- ✅ `simulation_service` endurece sus dos dependencias externas más sensibles
+- ✅ OpenWeather degrada de forma segura sin contaminar resultados
+- ✅ PVGIS falla de forma controlada sin inventar datos energéticos
+- ✅ PVGIS ahora tiene timeouts explícitos y cliente HTTP dedicado
+- ✅ Los escenarios de fallo y degradación quedan cubiertos por tests focalizados
+
+### Negativas
+
+- ⚠️ Los adapters tienen más wiring interno por la resiliencia programática
+- ⚠️ El fallback controlado de OpenWeather puede reducir calidad de respuesta cuando el proveedor está degradado
+- ⚠️ El fail-fast de PVGIS sigue generando error al usuario cuando el proveedor está caído, aunque eso sea preferible a una simulación falsa
+
+## Validación
+
+- ✅ `OpenWeatherMapAdapterTest`
+- ✅ `PvgisSolarResourceAdapterTest`
+- ✅ `LocationLookupServiceTest`
+- ✅ `SimulationLocationLookupControllerTest`
+- ✅ `CreateSimulationServiceTest`
+- ✅ `CreateSimulationFromScenarioServiceTest`
+
+## Referencias
+
+- `src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java`
+- `src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java`
+- `src/main/java/com/renewsim/backend/simulation_service/infrastructure/config/PvgisProperties.java`
+- `src/main/java/com/renewsim/backend/simulation_service/infrastructure/config/PvgisClientConfig.java`
+- `src/main/resources/application.yml`
+- Issue `#198`

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
@@ -4,7 +4,10 @@ import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
 import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
 import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
 import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
-import lombok.RequiredArgsConstructor;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -16,44 +19,56 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Adapter for resolving and searching locations through OpenWeatherMap.
  *
  * <p>Implements {@link LocationLookupProvider} and is activated only when the
  * simulation climate provider is configured as {@code openweathermap}.</p>
+ *
+ * <p>This integration tolerates degraded fallback because location enrichment is
+ * useful but not critical for preserving simulation correctness.</p>
  */
 @Component
 @ConditionalOnProperty(prefix = "simulation.climate", name = "provider", havingValue = "openweathermap")
-@RequiredArgsConstructor
 public class OpenWeatherMapAdapter implements LocationLookupProvider {
 
     private static final Logger log = LoggerFactory.getLogger(OpenWeatherMapAdapter.class);
 
     private final WeatherServiceProperties weatherProperties;
-    @Qualifier("openWeatherRestTemplate")
     private final RestTemplate restTemplate;
+    private final CircuitBreaker circuitBreaker;
+    private final Retry retry;
+
+    public OpenWeatherMapAdapter(
+            WeatherServiceProperties weatherProperties,
+            @Qualifier("openWeatherRestTemplate") RestTemplate restTemplate,
+            CircuitBreakerRegistry circuitBreakerRegistry,
+            RetryRegistry retryRegistry) {
+        this.weatherProperties = weatherProperties;
+        this.restTemplate = restTemplate;
+        this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("simulationOpenWeather");
+        this.retry = retryRegistry.retry("simulationOpenWeather");
+    }
+
+    OpenWeatherMapAdapter(WeatherServiceProperties weatherProperties, RestTemplate restTemplate) {
+        this(
+                weatherProperties,
+                restTemplate,
+                CircuitBreakerRegistry.ofDefaults(),
+                RetryRegistry.ofDefaults());
+    }
 
     @Override
     public ResolvedLocation resolveLocation(double latitude, double longitude) {
         try {
-            Map<?, ?> response = fetchWeatherResponse(latitude, longitude);
-            if (response == null) {
-                return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
-            }
-
-            String name = response.get("name") != null ? String.valueOf(response.get("name")) : null;
-            Map<?, ?> sys = (Map<?, ?>) response.get("sys");
-            String country = sys != null && sys.get("country") != null ? String.valueOf(sys.get("country")) : null;
-            if (!CountryCode.isSupported(country)) {
-                return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
-            }
-
-            return new ResolvedLocation(
-                    name != null && !name.isBlank() ? name : coordinateLabel(latitude, longitude),
-                    country != null && !country.isBlank() ? country : "Unknown");
-        } catch (Exception e) {
-            log.error("Error resolving location from weather provider ({})", summarizeFailure(e));
+            return execute(() -> doResolveLocation(latitude, longitude));
+        } catch (Exception exception) {
+            log.warn("OpenWeather fallback for resolveLocation lat={} lon={} reason={}",
+                    latitude,
+                    longitude,
+                    summarizeFailure(exception));
             return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
         }
     }
@@ -62,31 +77,60 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
     public List<ResolvedLocation> searchLocations(String query, int limit) {
         int requestedLimit = Math.max(1, limit);
         try {
-            String url = UriComponentsBuilder.fromHttpUrl(baseUrl() + "/geo/1.0/direct")
-                    .queryParam("q", query)
-                    .queryParam("limit", Math.max(requestedLimit * 5, 10))
-                    .queryParam("appid", apiKey())
-                    .toUriString();
-
-            List<?> response = restTemplate.getForObject(url, List.class);
-            if (response == null) {
-                return List.of();
-            }
-
-            return response.stream()
-                    .filter(Map.class::isInstance)
-                    .map(Map.class::cast)
-                    .map(this::toResolvedLocation)
-                    .filter(location -> CountryCode.isSupported(location.country()))
-                    .limit(requestedLimit)
-                    .toList();
-        } catch (Exception e) {
-            log.error("Error searching locations from weather provider (queryLength={}, limit={}) ({})",
+            return execute(() -> doSearchLocations(query, requestedLimit));
+        } catch (Exception exception) {
+            log.warn("OpenWeather fallback for searchLocations queryLength={} limit={} reason={}",
                     query == null ? 0 : query.length(),
                     requestedLimit,
-                    summarizeFailure(e));
+                    summarizeFailure(exception));
             return List.of();
         }
+    }
+
+    private ResolvedLocation doResolveLocation(double latitude, double longitude) {
+        Map<?, ?> response = fetchWeatherResponse(latitude, longitude);
+        if (response == null) {
+            return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
+        }
+
+        String name = response.get("name") != null ? String.valueOf(response.get("name")) : null;
+        Map<?, ?> sys = (Map<?, ?>) response.get("sys");
+        String country = sys != null && sys.get("country") != null ? String.valueOf(sys.get("country")) : null;
+        if (!CountryCode.isSupported(country)) {
+            return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
+        }
+
+        return new ResolvedLocation(
+                name != null && !name.isBlank() ? name : coordinateLabel(latitude, longitude),
+                country != null && !country.isBlank() ? country : "Unknown");
+    }
+
+    private List<ResolvedLocation> doSearchLocations(String query, int requestedLimit) {
+        String url = UriComponentsBuilder.fromHttpUrl(baseUrl() + "/geo/1.0/direct")
+                .queryParam("q", query)
+                .queryParam("limit", Math.max(requestedLimit * 5, 10))
+                .queryParam("appid", apiKey())
+                .toUriString();
+
+        List<?> response = restTemplate.getForObject(url, List.class);
+        if (response == null) {
+            return List.of();
+        }
+
+        return response.stream()
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .map(this::toResolvedLocation)
+                .filter(location -> CountryCode.isSupported(location.country()))
+                .limit(requestedLimit)
+                .toList();
+    }
+
+    private <T> T execute(Supplier<T> supplier) {
+        // Use explicit registries so resilience is exercised consistently even in direct adapter tests.
+        Supplier<T> decorated = CircuitBreaker.decorateSupplier(circuitBreaker, supplier);
+        decorated = Retry.decorateSupplier(retry, decorated);
+        return decorated.get();
     }
 
     private ResolvedLocation toResolvedLocation(Map<?, ?> candidate) {
@@ -122,9 +166,9 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
         return weatherProperties.key();
     }
 
-    private String summarizeFailure(Exception exception) {
-        String type = exception.getClass().getSimpleName();
-        String message = exception.getMessage();
+    private String summarizeFailure(Throwable throwable) {
+        String type = throwable.getClass().getSimpleName();
+        String message = throwable.getMessage();
         if (message == null || message.isBlank()) {
             return type;
         }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
@@ -8,6 +8,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -41,6 +42,7 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
     private final CircuitBreaker circuitBreaker;
     private final Retry retry;
 
+    @Autowired
     public OpenWeatherMapAdapter(
             WeatherServiceProperties weatherProperties,
             @Qualifier("openWeatherRestTemplate") RestTemplate restTemplate,
@@ -65,9 +67,7 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
         try {
             return execute(() -> doResolveLocation(latitude, longitude));
         } catch (Exception exception) {
-            log.warn("OpenWeather fallback for resolveLocation lat={} lon={} reason={}",
-                    latitude,
-                    longitude,
+            log.warn("OpenWeather fallback for resolveLocation reason={}",
                     summarizeFailure(exception));
             return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
         }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
@@ -5,27 +5,79 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.shared.exception.BadRequestException;
 import com.renewsim.backend.simulation_service.create.application.port.out.PvgisSolarResourcePort;
 import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
-import lombok.RequiredArgsConstructor;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
+/**
+ * Adapter for retrieving solar resource data from PVGIS.
+ *
+ * <p>Unlike location lookup, this integration must not fabricate fallback data
+ * because PVGIS output directly affects simulation results. Failures therefore
+ * stay explicit and controlled instead of degrading to synthetic profiles.</p>
+ */
 @Component
-@RequiredArgsConstructor
 public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
+
+    private static final Logger log = LoggerFactory.getLogger(PvgisSolarResourceAdapter.class);
 
     private final PvgisProperties properties;
     private final ObjectMapper objectMapper;
-    private final RestTemplateBuilder restTemplateBuilder;
+    private final RestTemplate restTemplate;
+    private final CircuitBreaker circuitBreaker;
+    private final Retry retry;
+
+    public PvgisSolarResourceAdapter(
+            PvgisProperties properties,
+            ObjectMapper objectMapper,
+            @Qualifier("pvgisRestTemplate") RestTemplate restTemplate,
+            CircuitBreakerRegistry circuitBreakerRegistry,
+            RetryRegistry retryRegistry) {
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+        this.restTemplate = restTemplate;
+        this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("simulationPvgis");
+        this.retry = retryRegistry.retry("simulationPvgis");
+    }
+
+    PvgisSolarResourceAdapter(PvgisProperties properties, ObjectMapper objectMapper, RestTemplate restTemplate) {
+        this(
+                properties,
+                objectMapper,
+                restTemplate,
+                CircuitBreakerRegistry.ofDefaults(),
+                RetryRegistry.ofDefaults());
+    }
 
     @Override
     public PvgisSolarResourceProfile fetchProfile(double latitude, double longitude, double systemLossPct) {
         try {
-            RestTemplate restTemplate = restTemplateBuilder.build();
+            return execute(() -> doFetchProfile(latitude, longitude, systemLossPct));
+        } catch (BadRequestException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            log.error("Error fetching PVGIS profile lat={} lon={} lossPct={} reason={}",
+                    latitude,
+                    longitude,
+                    systemLossPct,
+                    summarizeFailure(ex));
+            throw new IllegalStateException("Failed to fetch PVGIS solar resource data", ex);
+        }
+    }
+
+    private PvgisSolarResourceProfile doFetchProfile(double latitude, double longitude, double systemLossPct) {
+        try {
             JsonNode pvcalc = objectMapper
                     .readTree(restTemplate.getForObject(pvcalcUrl(latitude, longitude, systemLossPct), String.class));
             JsonNode tmy = objectMapper.readTree(restTemplate.getForObject(tmyUrl(latitude, longitude), String.class));
@@ -48,8 +100,15 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
         } catch (BadRequestException ex) {
             throw ex;
         } catch (Exception ex) {
-            throw new IllegalStateException("Failed to fetch PVGIS solar resource data", ex);
+            throw new IllegalStateException("Failed to parse PVGIS solar resource data", ex);
         }
+    }
+
+    private <T> T execute(Supplier<T> supplier) {
+        // Use explicit registries so resilience is exercised consistently even in direct adapter tests.
+        Supplier<T> decorated = CircuitBreaker.decorateSupplier(circuitBreaker, supplier);
+        decorated = Retry.decorateSupplier(retry, decorated);
+        return decorated.get();
     }
 
     private String pvcalcUrl(double latitude, double longitude, double systemLossPct) {
@@ -100,5 +159,13 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
             temperatures.add(counts[i] == 0 ? 0.0 : sums[i] / counts[i]);
         }
         return temperatures;
+    }
+
+    private String summarizeFailure(Throwable throwable) {
+        String message = throwable.getMessage();
+        if (message == null || message.isBlank()) {
+            return throwable.getClass().getSimpleName();
+        }
+        return throwable.getClass().getSimpleName() + ": " + message.replaceAll("[\r\n]", " ");
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
@@ -11,6 +11,7 @@ import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -38,6 +39,7 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
     private final CircuitBreaker circuitBreaker;
     private final Retry retry;
 
+    @Autowired
     public PvgisSolarResourceAdapter(
             PvgisProperties properties,
             ObjectMapper objectMapper,
@@ -63,24 +65,23 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
     @Override
     public PvgisSolarResourceProfile fetchProfile(double latitude, double longitude, double systemLossPct) {
         try {
-            return execute(() -> doFetchProfile(latitude, longitude, systemLossPct));
+            String pvcalcRaw = execute(() -> fetchRaw(pvcalcUrl(latitude, longitude, systemLossPct)));
+            String tmyRaw = execute(() -> fetchRaw(tmyUrl(latitude, longitude)));
+            return doFetchProfile(pvcalcRaw, tmyRaw);
         } catch (BadRequestException ex) {
             throw ex;
         } catch (Exception ex) {
-            log.error("Error fetching PVGIS profile lat={} lon={} lossPct={} reason={}",
-                    latitude,
-                    longitude,
+            log.error("Error fetching PVGIS profile lossPct={} reason={}",
                     systemLossPct,
                     summarizeFailure(ex));
             throw new IllegalStateException("Failed to fetch PVGIS solar resource data", ex);
         }
     }
 
-    private PvgisSolarResourceProfile doFetchProfile(double latitude, double longitude, double systemLossPct) {
+    private PvgisSolarResourceProfile doFetchProfile(String pvcalcRaw, String tmyRaw) {
         try {
-            JsonNode pvcalc = objectMapper
-                    .readTree(restTemplate.getForObject(pvcalcUrl(latitude, longitude, systemLossPct), String.class));
-            JsonNode tmy = objectMapper.readTree(restTemplate.getForObject(tmyUrl(latitude, longitude), String.class));
+            JsonNode pvcalc = objectMapper.readTree(pvcalcRaw);
+            JsonNode tmy = objectMapper.readTree(tmyRaw);
 
             List<Double> monthlyGeneration = readMonthlyValues(pvcalc.path("outputs").path("monthly").path("fixed"),
                     "E_m");
@@ -109,6 +110,10 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
         Supplier<T> decorated = CircuitBreaker.decorateSupplier(circuitBreaker, supplier);
         decorated = Retry.decorateSupplier(retry, decorated);
         return decorated.get();
+    }
+
+    private String fetchRaw(String url) {
+        return restTemplate.getForObject(url, String.class);
     }
 
     private String pvcalcUrl(double latitude, double longitude, double systemLossPct) {
@@ -166,6 +171,13 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
         if (message == null || message.isBlank()) {
             return throwable.getClass().getSimpleName();
         }
-        return throwable.getClass().getSimpleName() + ": " + message.replaceAll("[\r\n]", " ");
+        return throwable.getClass().getSimpleName() + ": " + sanitize(message);
+    }
+
+    private String sanitize(String value) {
+        return value
+                .replaceAll("[\r\n]", " ")
+                .replaceAll("lat=[^&\\s]+", "lat=<redacted>")
+                .replaceAll("lon=[^&\\s]+", "lon=<redacted>");
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/config/PvgisClientConfig.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/config/PvgisClientConfig.java
@@ -1,0 +1,26 @@
+package com.renewsim.backend.simulation_service.infrastructure.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Configures the dedicated HTTP client used by the PVGIS adapter.
+ *
+ * <p>This keeps transport concerns, especially timeout policy, outside the
+ * adapter so the adapter focuses on provider translation and failure handling.</p>
+ */
+@Configuration
+@EnableConfigurationProperties(PvgisProperties.class)
+public class PvgisClientConfig {
+
+    @Bean("pvgisRestTemplate")
+    RestTemplate pvgisRestTemplate(PvgisProperties properties) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout((int) properties.connectTimeout().toMillis());
+        requestFactory.setReadTimeout((int) properties.readTimeout().toMillis());
+        return new RestTemplate(requestFactory);
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/config/PvgisProperties.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/config/PvgisProperties.java
@@ -1,11 +1,21 @@
 package com.renewsim.backend.simulation_service.infrastructure.config;
 
+import java.time.Duration;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Binds outbound PVGIS configuration for the simulation module.
+ *
+ * <p>Keeps the provider base URL and timeout policy explicit so the external
+ * integration can be tuned operationally without changing adapter code.</p>
+ */
 @ConfigurationProperties(prefix = "services.pvgis")
-public record PvgisProperties(String url) {
+public record PvgisProperties(String url, Duration connectTimeout, Duration readTimeout) {
 
     public PvgisProperties {
         url = (url == null || url.isBlank()) ? "https://re.jrc.ec.europa.eu" : url;
+        connectTimeout = connectTimeout == null ? Duration.ofSeconds(2) : connectTimeout;
+        readTimeout = readTimeout == null ? Duration.ofSeconds(5) : readTimeout;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,6 +141,8 @@ resilience4j:
         wait-duration-in-open-state: 20s
         permitted-number-of-calls-in-half-open-state: 3
         automatic-transition-from-open-to-half-open-enabled: true
+        ignore-exceptions:
+          - com.renewsim.backend.shared.exception.BadRequestException
   retry:
     instances:
       userService:
@@ -152,6 +154,8 @@ resilience4j:
       simulationPvgis:
         max-attempts: 2
         wait-duration: 500ms
+        ignore-exceptions:
+          - com.renewsim.backend.shared.exception.BadRequestException
 
 # =============================
 # ZONA HORARIA

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,15 +125,33 @@ resilience4j:
         wait-duration-in-open-state: 10s
         permitted-number-of-calls-in-half-open-state: 3
         automatic-transition-from-open-to-half-open-enabled: true
+      simulationOpenWeather:
+        register-health-indicator: true
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 15s
+        permitted-number-of-calls-in-half-open-state: 3
+        automatic-transition-from-open-to-half-open-enabled: true
+      simulationPvgis:
+        register-health-indicator: true
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 20s
+        permitted-number-of-calls-in-half-open-state: 3
+        automatic-transition-from-open-to-half-open-enabled: true
   retry:
     instances:
       userService:
         max-attempts: 3
         wait-duration: 500ms
-  timelimiter:
-    instances:
-      userService:
-        timeout-duration: 2s
+      simulationOpenWeather:
+        max-attempts: 2
+        wait-duration: 300ms
+      simulationPvgis:
+        max-attempts: 2
+        wait-duration: 500ms
 
 # =============================
 # ZONA HORARIA
@@ -154,6 +172,8 @@ services:
     read-timeout: ${OPENWEATHER_READ_TIMEOUT:3s}
   pvgis:
     url: ${PVGIS_BASE_URL:https://re.jrc.ec.europa.eu}
+    connect-timeout: ${PVGIS_CONNECT_TIMEOUT:2s}
+    read-timeout: ${PVGIS_READ_TIMEOUT:5s}
 
 # =============================
 # SERVICE URLS (base - override en perfiles)

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapterTest.java
@@ -1,0 +1,158 @@
+package com.renewsim.backend.simulation_service.infrastructure.adapter.out.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.ExpectedCount.manyTimes;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.shared.exception.BadRequestException;
+import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+class PvgisSolarResourceAdapterTest {
+
+        @Test
+        @DisplayName("fetchProfile parses PVGIS responses into a complete profile")
+        void fetchProfileParsesResponsesIntoCompleteProfile() {
+                RestTemplate restTemplate = new RestTemplate();
+                MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+                PvgisSolarResourceAdapter adapter = new PvgisSolarResourceAdapter(
+                                new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
+                                new ObjectMapper(),
+                                restTemplate);
+
+                server.expect(requestTo(
+                                "https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.0&optimalangles=1&outputformat=json"))
+                                .andExpect(method(HttpMethod.GET))
+                                .andRespond(withSuccess(pvcalcPayload(), MediaType.APPLICATION_JSON));
+
+                server.expect(requestTo(
+                                "https://re.jrc.ec.europa.eu/api/v5_2/tmy?lat=37.3891&lon=-5.9845&outputformat=json"))
+                                .andExpect(method(HttpMethod.GET))
+                                .andRespond(withSuccess(tmyPayload(), MediaType.APPLICATION_JSON));
+
+                var profile = adapter.fetchProfile(37.3891, -5.9845, 14.0);
+
+                assertThat(profile.monthlyGenerationPerKwp()).hasSize(12);
+                assertThat(profile.monthlyIrradianceKwhM2()).hasSize(12);
+                assertThat(profile.monthlyTemperatureC()).hasSize(12);
+                assertThat(profile.climatePeriod()).isEqualTo("2005-2020");
+                assertThat(profile.source()).isEqualTo("PVGIS");
+                server.verify();
+        }
+
+        @Test
+        @DisplayName("fetchProfile fails fast when PVGIS response is incomplete")
+        void fetchProfileFailsFastWhenResponseIsIncomplete() {
+                RestTemplate restTemplate = new RestTemplate();
+                MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+                PvgisSolarResourceAdapter adapter = new PvgisSolarResourceAdapter(
+                                new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
+                                new ObjectMapper(),
+                                restTemplate);
+
+                server.expect(manyTimes(), requestTo(
+                                "https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.0&optimalangles=1&outputformat=json"))
+                                .andExpect(method(HttpMethod.GET))
+                                .andRespond(withSuccess(
+                                                "{\"outputs\":{\"monthly\":{\"fixed\":[]}},\"inputs\":{\"meteo_data\":{\"year_min\":2005,\"year_max\":2020}}}",
+                                                MediaType.APPLICATION_JSON));
+
+                server.expect(manyTimes(), requestTo(
+                                "https://re.jrc.ec.europa.eu/api/v5_2/tmy?lat=37.3891&lon=-5.9845&outputformat=json"))
+                                .andExpect(method(HttpMethod.GET))
+                                .andRespond(withSuccess("{\"outputs\":{\"tmy_hourly\":[]}}",
+                                                MediaType.APPLICATION_JSON));
+
+                assertThatThrownBy(() -> adapter.fetchProfile(37.3891, -5.9845, 14.0))
+                                .isInstanceOf(BadRequestException.class)
+                                .hasMessageContaining("PVGIS response is incomplete");
+
+                server.verify();
+        }
+
+        @Test
+        @DisplayName("fetchProfile wraps provider failure in an infrastructure exception")
+        void fetchProfileWrapsProviderFailure() {
+                RestTemplate restTemplate = new RestTemplate();
+                MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+                PvgisSolarResourceAdapter adapter = new PvgisSolarResourceAdapter(
+                                new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
+                                new ObjectMapper(),
+                                restTemplate);
+
+                server.expect(manyTimes(), requestTo(
+                                "https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.0&optimalangles=1&outputformat=json"))
+                                .andExpect(method(HttpMethod.GET))
+                                .andRespond(withServerError());
+
+                assertThatThrownBy(() -> adapter.fetchProfile(37.3891, -5.9845, 14.0))
+                                .isInstanceOf(IllegalStateException.class)
+                                .hasMessageContaining("Failed to fetch PVGIS solar resource data");
+
+                server.verify();
+        }
+
+        private String pvcalcPayload() {
+                return """
+                                {
+                                  "outputs": {
+                                    "monthly": {
+                                      "fixed": [
+                                        {"E_m":100.0,"H(i)_m":10.0},
+                                        {"E_m":101.0,"H(i)_m":11.0},
+                                        {"E_m":102.0,"H(i)_m":12.0},
+                                        {"E_m":103.0,"H(i)_m":13.0},
+                                        {"E_m":104.0,"H(i)_m":14.0},
+                                        {"E_m":105.0,"H(i)_m":15.0},
+                                        {"E_m":106.0,"H(i)_m":16.0},
+                                        {"E_m":107.0,"H(i)_m":17.0},
+                                        {"E_m":108.0,"H(i)_m":18.0},
+                                        {"E_m":109.0,"H(i)_m":19.0},
+                                        {"E_m":110.0,"H(i)_m":20.0},
+                                        {"E_m":111.0,"H(i)_m":21.0}
+                                      ]
+                                    }
+                                  },
+                                  "inputs": {
+                                    "meteo_data": {
+                                      "year_min": 2005,
+                                      "year_max": 2020
+                                    }
+                                  }
+                                }
+                                """;
+        }
+
+        private String tmyPayload() {
+                return """
+                                {
+                                  "outputs": {
+                                    "tmy_hourly": [
+                                      {"time(UTC)":"2024010100","T2m":10.0},
+                                      {"time(UTC)":"2024020100","T2m":11.0},
+                                      {"time(UTC)":"2024030100","T2m":12.0},
+                                      {"time(UTC)":"2024040100","T2m":13.0},
+                                      {"time(UTC)":"2024050100","T2m":14.0},
+                                      {"time(UTC)":"2024060100","T2m":15.0},
+                                      {"time(UTC)":"2024070100","T2m":16.0},
+                                      {"time(UTC)":"2024080100","T2m":17.0},
+                                      {"time(UTC)":"2024090100","T2m":18.0},
+                                      {"time(UTC)":"2024100100","T2m":19.0},
+                                      {"time(UTC)":"2024110100","T2m":20.0},
+                                      {"time(UTC)":"2024120100","T2m":21.0}
+                                    ]
+                                  }
+                                }
+                                """;
+        }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/config/ClimateProviderWiringTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/config/ClimateProviderWiringTest.java
@@ -3,6 +3,8 @@ package com.renewsim.backend.simulation_service.infrastructure.config;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.external.OpenWeatherMapAdapter;
 import com.renewsim.backend.simulation_service.location_lookup.application.LocationLookupService;
 import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.RetryRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +21,9 @@ class ClimateProviderWiringTest {
                     RestTemplateAutoConfiguration.class,
                     OpenWeatherClientConfig.class,
                     LocationLookupService.class,
-                    OpenWeatherMapAdapter.class));
+                    OpenWeatherMapAdapter.class))
+            .withBean(CircuitBreakerRegistry.class, CircuitBreakerRegistry::ofDefaults)
+            .withBean(RetryRegistry.class, RetryRegistry::ofDefaults);
 
     @Test
     @DisplayName("missing provider does not instantiate a location lookup provider")


### PR DESCRIPTION
## What changed
- hardens `OpenWeatherMapAdapter` and `PvgisSolarResourceAdapter` with explicit retry and circuit breaker behavior
- centralizes PVGIS transport policy through `PvgisProperties` + `PvgisClientConfig` with dedicated connect/read timeouts
- adds focused PVGIS adapter tests for valid responses, incomplete payloads and provider failures
- documents the fallback strategy in `ADR-012`, including why OpenWeather can degrade safely while PVGIS must fail fast

## Why
Closes #198.

This is the first resilience hardening slice for `simulation_service`, which is the most central bounded context in RenewSim and still depended on external providers with mostly local/ad-hoc failure handling. The goal of this PR is to make those integrations more explicit, testable and defendable from an enterprise backend perspective.

## Validation
- `mvn -Dtest=OpenWeatherMapAdapterTest,PvgisSolarResourceAdapterTest test`
- `mvn -Dtest=LocationLookupServiceTest,SimulationLocationLookupControllerTest,CreateSimulationServiceTest,CreateSimulationFromScenarioServiceTest test`

## Notes for reviewers
- The key design decision is not just the use of Resilience4j, but the different fallback policy by domain impact: OpenWeather may degrade to `Unknown`/empty results, while PVGIS must not fabricate synthetic energy profiles.
- Resilience is applied programmatically inside these adapters so the behavior is exercised consistently in direct adapter tests, not only through Spring proxy wiring.