### PR TITLE
refactor(simulation): add provider and degradation telemetry

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
@@ -61,6 +61,7 @@ public class GetSimulationService implements GetRealSimulationUseCase {
             return snapshotReader.read(snapshot);
         } catch (IllegalStateException ex) {
             telemetry.recordDegraded(USE_CASE, sample);
+            telemetry.recordSnapshotDegraded("invalid_result_snapshot");
             log.warn("Simulation detail snapshot degraded requester={} simulationId={} admin={} reason={}",
                     requesterUsername,
                     id,

--- a/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationService.java
@@ -58,7 +58,11 @@ public class GetSimulationService implements GetRealSimulationUseCase {
             boolean isAdmin,
             Timer.Sample sample) {
         try {
-            return snapshotReader.read(snapshot);
+            SimulationDetailsResult result = snapshotReader.read(snapshot);
+            if (result == null) {
+                throw new IllegalStateException("Decoded snapshot is null");
+            }
+            return result;
         } catch (IllegalStateException ex) {
             telemetry.recordDegraded(USE_CASE, sample);
             telemetry.recordSnapshotDegraded("invalid_result_snapshot");

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
@@ -4,6 +4,7 @@ import com.renewsim.backend.simulation_service.domain.model.vo.CountryCode;
 import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
 import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
 import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import com.renewsim.backend.simulation_service.shared.application.SimulationProviderTelemetry;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.retry.Retry;
@@ -41,32 +42,43 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
     private final RestTemplate restTemplate;
     private final CircuitBreaker circuitBreaker;
     private final Retry retry;
+    private final SimulationProviderTelemetry telemetry;
 
     @Autowired
     public OpenWeatherMapAdapter(
             WeatherServiceProperties weatherProperties,
             @Qualifier("openWeatherRestTemplate") RestTemplate restTemplate,
             CircuitBreakerRegistry circuitBreakerRegistry,
-            RetryRegistry retryRegistry) {
+            RetryRegistry retryRegistry,
+            SimulationProviderTelemetry telemetry) {
         this.weatherProperties = weatherProperties;
         this.restTemplate = restTemplate;
         this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("simulationOpenWeather");
         this.retry = retryRegistry.retry("simulationOpenWeather");
+        this.telemetry = telemetry;
     }
 
-    OpenWeatherMapAdapter(WeatherServiceProperties weatherProperties, RestTemplate restTemplate) {
+    OpenWeatherMapAdapter(
+            WeatherServiceProperties weatherProperties,
+            RestTemplate restTemplate,
+            SimulationProviderTelemetry telemetry) {
         this(
                 weatherProperties,
                 restTemplate,
                 CircuitBreakerRegistry.ofDefaults(),
-                RetryRegistry.ofDefaults());
+                RetryRegistry.ofDefaults(),
+                telemetry);
     }
 
     @Override
     public ResolvedLocation resolveLocation(double latitude, double longitude) {
+        var sample = telemetry.start();
         try {
-            return execute(() -> doResolveLocation(latitude, longitude));
+            ResolvedLocation result = execute(() -> doResolveLocation(latitude, longitude));
+            telemetry.recordSuccess("openweather", sample);
+            return result;
         } catch (Exception exception) {
+            telemetry.recordFallback("openweather", sample);
             log.warn("OpenWeather fallback for resolveLocation reason={}",
                     summarizeFailure(exception));
             return new ResolvedLocation(coordinateLabel(latitude, longitude), "Unknown");
@@ -76,9 +88,13 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
     @Override
     public List<ResolvedLocation> searchLocations(String query, int limit) {
         int requestedLimit = Math.max(1, limit);
+        var sample = telemetry.start();
         try {
-            return execute(() -> doSearchLocations(query, requestedLimit));
+            List<ResolvedLocation> result = execute(() -> doSearchLocations(query, requestedLimit));
+            telemetry.recordSuccess("openweather", sample);
+            return result;
         } catch (Exception exception) {
+            telemetry.recordFallback("openweather", sample);
             log.warn("OpenWeather fallback for searchLocations queryLength={} limit={} reason={}",
                     query == null ? 0 : query.length(),
                     requestedLimit,

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapter.java
@@ -75,7 +75,11 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
         var sample = telemetry.start();
         try {
             ResolvedLocation result = execute(() -> doResolveLocation(latitude, longitude));
-            telemetry.recordSuccess("openweather", sample);
+            if (isDegradedResolveLocation(latitude, longitude, result)) {
+                telemetry.recordFallback("openweather", sample);
+            } else {
+                telemetry.recordSuccess("openweather", sample);
+            }
             return result;
         } catch (Exception exception) {
             telemetry.recordFallback("openweather", sample);
@@ -207,6 +211,12 @@ public class OpenWeatherMapAdapter implements LocationLookupProvider {
 
     private String coordinateLabel(double latitude, double longitude) {
         return String.format(Locale.ROOT, "%.4f, %.4f", latitude, longitude);
+    }
+
+    private boolean isDegradedResolveLocation(double latitude, double longitude, ResolvedLocation result) {
+        return result != null
+                && "Unknown".equals(result.country())
+                && coordinateLabel(latitude, longitude).equals(result.name());
     }
 
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.shared.exception.BadRequestException;
 import com.renewsim.backend.simulation_service.create.application.port.out.PvgisSolarResourcePort;
 import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import com.renewsim.backend.simulation_service.shared.application.SimulationProviderTelemetry;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.retry.Retry;
@@ -38,6 +39,7 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
     private final RestTemplate restTemplate;
     private final CircuitBreaker circuitBreaker;
     private final Retry retry;
+    private final SimulationProviderTelemetry telemetry;
 
     @Autowired
     public PvgisSolarResourceAdapter(
@@ -45,32 +47,44 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
             ObjectMapper objectMapper,
             @Qualifier("pvgisRestTemplate") RestTemplate restTemplate,
             CircuitBreakerRegistry circuitBreakerRegistry,
-            RetryRegistry retryRegistry) {
+            RetryRegistry retryRegistry,
+            SimulationProviderTelemetry telemetry) {
         this.properties = properties;
         this.objectMapper = objectMapper;
         this.restTemplate = restTemplate;
         this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("simulationPvgis");
         this.retry = retryRegistry.retry("simulationPvgis");
+        this.telemetry = telemetry;
     }
 
-    PvgisSolarResourceAdapter(PvgisProperties properties, ObjectMapper objectMapper, RestTemplate restTemplate) {
+    PvgisSolarResourceAdapter(
+            PvgisProperties properties,
+            ObjectMapper objectMapper,
+            RestTemplate restTemplate,
+            SimulationProviderTelemetry telemetry) {
         this(
                 properties,
                 objectMapper,
                 restTemplate,
                 CircuitBreakerRegistry.ofDefaults(),
-                RetryRegistry.ofDefaults());
+                RetryRegistry.ofDefaults(),
+                telemetry);
     }
 
     @Override
     public PvgisSolarResourceProfile fetchProfile(double latitude, double longitude, double systemLossPct) {
+        var sample = telemetry.start();
         try {
             String pvcalcRaw = execute(() -> fetchRaw(pvcalcUrl(latitude, longitude, systemLossPct)));
             String tmyRaw = execute(() -> fetchRaw(tmyUrl(latitude, longitude)));
-            return doFetchProfile(pvcalcRaw, tmyRaw);
+            PvgisSolarResourceProfile profile = doFetchProfile(pvcalcRaw, tmyRaw);
+            telemetry.recordSuccess("pvgis", sample);
+            return profile;
         } catch (BadRequestException ex) {
+            telemetry.recordError("pvgis", sample);
             throw ex;
         } catch (Exception ex) {
+            telemetry.recordError("pvgis", sample);
             log.error("Error fetching PVGIS profile lossPct={} reason={}",
                     systemLossPct,
                     summarizeFailure(ex));

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationProviderTelemetry.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationProviderTelemetry.java
@@ -1,0 +1,58 @@
+package com.renewsim.backend.simulation_service.shared.application;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+public class SimulationProviderTelemetry {
+
+    private final MeterRegistry meterRegistry;
+    private final ConcurrentMap<String, Counter> counters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Timer> timers = new ConcurrentHashMap<>();
+
+    public SimulationProviderTelemetry(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public Timer.Sample start() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordSuccess(String provider, Timer.Sample sample) {
+        record(provider, "success", sample);
+    }
+
+    public void recordFallback(String provider, Timer.Sample sample) {
+        record(provider, "fallback", sample);
+    }
+
+    public void recordError(String provider, Timer.Sample sample) {
+        record(provider, "error", sample);
+    }
+
+    private void record(String provider, String outcome, Timer.Sample sample) {
+        counter(provider, outcome).increment();
+        sample.stop(timer(provider, outcome));
+    }
+
+    private Counter counter(String provider, String outcome) {
+        return counters.computeIfAbsent(provider + ':' + outcome,
+                ignored -> Counter.builder("simulation_service_provider_calls_total")
+                        .tag("provider", provider)
+                        .tag("outcome", outcome)
+                        .register(meterRegistry));
+    }
+
+    private Timer timer(String provider, String outcome) {
+        return timers.computeIfAbsent(provider + ':' + outcome,
+                ignored -> Timer.builder("simulation_service_provider_call_duration")
+                        .tag("provider", provider)
+                        .tag("outcome", outcome)
+                        .register(meterRegistry));
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationUseCaseTelemetry.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/shared/application/SimulationUseCaseTelemetry.java
@@ -35,6 +35,13 @@ public class SimulationUseCaseTelemetry {
         record(useCase, "degraded", sample);
     }
 
+    public void recordSnapshotDegraded(String reason) {
+        Counter.builder("simulation_service_snapshot_degraded_total")
+                .tag("reason", reason)
+                .register(meterRegistry)
+                .increment();
+    }
+
     private void record(String useCase, String outcome, Timer.Sample sample) {
         counter(useCase, outcome).increment();
         sample.stop(timer(useCase, outcome));

--- a/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
@@ -66,5 +66,7 @@ class GetSimulationServiceTest {
                 .isInstanceOf(SimulationNotFoundException.class);
         assertThat(meterRegistry.counter("simulation_service_use_case_total", "use_case", "detail", "outcome", "degraded").count())
                 .isEqualTo(1.0d);
+        assertThat(meterRegistry.counter("simulation_service_snapshot_degraded_total", "reason", "invalid_result_snapshot").count())
+                .isEqualTo(1.0d);
     }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/detail/application/GetSimulationServiceTest.java
@@ -69,4 +69,19 @@ class GetSimulationServiceTest {
         assertThat(meterRegistry.counter("simulation_service_snapshot_degraded_total", "reason", "invalid_result_snapshot").count())
                 .isEqualTo(1.0d);
     }
+
+    @Test
+    @DisplayName("getSimulationById degrades null-decoded snapshots to not found")
+    void getSimulationByIdDegradesNullDecodedSnapshotsToNotFound() {
+        GetSimulationService service = new GetSimulationService(repository, snapshotReader(), new SimulationUseCaseTelemetry(meterRegistry));
+        var simulation = completedSimulation(55L, "alice", "null");
+        when(repository.findById(55L)).thenReturn(Optional.of(simulation));
+
+        assertThatThrownBy(() -> service.getSimulationById(55L, "alice", false))
+                .isInstanceOf(SimulationNotFoundException.class);
+        assertThat(meterRegistry.counter("simulation_service_use_case_total", "use_case", "detail", "outcome", "degraded").count())
+                .isGreaterThanOrEqualTo(1.0d);
+        assertThat(meterRegistry.counter("simulation_service_snapshot_degraded_total", "reason", "invalid_result_snapshot").count())
+                .isGreaterThanOrEqualTo(1.0d);
+    }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapterTest.java
@@ -5,6 +5,8 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
+import com.renewsim.backend.simulation_service.shared.application.SimulationProviderTelemetry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
@@ -21,9 +23,11 @@ class OpenWeatherMapAdapterTest {
     void searchLocationsKeepsOnlySupportedSpainResults() {
         RestTemplate restTemplate = new RestTemplate();
         MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         OpenWeatherMapAdapter adapter = new OpenWeatherMapAdapter(
                 new WeatherServiceProperties("https://api.openweathermap.org", "test-key", null, null),
-                restTemplate);
+                restTemplate,
+                new SimulationProviderTelemetry(meterRegistry));
 
         server.expect(requestTo("https://api.openweathermap.org/geo/1.0/direct?q=mendoza&limit=25&appid=test-key"))
                 .andExpect(method(HttpMethod.GET))
@@ -37,27 +41,35 @@ class OpenWeatherMapAdapterTest {
         assertThat(results.getFirst().name()).isEqualTo("Sevilla, Andalucia");
         assertThat(results.getFirst().country()).isEqualTo("ES");
         assertThat(results.getFirst().latitude()).isEqualTo(37.3891);
+        assertThat(meterRegistry.counter("simulation_service_provider_calls_total", "provider", "openweather", "outcome", "success").count())
+                .isEqualTo(1.0d);
         server.verify();
     }
 
     @Test
     @DisplayName("searchLocations returns empty list on provider failure when api key is missing")
     void searchLocationsReturnsEmptyListOnProviderFailureWhenApiKeyIsMissing() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         OpenWeatherMapAdapter adapter = new OpenWeatherMapAdapter(
                 new WeatherServiceProperties("not-a-valid-url", null, null, null),
-                new RestTemplate());
+                new RestTemplate(),
+                new SimulationProviderTelemetry(meterRegistry));
 
         var results = adapter.searchLocations("sevilla", 5);
 
         assertThat(results).isEmpty();
+        assertThat(meterRegistry.counter("simulation_service_provider_calls_total", "provider", "openweather", "outcome", "fallback").count())
+                .isEqualTo(1.0d);
     }
 
     @Test
     @DisplayName("resolveLocation returns unknown on provider failure when api key is missing")
     void resolveLocationReturnsUnknownOnProviderFailureWhenApiKeyIsMissing() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         OpenWeatherMapAdapter adapter = new OpenWeatherMapAdapter(
                 new WeatherServiceProperties("not-a-valid-url", null, null, null),
-                new RestTemplate());
+                new RestTemplate(),
+                new SimulationProviderTelemetry(meterRegistry));
 
         var result = adapter.resolveLocation(37.3891, -5.9845);
 

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/OpenWeatherMapAdapterTest.java
@@ -75,5 +75,31 @@ class OpenWeatherMapAdapterTest {
 
         assertThat(result.name()).isEqualTo("37.3891, -5.9845");
         assertThat(result.country()).isEqualTo("Unknown");
+        assertThat(meterRegistry.counter("simulation_service_provider_calls_total", "provider", "openweather", "outcome", "fallback").count())
+                .isEqualTo(1.0d);
+    }
+
+    @Test
+    @DisplayName("resolveLocation counts null payload as fallback")
+    void resolveLocationCountsNullPayloadAsFallback() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        OpenWeatherMapAdapter adapter = new OpenWeatherMapAdapter(
+                new WeatherServiceProperties("https://api.openweathermap.org", "test-key", null, null),
+                restTemplate,
+                new SimulationProviderTelemetry(meterRegistry));
+
+        server.expect(requestTo("https://api.openweathermap.org/data/2.5/weather?lat=37.3891&lon=-5.9845&units=metric&appid=test-key"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
+
+        var result = adapter.resolveLocation(37.3891, -5.9845);
+
+        assertThat(result.name()).isEqualTo("37.3891, -5.9845");
+        assertThat(result.country()).isEqualTo("Unknown");
+        assertThat(meterRegistry.counter("simulation_service_provider_calls_total", "provider", "openweather", "outcome", "fallback").count())
+                .isEqualTo(1.0d);
+        server.verify();
     }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapterTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapterTest.java
@@ -11,6 +11,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.renewsim.backend.shared.exception.BadRequestException;
 import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import com.renewsim.backend.simulation_service.shared.application.SimulationProviderTelemetry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
@@ -25,10 +27,12 @@ class PvgisSolarResourceAdapterTest {
         void fetchProfileParsesResponsesIntoCompleteProfile() {
                 RestTemplate restTemplate = new RestTemplate();
                 MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+                SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
                 PvgisSolarResourceAdapter adapter = new PvgisSolarResourceAdapter(
                                 new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
                                 new ObjectMapper(),
-                                restTemplate);
+                                restTemplate,
+                                new SimulationProviderTelemetry(meterRegistry));
 
                 server.expect(requestTo(
                                 "https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.0&optimalangles=1&outputformat=json"))
@@ -47,6 +51,8 @@ class PvgisSolarResourceAdapterTest {
                 assertThat(profile.monthlyTemperatureC()).hasSize(12);
                 assertThat(profile.climatePeriod()).isEqualTo("2005-2020");
                 assertThat(profile.source()).isEqualTo("PVGIS");
+                assertThat(meterRegistry.counter("simulation_service_provider_calls_total", "provider", "pvgis", "outcome", "success").count())
+                                .isEqualTo(1.0d);
                 server.verify();
         }
 
@@ -55,10 +61,12 @@ class PvgisSolarResourceAdapterTest {
         void fetchProfileFailsFastWhenResponseIsIncomplete() {
                 RestTemplate restTemplate = new RestTemplate();
                 MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+                SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
                 PvgisSolarResourceAdapter adapter = new PvgisSolarResourceAdapter(
                                 new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
                                 new ObjectMapper(),
-                                restTemplate);
+                                restTemplate,
+                                new SimulationProviderTelemetry(meterRegistry));
 
                 server.expect(manyTimes(), requestTo(
                                 "https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.0&optimalangles=1&outputformat=json"))
@@ -76,6 +84,8 @@ class PvgisSolarResourceAdapterTest {
                 assertThatThrownBy(() -> adapter.fetchProfile(37.3891, -5.9845, 14.0))
                                 .isInstanceOf(BadRequestException.class)
                                 .hasMessageContaining("PVGIS response is incomplete");
+                assertThat(meterRegistry.counter("simulation_service_provider_calls_total", "provider", "pvgis", "outcome", "error").count())
+                                .isEqualTo(1.0d);
 
                 server.verify();
         }
@@ -85,10 +95,12 @@ class PvgisSolarResourceAdapterTest {
         void fetchProfileWrapsProviderFailure() {
                 RestTemplate restTemplate = new RestTemplate();
                 MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+                SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
                 PvgisSolarResourceAdapter adapter = new PvgisSolarResourceAdapter(
                                 new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
                                 new ObjectMapper(),
-                                restTemplate);
+                                restTemplate,
+                                new SimulationProviderTelemetry(meterRegistry));
 
                 server.expect(manyTimes(), requestTo(
                                 "https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.0&optimalangles=1&outputformat=json"))
@@ -98,6 +110,8 @@ class PvgisSolarResourceAdapterTest {
                 assertThatThrownBy(() -> adapter.fetchProfile(37.3891, -5.9845, 14.0))
                                 .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("Failed to fetch PVGIS solar resource data");
+                assertThat(meterRegistry.counter("simulation_service_provider_calls_total", "provider", "pvgis", "outcome", "error").count())
+                                .isEqualTo(1.0d);
 
                 server.verify();
         }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/config/ClimateProviderWiringTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/config/ClimateProviderWiringTest.java
@@ -3,8 +3,10 @@ package com.renewsim.backend.simulation_service.infrastructure.config;
 import com.renewsim.backend.simulation_service.infrastructure.adapter.out.external.OpenWeatherMapAdapter;
 import com.renewsim.backend.simulation_service.location_lookup.application.LocationLookupService;
 import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import com.renewsim.backend.simulation_service.shared.application.SimulationProviderTelemetry;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.retry.RetryRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +25,9 @@ class ClimateProviderWiringTest {
                     LocationLookupService.class,
                     OpenWeatherMapAdapter.class))
             .withBean(CircuitBreakerRegistry.class, CircuitBreakerRegistry::ofDefaults)
-            .withBean(RetryRegistry.class, RetryRegistry::ofDefaults);
+            .withBean(RetryRegistry.class, RetryRegistry::ofDefaults)
+            .withBean(SimulationProviderTelemetry.class,
+                    () -> new SimulationProviderTelemetry(new SimpleMeterRegistry()));
 
     @Test
     @DisplayName("missing provider does not instantiate a location lookup provider")


### PR DESCRIPTION
## What changed
- adds `SimulationProviderTelemetry` for low-cardinality provider metrics in `simulation_service`
- adds `simulation_service_snapshot_degraded_total` to make invalid result snapshots explicitly observable
- instruments `OpenWeatherMapAdapter` and `PvgisSolarResourceAdapter` with provider success/fallback/error counters and duration timers
- extends `GetSimulationService` to record a dedicated snapshot degradation metric
- updates adapter/detail wiring tests and adds explicit metric assertions for providers and snapshot degradation

## Why
Closes  #199 

The first observability slice from `#203` added generic use-case telemetry for `create`, `detail`, `dashboard` and `history`. This follow-up finishes the operational story by making snapshot degradation and external-provider behavior explicitly measurable, while keeping tags limited to `provider`, `use_case`, `outcome` and a narrow `reason` value.

## Validation
- `mvn -Dtest=OpenWeatherMapAdapterTest,PvgisSolarResourceAdapterTest,GetSimulationServiceTest,ClimateProviderWiringTest test`

## Notes for reviewers
- `OpenWeather` records `fallback` because degraded location enrichment is acceptable in this domain.
- `PVGIS` records `error`, not `fallback`, because synthetic energy profiles would be functionally unsafe.
- Follow-up issues already capture work that is intentionally out of scope for `#199`: `#204`, `#205`, `#206`, `#207`.