### PR TITLE
refactor(simulation): add use-case telemetry and operational logging

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
@@ -3,12 +3,16 @@ package com.renewsim.backend.simulation_service.create.application;
 import com.renewsim.backend.simulation_service.create.application.command.CreateRealSimulationCommand;
 import com.renewsim.backend.simulation_service.create.application.port.in.CreateRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.create.application.port.out.CreateSimulationRepositoryPort;
-import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
-import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationTechnologyException;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
+import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,24 +24,46 @@ import java.util.List;
 @Transactional
 public class CreateSimulationService implements CreateRealSimulationUseCase {
 
+    private static final Logger log = LoggerFactory.getLogger(CreateSimulationService.class);
+    private static final String USE_CASE = "create";
+
     private final CreateSimulationRepositoryPort repository;
     private final TechnologyLookupPort technologyLookupPort;
     private final List<SimulationEngine> simulationEngines;
     private final SimulationCompletionAssembler completionAssembler;
+    private final SimulationUseCaseTelemetry telemetry;
 
     @Override
     public SimulationDetailsResult createSimulation(CreateRealSimulationCommand command) {
-        validateTechnology(command.technology());
-        SimulationEngine simulationEngine = resolveEngine(command.technology());
-        simulationEngine.assertImplemented();
+        Timer.Sample sample = telemetry.start();
+        try {
+            validateTechnology(command.technology());
+            SimulationEngine simulationEngine = resolveEngine(command.technology());
+            simulationEngine.assertImplemented();
 
-        List<Long> technologyIds = resolveTechnologyIds(command);
-        Simulation simulation = persistDraft(command, technologyIds);
-        SimulationDetailsResult result = simulationEngine.simulate(simulation, command);
-        simulation.complete(completionAssembler.toCompletion(result, technologyIds));
-        repository.save(simulation);
+            List<Long> technologyIds = resolveTechnologyIds(command);
+            Simulation simulation = persistDraft(command, technologyIds);
+            SimulationDetailsResult result = simulationEngine.simulate(simulation, command);
+            simulation.complete(completionAssembler.toCompletion(result, technologyIds));
+            repository.save(simulation);
 
-        return result;
+            telemetry.recordSuccess(USE_CASE, sample);
+            log.info("Simulation create succeeded user={} simulationId={} energyType={} scenarioOrigin={}",
+                    command.createdBy(),
+                    result.id(),
+                    command.technology().value(),
+                    command.scenarioId() != null);
+
+            return result;
+        } catch (RuntimeException ex) {
+            telemetry.recordError(USE_CASE, sample);
+            log.info("Simulation create rejected user={} energyType={} scenarioOrigin={} reason={}",
+                    command.createdBy(),
+                    command.technology().value(),
+                    command.scenarioId() != null,
+                    ex.getClass().getSimpleName());
+            throw ex;
+        }
     }
 
     private Simulation persistDraft(CreateRealSimulationCommand command, List<Long> technologyIds) {

--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedHashSet;
@@ -47,12 +49,7 @@ public class CreateSimulationService implements CreateRealSimulationUseCase {
             simulation.complete(completionAssembler.toCompletion(result, technologyIds));
             repository.save(simulation);
 
-            telemetry.recordSuccess(USE_CASE, sample);
-            log.info("Simulation create succeeded user={} simulationId={} energyType={} scenarioOrigin={}",
-                    command.createdBy(),
-                    result.id(),
-                    command.technology().value(),
-                    command.scenarioId() != null);
+            recordCreateSuccess(command, result, sample);
 
             return result;
         } catch (RuntimeException ex) {
@@ -64,6 +61,44 @@ public class CreateSimulationService implements CreateRealSimulationUseCase {
                     ex.getClass().getSimpleName());
             throw ex;
         }
+    }
+
+    private void recordCreateSuccess(
+            CreateRealSimulationCommand command,
+            SimulationDetailsResult result,
+            Timer.Sample sample) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            telemetry.recordSuccess(USE_CASE, sample);
+            log.info("Simulation create succeeded user={} simulationId={} energyType={} scenarioOrigin={}",
+                    command.createdBy(),
+                    result.id(),
+                    command.technology().value(),
+                    command.scenarioId() != null);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                telemetry.recordSuccess(USE_CASE, sample);
+                log.info("Simulation create succeeded user={} simulationId={} energyType={} scenarioOrigin={}",
+                        command.createdBy(),
+                        result.id(),
+                        command.technology().value(),
+                        command.scenarioId() != null);
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+                if (status != STATUS_COMMITTED) {
+                    telemetry.recordError(USE_CASE, sample);
+                    log.warn("Simulation create rolled back user={} energyType={} scenarioOrigin={}",
+                            command.createdBy(),
+                            command.technology().value(),
+                            command.scenarioId() != null);
+                }
+            }
+        });
     }
 
     private Simulation persistDraft(CreateRealSimulationCommand command, List<Long> technologyIds) {

--- a/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardService.java
@@ -4,7 +4,11 @@ import com.renewsim.backend.simulation_service.dashboard.application.port.out.Po
 import com.renewsim.backend.simulation_service.dashboard.application.port.in.GetPortfolioDashboardUseCase;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.PortfolioDashboardResult;
 import com.renewsim.backend.simulation_service.dashboard.application.projection.ScenarioSnapshot;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,22 +23,39 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class GetPortfolioDashboardService implements GetPortfolioDashboardUseCase {
 
+        private static final Logger log = LoggerFactory.getLogger(GetPortfolioDashboardService.class);
+        private static final String USE_CASE = "dashboard";
+
         private final PortfolioDashboardQueryPort repository;
         private final ScenarioSnapshotAssembler snapshotAssembler;
         private final PortfolioDashboardAggregator dashboardAggregator;
+        private final SimulationUseCaseTelemetry telemetry;
 
         @Override
         public PortfolioDashboardResult getDashboard(String username) {
-                List<ScenarioSnapshot> snapshots = repository.findByCreatedByOrderByCreatedAtDesc(username).stream()
-                                .map(snapshotAssembler::toSnapshot)
-                                .toList();
+                Timer.Sample sample = telemetry.start();
+                try {
+                        List<ScenarioSnapshot> snapshots = repository.findByCreatedByOrderByCreatedAtDesc(username).stream()
+                                        .map(snapshotAssembler::toSnapshot)
+                                        .toList();
 
-                List<ScenarioSnapshot> ranked = snapshots.stream()
-                                .sorted(Comparator.comparingInt(ScenarioSnapshot::score).reversed()
-                                                .thenComparing(ScenarioSnapshot::createdAt,
-                                                                Comparator.nullsLast(Comparator.reverseOrder())))
-                                .toList();
+                        List<ScenarioSnapshot> ranked = snapshots.stream()
+                                        .sorted(Comparator.comparingInt(ScenarioSnapshot::score).reversed()
+                                                        .thenComparing(ScenarioSnapshot::createdAt,
+                                                                        Comparator.nullsLast(Comparator.reverseOrder())))
+                                        .toList();
 
-                return dashboardAggregator.buildDashboard(snapshots, ranked);
+                        PortfolioDashboardResult result = dashboardAggregator.buildDashboard(snapshots, ranked);
+                        telemetry.recordSuccess(USE_CASE, sample);
+                        log.info("Simulation dashboard built user={} totalSimulations={} prioritized={}",
+                                        username,
+                                        result.summary().totalSimulations(),
+                                        result.prioritizedScenarios().size());
+                        return result;
+                } catch (RuntimeException ex) {
+                        telemetry.recordError(USE_CASE, sample);
+                        log.warn("Simulation dashboard failed user={} reason={}", username, ex.getClass().getSimpleName());
+                        throw ex;
+                }
         }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
@@ -36,18 +36,10 @@ public class GetSimulationService implements GetRealSimulationUseCase {
                 throw new SimulationNotFoundException(id);
             }
 
-            SimulationDetailsResult result = snapshotReader.read(simulation.getResultSnapshot());
+            SimulationDetailsResult result = readSnapshotOrDegrade(id, simulation.getResultSnapshot(), requesterUsername, isAdmin, sample);
             telemetry.recordSuccess(USE_CASE, sample);
             log.info("Simulation detail retrieved requester={} simulationId={} admin={}", requesterUsername, id, isAdmin);
             return result;
-        } catch (IllegalStateException ex) {
-            telemetry.recordDegraded(USE_CASE, sample);
-            log.warn("Simulation detail snapshot degraded requester={} simulationId={} admin={} reason={}",
-                    requesterUsername,
-                    id,
-                    isAdmin,
-                    ex.getClass().getSimpleName());
-            throw new SimulationNotFoundException(id);
         } catch (RuntimeException ex) {
             telemetry.recordError(USE_CASE, sample);
             log.info("Simulation detail rejected requester={} simulationId={} admin={} reason={}",
@@ -56,6 +48,25 @@ public class GetSimulationService implements GetRealSimulationUseCase {
                     isAdmin,
                     ex.getClass().getSimpleName());
             throw ex;
+        }
+    }
+
+    private SimulationDetailsResult readSnapshotOrDegrade(
+            Long id,
+            String snapshot,
+            String requesterUsername,
+            boolean isAdmin,
+            Timer.Sample sample) {
+        try {
+            return snapshotReader.read(snapshot);
+        } catch (IllegalStateException ex) {
+            telemetry.recordDegraded(USE_CASE, sample);
+            log.warn("Simulation detail snapshot degraded requester={} simulationId={} admin={} reason={}",
+                    requesterUsername,
+                    id,
+                    isAdmin,
+                    ex.getClass().getSimpleName());
+            throw new SimulationNotFoundException(id);
         }
     }
 

--- a/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
@@ -2,11 +2,15 @@ package com.renewsim.backend.simulation_service.detail.application;
 
 import com.renewsim.backend.simulation_service.detail.application.port.in.GetRealSimulationUseCase;
 import com.renewsim.backend.simulation_service.detail.application.port.out.SimulationDetailQueryPort;
-import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
-import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationResultSnapshotReaderPort;
 import com.renewsim.backend.simulation_service.domain.exception.SimulationNotFoundException;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
+import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationResultSnapshotReaderPort;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,19 +20,42 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GetSimulationService implements GetRealSimulationUseCase {
 
+    private static final Logger log = LoggerFactory.getLogger(GetSimulationService.class);
+    private static final String USE_CASE = "detail";
+
     private final SimulationDetailQueryPort repository;
     private final SimulationResultSnapshotReaderPort snapshotReader;
+    private final SimulationUseCaseTelemetry telemetry;
 
     @Override
     public SimulationDetailsResult getSimulationById(Long id, String requesterUsername, boolean isAdmin) {
-        Simulation simulation = getAccessibleSimulation(id, requesterUsername, isAdmin);
-        if (!simulation.hasResult()) {
-            throw new SimulationNotFoundException(id);
-        }
+        Timer.Sample sample = telemetry.start();
         try {
-            return snapshotReader.read(simulation.getResultSnapshot());
+            Simulation simulation = getAccessibleSimulation(id, requesterUsername, isAdmin);
+            if (!simulation.hasResult()) {
+                throw new SimulationNotFoundException(id);
+            }
+
+            SimulationDetailsResult result = snapshotReader.read(simulation.getResultSnapshot());
+            telemetry.recordSuccess(USE_CASE, sample);
+            log.info("Simulation detail retrieved requester={} simulationId={} admin={}", requesterUsername, id, isAdmin);
+            return result;
         } catch (IllegalStateException ex) {
+            telemetry.recordDegraded(USE_CASE, sample);
+            log.warn("Simulation detail snapshot degraded requester={} simulationId={} admin={} reason={}",
+                    requesterUsername,
+                    id,
+                    isAdmin,
+                    ex.getClass().getSimpleName());
             throw new SimulationNotFoundException(id);
+        } catch (RuntimeException ex) {
+            telemetry.recordError(USE_CASE, sample);
+            log.info("Simulation detail rejected requester={} simulationId={} admin={} reason={}",
+                    requesterUsername,
+                    id,
+                    isAdmin,
+                    ex.getClass().getSimpleName());
+            throw ex;
         }
     }
 

--- a/src/main/java/com/renewsim/backend/simulation_service/history/application/ListSimulationsService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/history/application/ListSimulationsService.java
@@ -5,7 +5,11 @@ import com.renewsim.backend.simulation_service.history.application.port.out.Simu
 import com.renewsim.backend.simulation_service.history.application.result.SimulationHistoryRowResult;
 import com.renewsim.backend.simulation_service.history.application.result.UserSimulationListResult;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,18 +23,31 @@ import static com.renewsim.backend.simulation_service.shared.application.Simulat
 @Transactional(readOnly = true)
 public class ListSimulationsService implements ListUserRealSimulationsUseCase {
 
+    private static final Logger log = LoggerFactory.getLogger(ListSimulationsService.class);
     private static final String MODEL_VERSION = "solar-spain-v1";
     private static final String RESOURCE_SOURCE = "PVGIS";
+    private static final String USE_CASE = "history";
 
     private final SimulationHistoryQueryPort repository;
+    private final SimulationUseCaseTelemetry telemetry;
 
     @Override
     public UserSimulationListResult getUserSimulations(String username) {
-        List<SimulationHistoryRowResult> items = repository.findByCreatedByOrderByCreatedAtDesc(username)
-                .stream()
-                .map(this::toHistoryRow)
-                .toList();
-        return new UserSimulationListResult(items, items.size());
+        Timer.Sample sample = telemetry.start();
+        try {
+            List<SimulationHistoryRowResult> items = repository.findByCreatedByOrderByCreatedAtDesc(username)
+                    .stream()
+                    .map(this::toHistoryRow)
+                    .toList();
+            UserSimulationListResult result = new UserSimulationListResult(items, items.size());
+            telemetry.recordSuccess(USE_CASE, sample);
+            log.info("Simulation history retrieved user={} total={}", username, result.total());
+            return result;
+        } catch (RuntimeException ex) {
+            telemetry.recordError(USE_CASE, sample);
+            log.warn("Simulation history failed user={} reason={}", username, ex.getClass().getSimpleName());
+            throw ex;
+        }
     }
 
     private SimulationHistoryRowResult toHistoryRow(Simulation simulation) {

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationUseCaseTelemetry.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationUseCaseTelemetry.java
@@ -1,0 +1,58 @@
+package com.renewsim.backend.simulation_service.shared.application;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+public class SimulationUseCaseTelemetry {
+
+    private final MeterRegistry meterRegistry;
+    private final ConcurrentMap<String, Counter> counters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Timer> timers = new ConcurrentHashMap<>();
+
+    public SimulationUseCaseTelemetry(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public Timer.Sample start() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordSuccess(String useCase, Timer.Sample sample) {
+        record(useCase, "success", sample);
+    }
+
+    public void recordError(String useCase, Timer.Sample sample) {
+        record(useCase, "error", sample);
+    }
+
+    public void recordDegraded(String useCase, Timer.Sample sample) {
+        record(useCase, "degraded", sample);
+    }
+
+    private void record(String useCase, String outcome, Timer.Sample sample) {
+        counter(useCase, outcome).increment();
+        sample.stop(timer(useCase, outcome));
+    }
+
+    private Counter counter(String useCase, String outcome) {
+        return counters.computeIfAbsent(useCase + ':' + outcome,
+                ignored -> Counter.builder("simulation_service_use_case_total")
+                        .tag("use_case", useCase)
+                        .tag("outcome", outcome)
+                        .register(meterRegistry));
+    }
+
+    private Timer timer(String useCase, String outcome) {
+        return timers.computeIfAbsent(useCase + ':' + outcome,
+                ignored -> Timer.builder("simulation_service_use_case_duration")
+                        .tag("use_case", useCase)
+                        .tag("outcome", outcome)
+                        .register(meterRegistry));
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationFromScenarioServiceTest.java
@@ -13,6 +13,7 @@ import com.renewsim.backend.simulation_service.create.application.port.out.Pvgis
 import com.renewsim.backend.simulation_service.domain.exception.InvalidConsumptionProfileException;
 import com.renewsim.backend.simulation_service.domain.exception.InvalidSimulationCurrencyException;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
 import com.renewsim.backend.simulation_service.shared.application.port.out.ScenarioLookupPort;
 import com.renewsim.backend.simulation_service.shared.application.port.out.TechnologyLookupPort;
 import com.renewsim.backend.simulation_service.domain.model.Simulation;
@@ -26,6 +27,7 @@ import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persis
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -377,7 +379,8 @@ class CreateSimulationFromScenarioServiceTest {
                                                 new HydroSimulationEngine()),
                                 new SimulationCompletionAssembler(
                                                 new SimulationResultSnapshotJacksonWriter(
-                                                                new ObjectMapper().findAndRegisterModules())));
+                                                                new ObjectMapper().findAndRegisterModules())),
+                                new SimulationUseCaseTelemetry(new SimpleMeterRegistry()));
         }
 
         private SimulationRecordRepositoryAdapter inMemoryPersistenceRepository(JpaSimulationRepository jpaRepository) {

--- a/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/create/application/CreateSimulationServiceTest.java
@@ -12,6 +12,8 @@ import com.renewsim.backend.simulation_service.domain.model.SimulationId;
 import com.renewsim.backend.simulation_service.domain.model.vo.ConsumptionProfile;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.persistence.SimulationResultSnapshotJacksonWriter;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,6 +74,8 @@ class CreateSimulationServiceTest {
                 assertThat(captor.getAllValues().get(1).getResultSnapshot()).isNotBlank();
                 assertThat(captor.getAllValues().get(1).getTechnologyIds()).containsExactly(1L, 2L);
                 verify(technologyLookupPort).recommendActiveTechnologyIdsByEnergyType("solar");
+                assertThat(meterRegistry().counter("simulation_service_use_case_total", "use_case", "create", "outcome", "success").count())
+                                .isEqualTo(1.0d);
         }
 
         @Test
@@ -192,6 +196,13 @@ class CreateSimulationServiceTest {
                                 technologyLookupPort,
                                 engines(resourcePort),
                                 new SimulationCompletionAssembler(
-                                                new SimulationResultSnapshotJacksonWriter(objectMapper)));
+                                                new SimulationResultSnapshotJacksonWriter(objectMapper)),
+                                new SimulationUseCaseTelemetry(meterRegistry()));
         }
+
+        private SimpleMeterRegistry meterRegistry() {
+                return registry;
+        }
+
+        private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/dashboard/application/GetPortfolioDashboardServiceTest.java
@@ -16,6 +16,8 @@ import com.renewsim.backend.simulation_service.domain.model.vo.SimulationEconomi
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationLocation;
 import com.renewsim.backend.simulation_service.domain.model.vo.SimulationSystem;
 import com.renewsim.backend.simulation_service.domain.model.vo.Technology;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,13 +42,16 @@ class GetPortfolioDashboardServiceTest {
         @Mock
         private TechnologyLookupPort technologyLookupPort;
 
+        private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
         @Test
         @DisplayName("getDashboard aggregates portfolio KPIs, recommendation and alerts")
         void getDashboardAggregatesPortfolioData() throws Exception {
                 GetPortfolioDashboardService service = new GetPortfolioDashboardService(
                                 repository,
                                 snapshotAssembler(technologyLookupPort),
-                                dashboardAggregator());
+                                dashboardAggregator(),
+                                new SimulationUseCaseTelemetry(meterRegistry));
 
                 Simulation best = completedSimulation(55L, "alice",
                                 new ObjectMapper().findAndRegisterModules().writeValueAsString(resultWithMetrics(
@@ -102,7 +107,8 @@ class GetPortfolioDashboardServiceTest {
                 GetPortfolioDashboardService service = new GetPortfolioDashboardService(
                                 repository,
                                 snapshotAssembler(technologyLookupPort),
-                                dashboardAggregator());
+                                dashboardAggregator(),
+                                new SimulationUseCaseTelemetry(meterRegistry));
 
                 Simulation partial = completedSimulation(58L, "alice", """
                                 {
@@ -131,7 +137,8 @@ class GetPortfolioDashboardServiceTest {
                 GetPortfolioDashboardService service = new GetPortfolioDashboardService(
                                 repository,
                                 snapshotAssembler(technologyLookupPort),
-                                dashboardAggregator());
+                                dashboardAggregator(),
+                                new SimulationUseCaseTelemetry(meterRegistry));
 
                 Simulation malformed = completedSimulation(59L, "alice", "{ bad json");
 

--- a/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.simulation_service.detail.application.port.out.SimulationDetailQueryPort;
 import com.renewsim.backend.simulation_service.domain.exception.SimulationNotFoundException;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,10 +28,12 @@ class GetSimulationServiceTest {
     @Mock
     private SimulationDetailQueryPort repository;
 
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
     @Test
-    @DisplayName("getSimulationById enforces ownership for non admins")
+        @DisplayName("getSimulationById enforces ownership for non admins")
     void getSimulationByIdEnforcesOwnership() throws Exception {
-        GetSimulationService service = new GetSimulationService(repository, snapshotReader());
+        GetSimulationService service = new GetSimulationService(repository, snapshotReader(), new SimulationUseCaseTelemetry(meterRegistry));
         SimulationDetailsResult result = minimalResult();
         var simulation = completedSimulation(55L, "alice",
                 new ObjectMapper().findAndRegisterModules().writeValueAsString(result));
@@ -43,7 +47,7 @@ class GetSimulationServiceTest {
     @Test
     @DisplayName("getSimulationById fails when snapshot is missing")
     void getSimulationByIdFailsWhenSnapshotMissing() {
-        GetSimulationService service = new GetSimulationService(repository, snapshotReader());
+        GetSimulationService service = new GetSimulationService(repository, snapshotReader(), new SimulationUseCaseTelemetry(meterRegistry));
         var simulation = completedSimulation(55L, "alice", null);
         when(repository.findById(55L)).thenReturn(Optional.of(simulation));
 
@@ -54,11 +58,13 @@ class GetSimulationServiceTest {
     @Test
     @DisplayName("getSimulationById degrades invalid snapshots to not found")
     void getSimulationByIdDegradesInvalidSnapshotsToNotFound() {
-        GetSimulationService service = new GetSimulationService(repository, snapshotReader());
+        GetSimulationService service = new GetSimulationService(repository, snapshotReader(), new SimulationUseCaseTelemetry(meterRegistry));
         var simulation = completedSimulation(55L, "alice", "{ bad json");
         when(repository.findById(55L)).thenReturn(Optional.of(simulation));
 
         assertThatThrownBy(() -> service.getSimulationById(55L, "alice", false))
                 .isInstanceOf(SimulationNotFoundException.class);
+        assertThat(meterRegistry.counter("simulation_service_use_case_total", "use_case", "detail", "outcome", "degraded").count())
+                .isEqualTo(1.0d);
     }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/history/application/ListSimulationsServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/history/application/ListSimulationsServiceTest.java
@@ -2,6 +2,8 @@ package com.renewsim.backend.simulation_service.history.application;
 
 import com.renewsim.backend.simulation_service.history.application.port.out.SimulationHistoryQueryPort;
 import com.renewsim.backend.simulation_service.history.application.result.UserSimulationListResult;
+import com.renewsim.backend.simulation_service.shared.application.SimulationUseCaseTelemetry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,10 +22,12 @@ class ListSimulationsServiceTest {
     @Mock
     private SimulationHistoryQueryPort repository;
 
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+
     @Test
     @DisplayName("getUserSimulations maps stored summary columns for scenario-created simulations")
     void getUserSimulationsMapsStoredSummaryColumnsForScenarioCreatedSimulations() {
-        ListSimulationsService service = new ListSimulationsService(repository);
+        ListSimulationsService service = new ListSimulationsService(repository, new SimulationUseCaseTelemetry(meterRegistry));
         var simulation = completedSimulation(55L, "alice", null);
         simulation.assignScenarioId(42L);
         simulation.assignTechnologyIds(List.of(11L, 12L));


### PR DESCRIPTION
## What changed
- adds `SimulationUseCaseTelemetry` as a small reusable helper for `simulation_service` use-case metrics
- instruments `CreateSimulationService`, `GetSimulationService`, `GetPortfolioDashboardService` and `ListSimulationsService` with total and duration metrics tagged by `use_case` and `outcome`
- adds operational logging for success, rejection and degradation paths with low-cardinality context
- updates simulation tests and adds explicit metric assertions for `create` success and `detail` degraded snapshot handling

## Why
Closes #199.

After the external-provider resilience hardening from #198, `simulation_service` still lacked its own operational signals in the core use cases that matter most for runtime diagnosis and interview/demo storytelling. This PR adds a first observability slice with intentionally low-cardinality metrics and consistent outcome semantics, without introducing a large observability layer.

## Validation
- `mvn -Dtest=CreateSimulationServiceTest,CreateSimulationFromScenarioServiceTest,GetSimulationServiceTest,GetPortfolioDashboardServiceTest,ListSimulationsServiceTest test`

## Notes for reviewers
- The key design choice is to distinguish `success`, `error` and `degraded` outcomes while keeping metric tags limited to `use_case` and `outcome` only.
- `GetSimulationService` treats invalid historical snapshots as `degraded` rather than a generic error because that distinction is operationally meaningful for the module.