### PR TITLE
refactor(simulation): cache repeated lookup and solar resource calls

### DIFF
--- a/src/main/java/com/renewsim/backend/shared/config/CacheConfig.java
+++ b/src/main/java/com/renewsim/backend/shared/config/CacheConfig.java
@@ -15,7 +15,12 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("products", "users", "technologies");
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(
+                "products",
+                "users",
+                "technologies",
+                "simulationLocationLookup",
+                "simulationSolarResourceProfiles");
         cacheManager.setCaffeine(Caffeine.newBuilder()
                 .recordStats()
                 .expireAfterWrite(10, TimeUnit.MINUTES) 

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
@@ -14,12 +14,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 /**
@@ -72,6 +74,7 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
     }
 
     @Override
+    @Cacheable(value = "simulationSolarResourceProfiles", key = "#root.target.profileKey(#latitude, #longitude, #systemLossPct)")
     public PvgisSolarResourceProfile fetchProfile(double latitude, double longitude, double systemLossPct) {
         var sample = telemetry.start();
         try {
@@ -178,6 +181,10 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
             temperatures.add(counts[i] == 0 ? 0.0 : sums[i] / counts[i]);
         }
         return temperatures;
+    }
+
+    public String profileKey(double latitude, double longitude, double systemLossPct) {
+        return String.format(Locale.ROOT, "%.4f:%.4f:%.2f", latitude, longitude, systemLossPct);
     }
 
     private String summarizeFailure(Throwable throwable) {

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
@@ -184,7 +184,7 @@ public class PvgisSolarResourceAdapter implements PvgisSolarResourcePort {
     }
 
     public String profileKey(double latitude, double longitude, double systemLossPct) {
-        return String.format(Locale.ROOT, "%.4f:%.4f:%.2f", latitude, longitude, systemLossPct);
+        return Double.toString(latitude) + ':' + Double.toString(longitude) + ':' + Double.toString(systemLossPct);
     }
 
     private String summarizeFailure(Throwable throwable) {

--- a/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupService.java
@@ -4,10 +4,12 @@ import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
 import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupUseCase;
 import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Locale;
 
 @Service
 @ConditionalOnBean(LocationLookupProvider.class)
@@ -17,12 +19,22 @@ public class LocationLookupService implements LocationLookupUseCase {
     private final LocationLookupProvider locationLookupProvider;
 
     @Override
+    @Cacheable(value = "simulationLocationLookup", key = "'resolve:' + #root.target.coordinateKey(#latitude, #longitude)")
     public ResolvedLocation resolveLocation(double latitude, double longitude) {
         return locationLookupProvider.resolveLocation(latitude, longitude);
     }
 
     @Override
+    @Cacheable(value = "simulationLocationLookup", key = "'search:' + #root.target.queryKey(#query) + ':' + #limit")
     public List<ResolvedLocation> searchLocations(String query, int limit) {
         return locationLookupProvider.searchLocations(query, limit);
+    }
+
+    public String coordinateKey(double latitude, double longitude) {
+        return String.format(Locale.ROOT, "%.4f:%.4f", latitude, longitude);
+    }
+
+    public String queryKey(String query) {
+        return query == null ? "" : query.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupService.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupService.java
@@ -19,19 +19,29 @@ public class LocationLookupService implements LocationLookupUseCase {
     private final LocationLookupProvider locationLookupProvider;
 
     @Override
-    @Cacheable(value = "simulationLocationLookup", key = "'resolve:' + #root.target.coordinateKey(#latitude, #longitude)")
+    @Cacheable(
+            value = "simulationLocationLookup",
+            key = "'resolve:' + #root.target.coordinateKey(#latitude, #longitude)",
+            unless = "#result == null || (#result.country() == 'Unknown' && #result.name() == #root.target.coordinateLabel(#latitude, #longitude))")
     public ResolvedLocation resolveLocation(double latitude, double longitude) {
         return locationLookupProvider.resolveLocation(latitude, longitude);
     }
 
     @Override
-    @Cacheable(value = "simulationLocationLookup", key = "'search:' + #root.target.queryKey(#query) + ':' + #limit")
+    @Cacheable(
+            value = "simulationLocationLookup",
+            key = "'search:' + #root.target.queryKey(#query) + ':' + #limit",
+            unless = "#result == null || #result.isEmpty()")
     public List<ResolvedLocation> searchLocations(String query, int limit) {
         return locationLookupProvider.searchLocations(query, limit);
     }
 
     public String coordinateKey(double latitude, double longitude) {
         return String.format(Locale.ROOT, "%.4f:%.4f", latitude, longitude);
+    }
+
+    public String coordinateLabel(double latitude, double longitude) {
+        return String.format(Locale.ROOT, "%.4f, %.4f", latitude, longitude);
     }
 
     public String queryKey(String query) {

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceCacheTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceCacheTest.java
@@ -93,6 +93,30 @@ class PvgisSolarResourceCacheTest {
         server.verify();
     }
 
+    @Test
+    @DisplayName("profileKey keeps close PVGIS inputs distinct")
+    void profileKeyKeepsCloseInputsDistinct() {
+        server.expect(requestTo("https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.001&optimalangles=1&outputformat=json"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(pvcalcPayload(), MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://re.jrc.ec.europa.eu/api/v5_2/tmy?lat=37.3891&lon=-5.9845&outputformat=json"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(tmyPayload(), MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.004&optimalangles=1&outputformat=json"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(pvcalcPayload(), MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://re.jrc.ec.europa.eu/api/v5_2/tmy?lat=37.3891&lon=-5.9845&outputformat=json"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(tmyPayload(), MediaType.APPLICATION_JSON));
+
+        var first = pvgisSolarResourceAdapter.fetchProfile(37.3891, -5.9845, 14.001d);
+        var second = pvgisSolarResourceAdapter.fetchProfile(37.3891, -5.9845, 14.004d);
+
+        assertThat(first.climatePeriod()).isEqualTo("2005-2020");
+        assertThat(second.climatePeriod()).isEqualTo("2005-2020");
+        server.verify();
+    }
+
     private String pvcalcPayload() {
         return """
                 {

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceCacheTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceCacheTest.java
@@ -1,0 +1,149 @@
+package com.renewsim.backend.simulation_service.infrastructure.adapter.out.external;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.renewsim.backend.shared.config.CacheConfig;
+import com.renewsim.backend.simulation_service.create.application.port.out.PvgisSolarResourcePort;
+import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import com.renewsim.backend.simulation_service.shared.application.SimulationProviderTelemetry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@SpringBootTest(classes = {CacheConfig.class, PvgisSolarResourceCacheTest.TestConfig.class})
+@ActiveProfiles("test")
+class PvgisSolarResourceCacheTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        RestTemplate pvgisRestTemplate() {
+            return new RestTemplate();
+        }
+
+        @Bean
+        PvgisProperties pvgisProperties() {
+            return new PvgisProperties("https://re.jrc.ec.europa.eu", null, null);
+        }
+
+        @Bean
+        SimulationProviderTelemetry simulationProviderTelemetry() {
+            return new SimulationProviderTelemetry(new SimpleMeterRegistry());
+        }
+
+        @Bean
+        PvgisSolarResourceAdapter pvgisSolarResourceAdapter(
+                PvgisProperties properties,
+                RestTemplate pvgisRestTemplate,
+                SimulationProviderTelemetry telemetry) {
+            return new PvgisSolarResourceAdapter(properties, new ObjectMapper(), pvgisRestTemplate, telemetry);
+        }
+    }
+
+    @Autowired
+    private RestTemplate pvgisRestTemplate;
+
+    @Autowired
+    private PvgisSolarResourcePort pvgisSolarResourceAdapter;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    private MockRestServiceServer server;
+
+    @BeforeEach
+    void setUp() {
+        server = MockRestServiceServer.createServer(pvgisRestTemplate);
+        var cache = cacheManager.getCache("simulationSolarResourceProfiles");
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @Test
+    @DisplayName("fetchProfile uses cache on second identical call")
+    void fetchProfileUsesCacheOnSecondIdenticalCall() {
+        server.expect(requestTo("https://re.jrc.ec.europa.eu/api/v5_2/PVcalc?lat=37.3891&lon=-5.9845&peakpower=1&loss=14.0&optimalangles=1&outputformat=json"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(pvcalcPayload(), MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://re.jrc.ec.europa.eu/api/v5_2/tmy?lat=37.3891&lon=-5.9845&outputformat=json"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(tmyPayload(), MediaType.APPLICATION_JSON));
+
+        var first = pvgisSolarResourceAdapter.fetchProfile(37.3891, -5.9845, 14.0);
+        var second = pvgisSolarResourceAdapter.fetchProfile(37.3891, -5.9845, 14.0);
+
+        assertThat(first.climatePeriod()).isEqualTo("2005-2020");
+        assertThat(second.climatePeriod()).isEqualTo("2005-2020");
+        server.verify();
+    }
+
+    private String pvcalcPayload() {
+        return """
+                {
+                  "outputs": {
+                    "monthly": {
+                      "fixed": [
+                        {"E_m":100.0,"H(i)_m":10.0},
+                        {"E_m":101.0,"H(i)_m":11.0},
+                        {"E_m":102.0,"H(i)_m":12.0},
+                        {"E_m":103.0,"H(i)_m":13.0},
+                        {"E_m":104.0,"H(i)_m":14.0},
+                        {"E_m":105.0,"H(i)_m":15.0},
+                        {"E_m":106.0,"H(i)_m":16.0},
+                        {"E_m":107.0,"H(i)_m":17.0},
+                        {"E_m":108.0,"H(i)_m":18.0},
+                        {"E_m":109.0,"H(i)_m":19.0},
+                        {"E_m":110.0,"H(i)_m":20.0},
+                        {"E_m":111.0,"H(i)_m":21.0}
+                      ]
+                    }
+                  },
+                  "inputs": {
+                    "meteo_data": {
+                      "year_min": 2005,
+                      "year_max": 2020
+                    }
+                  }
+                }
+                """;
+    }
+
+    private String tmyPayload() {
+        return """
+                {
+                  "outputs": {
+                    "tmy_hourly": [
+                      {"time(UTC)":"2024010100","T2m":10.0},
+                      {"time(UTC)":"2024020100","T2m":11.0},
+                      {"time(UTC)":"2024030100","T2m":12.0},
+                      {"time(UTC)":"2024040100","T2m":13.0},
+                      {"time(UTC)":"2024050100","T2m":14.0},
+                      {"time(UTC)":"2024060100","T2m":15.0},
+                      {"time(UTC)":"2024070100","T2m":16.0},
+                      {"time(UTC)":"2024080100","T2m":17.0},
+                      {"time(UTC)":"2024090100","T2m":18.0},
+                      {"time(UTC)":"2024100100","T2m":19.0},
+                      {"time(UTC)":"2024110100","T2m":20.0},
+                      {"time(UTC)":"2024120100","T2m":21.0}
+                    ]
+                  }
+                }
+                """;
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupCacheTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupCacheTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -54,6 +55,7 @@ class LocationLookupCacheTest {
         if (cache != null) {
             cache.clear();
         }
+        reset(locationLookupProvider);
     }
 
     @Test
@@ -82,5 +84,28 @@ class LocationLookupCacheTest {
         assertThat(first).containsExactlyElementsOf(expected);
         assertThat(second).containsExactlyElementsOf(expected);
         verify(locationLookupProvider, times(1)).searchLocations("sevilla", 5);
+    }
+
+    @Test
+    @DisplayName("searchLocations does not cache degraded empty fallback results")
+    void searchLocationsDoesNotCacheDegradedEmptyFallbackResults() {
+        when(locationLookupProvider.searchLocations("sevilla", 5)).thenReturn(List.of());
+
+        locationLookupService.searchLocations("sevilla", 5);
+        locationLookupService.searchLocations("sevilla", 5);
+
+        verify(locationLookupProvider, times(2)).searchLocations("sevilla", 5);
+    }
+
+    @Test
+    @DisplayName("resolveLocation does not cache degraded unknown fallback results")
+    void resolveLocationDoesNotCacheDegradedUnknownFallbackResults() {
+        ResolvedLocation degraded = new ResolvedLocation("37.3891, -5.9845", "Unknown");
+        when(locationLookupProvider.resolveLocation(37.3891, -5.9845)).thenReturn(degraded);
+
+        locationLookupService.resolveLocation(37.3891, -5.9845);
+        locationLookupService.resolveLocation(37.3891, -5.9845);
+
+        verify(locationLookupProvider, times(2)).resolveLocation(37.3891, -5.9845);
     }
 }

--- a/src/test/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupCacheTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/location_lookup/application/LocationLookupCacheTest.java
@@ -1,0 +1,86 @@
+package com.renewsim.backend.simulation_service.location_lookup.application;
+
+import com.renewsim.backend.shared.config.CacheConfig;
+import com.renewsim.backend.simulation_service.domain.model.vo.ResolvedLocation;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.in.LocationLookupUseCase;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = {CacheConfig.class, LocationLookupCacheTest.TestConfig.class})
+@ActiveProfiles("test")
+class LocationLookupCacheTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        LocationLookupProvider locationLookupProvider() {
+            return mock(LocationLookupProvider.class);
+        }
+
+        @Bean
+        LocationLookupUseCase locationLookupUseCase(LocationLookupProvider locationLookupProvider) {
+            return new LocationLookupService(locationLookupProvider);
+        }
+    }
+
+    @Autowired
+    private LocationLookupProvider locationLookupProvider;
+
+    @Autowired
+    private LocationLookupUseCase locationLookupService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void clearCache() {
+        var cache = cacheManager.getCache("simulationLocationLookup");
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @Test
+    @DisplayName("resolveLocation uses cache on second identical call")
+    void resolveLocationUsesCacheOnSecondIdenticalCall() {
+        ResolvedLocation expected = new ResolvedLocation("Sevilla", "ES", 37.3891, -5.9845);
+        when(locationLookupProvider.resolveLocation(37.3891, -5.9845)).thenReturn(expected);
+
+        ResolvedLocation first = locationLookupService.resolveLocation(37.3891, -5.9845);
+        ResolvedLocation second = locationLookupService.resolveLocation(37.3891, -5.9845);
+
+        assertThat(first).isEqualTo(expected);
+        assertThat(second).isEqualTo(expected);
+        verify(locationLookupProvider, times(1)).resolveLocation(37.3891, -5.9845);
+    }
+
+    @Test
+    @DisplayName("searchLocations uses cache on second identical call")
+    void searchLocationsUsesCacheOnSecondIdenticalCall() {
+        List<ResolvedLocation> expected = List.of(new ResolvedLocation("Sevilla", "ES", 37.3891, -5.9845));
+        when(locationLookupProvider.searchLocations("sevilla", 5)).thenReturn(expected);
+
+        List<ResolvedLocation> first = locationLookupService.searchLocations("sevilla", 5);
+        List<ResolvedLocation> second = locationLookupService.searchLocations("sevilla", 5);
+
+        assertThat(first).containsExactlyElementsOf(expected);
+        assertThat(second).containsExactlyElementsOf(expected);
+        verify(locationLookupProvider, times(1)).searchLocations("sevilla", 5);
+    }
+}


### PR DESCRIPTION
## What changed
- adds dedicated cache regions for repeated `simulation_service` lookups and PVGIS resource profiles
- caches `LocationLookupService.resolveLocation(...)` and `searchLocations(...)` behind low-risk keys
- caches `PvgisSolarResourceAdapter.fetchProfile(...)` for repeated identical solar resource requests
- adds focused cache tests for location lookup and PVGIS profile reuse

## Why
Closes #200.

After finishing resilience and observability, `simulation_service` still repeated the most obvious deterministic external lookups without using the cache infrastructure that already exists in the project. This PR adds a first selective caching slice only where the performance/cost benefit is clear and coherence risk is low: location lookup and repeated PVGIS profile fetches.

## Validation
- `mvn -Dtest=LocationLookupCacheTest,PvgisSolarResourceCacheTest test`

## Notes for reviewers
- This PR intentionally does **not** cache `detail` or `dashboard`; those flows have a more sensitive coherence story and deserve a separate decision if we ever want them cached.
- Cache keys are normalized and low-cardinality (`lat/lon`, query + limit, and PVGIS input tuple) to keep behavior predictable and defendable.