### PR TITLE
refactor(simulation): add operational health guardrails

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicator.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicator.java
@@ -1,0 +1,103 @@
+package com.renewsim.backend.simulation_service.infrastructure.health;
+
+import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import com.renewsim.backend.simulation_service.infrastructure.config.SimulationClimateProperties;
+import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Set;
+
+@Component("simulationService")
+public class SimulationServiceHealthIndicator implements HealthIndicator {
+
+    private static final Set<String> STRICT_PROFILES = Set.of("stage", "prod");
+
+    private final SimulationClimateProperties climateProperties;
+    private final WeatherServiceProperties weatherProperties;
+    private final PvgisProperties pvgisProperties;
+    private final ObjectProvider<LocationLookupProvider> locationLookupProvider;
+    private final Environment environment;
+
+    public SimulationServiceHealthIndicator(
+            SimulationClimateProperties climateProperties,
+            WeatherServiceProperties weatherProperties,
+            PvgisProperties pvgisProperties,
+            ObjectProvider<LocationLookupProvider> locationLookupProvider,
+            Environment environment) {
+        this.climateProperties = climateProperties;
+        this.weatherProperties = weatherProperties;
+        this.pvgisProperties = pvgisProperties;
+        this.locationLookupProvider = locationLookupProvider;
+        this.environment = environment;
+    }
+
+    @Override
+    public Health health() {
+        String provider = normalize(climateProperties.provider());
+        boolean strictProfile = STRICT_PROFILES.stream()
+                .anyMatch(profile -> environment.acceptsProfiles(Profiles.of(profile)));
+
+        Health.Builder builder = Health.up()
+                .withDetail("climateProvider", provider.isBlank() ? "unset" : provider)
+                .withDetail("strictProfile", strictProfile)
+                .withDetail("locationLookupProviderPresent", locationLookupProvider.getIfAvailable() != null)
+                .withDetail("pvgisConfigured", hasValidUri(pvgisProperties.url()));
+
+        if (!provider.isBlank() && !provider.equals("dummy") && !provider.equals("openweathermap")) {
+            return builder.down()
+                    .withDetail("reason", "unsupported_climate_provider")
+                    .build();
+        }
+
+        if (provider.equals("openweathermap")) {
+            if (locationLookupProvider.getIfAvailable() == null) {
+                return builder.down()
+                        .withDetail("reason", "missing_location_lookup_provider")
+                        .build();
+            }
+            if (!hasValidUri(weatherProperties.url())) {
+                return builder.down()
+                        .withDetail("reason", "invalid_openweather_url")
+                        .build();
+            }
+            if (strictProfile && isMissingOrDummy(weatherProperties.key())) {
+                return builder.down()
+                        .withDetail("reason", "missing_openweather_api_key")
+                        .build();
+            }
+        }
+
+        if (!hasValidUri(pvgisProperties.url())) {
+            return builder.down()
+                    .withDetail("reason", "invalid_pvgis_url")
+                    .build();
+        }
+
+        return builder.build();
+    }
+
+    private boolean hasValidUri(String value) {
+        try {
+            URI uri = URI.create(value);
+            return uri.getScheme() != null && uri.getHost() != null;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    private boolean isMissingOrDummy(String key) {
+        String normalized = normalize(key);
+        return normalized.isBlank() || normalized.equals("dummy-key");
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim().toLowerCase();
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicator.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicator.java
@@ -86,7 +86,8 @@ public class SimulationServiceHealthIndicator implements HealthIndicator {
     private boolean hasValidUri(String value) {
         try {
             URI uri = URI.create(value);
-            return uri.getScheme() != null && uri.getHost() != null;
+            String scheme = normalize(uri.getScheme());
+            return (scheme.equals("http") || scheme.equals("https")) && uri.getHost() != null;
         } catch (Exception ex) {
             return false;
         }

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceActuatorHealthIntegrationTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceActuatorHealthIntegrationTest.java
@@ -1,0 +1,80 @@
+package com.renewsim.backend.simulation_service.infrastructure.health;
+
+import com.renewsim.backend.auth_service.infrastructure.config.ActuatorSecurityConfig;
+import com.renewsim.backend.auth_service.infrastructure.security.SecurityHeadersFilter;
+import com.renewsim.backend.shared.observability.CorrelationIdFilter;
+import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import com.renewsim.backend.simulation_service.infrastructure.config.SimulationClimateProperties;
+import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Duration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = SimulationServiceActuatorHealthIntegrationTest.TestApp.class,
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+@TestPropertySource(properties = {
+        "management.endpoints.web.exposure.include=health",
+        "management.endpoint.health.show-details=always"
+})
+class SimulationServiceActuatorHealthIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    @DisplayName("local actuator exposes simulationService health contributor details")
+    void actuatorHealthExposesSimulationServiceContributor() throws Exception {
+        mvc.perform(get("/actuator/health/simulationService"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.details.climateProvider").value("dummy"))
+                .andExpect(jsonPath("$.details.pvgisConfigured").value(true));
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration(exclude = {
+            DataSourceAutoConfiguration.class,
+            HibernateJpaAutoConfiguration.class,
+            FlywayAutoConfiguration.class
+    })
+    @Import({ ActuatorSecurityConfig.class, SecurityHeadersFilter.class, CorrelationIdFilter.class,
+            SimulationServiceHealthIndicator.class })
+    static class TestApp {
+
+        @Bean
+        SimulationClimateProperties simulationClimateProperties() {
+            return new SimulationClimateProperties("dummy");
+        }
+
+        @Bean
+        WeatherServiceProperties weatherServiceProperties() {
+            return new WeatherServiceProperties("https://api.openweathermap.org", "dummy-key",
+                    Duration.ofSeconds(2), Duration.ofSeconds(3));
+        }
+
+        @Bean
+        PvgisProperties pvgisProperties() {
+            return new PvgisProperties("https://re.jrc.ec.europa.eu", Duration.ofSeconds(2), Duration.ofSeconds(5));
+        }
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicatorTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicatorTest.java
@@ -69,6 +69,22 @@ class SimulationServiceHealthIndicatorTest {
         assertThat(health.getDetails()).containsEntry("reason", "invalid_pvgis_url");
     }
 
+    @Test
+    @DisplayName("health is down for unsupported weather url scheme")
+    void healthIsDownForUnsupportedWeatherUrlScheme() {
+        SimulationServiceHealthIndicator indicator = new SimulationServiceHealthIndicator(
+                new SimulationClimateProperties("openweathermap"),
+                new WeatherServiceProperties("ftp://api.openweathermap.org", "real-key", Duration.ofSeconds(2), Duration.ofSeconds(3)),
+                new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
+                providerOf(mock(LocationLookupProvider.class)),
+                new MockEnvironment().withProperty("spring.profiles.active", "local"));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "invalid_openweather_url");
+    }
+
     private ObjectProvider<LocationLookupProvider> providerOf(LocationLookupProvider provider) {
         return new ObjectProvider<>() {
             @Override

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicatorTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicatorTest.java
@@ -1,0 +1,95 @@
+package com.renewsim.backend.simulation_service.infrastructure.health;
+
+import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import com.renewsim.backend.simulation_service.infrastructure.config.SimulationClimateProperties;
+import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class SimulationServiceHealthIndicatorTest {
+
+    @Test
+    @DisplayName("health is up for valid openweather configuration")
+    void healthIsUpForValidOpenWeatherConfiguration() {
+        SimulationServiceHealthIndicator indicator = new SimulationServiceHealthIndicator(
+                new SimulationClimateProperties("openweathermap"),
+                new WeatherServiceProperties("https://api.openweathermap.org", "real-key", Duration.ofSeconds(2),
+                        Duration.ofSeconds(3)),
+                new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
+                providerOf(mock(LocationLookupProvider.class)),
+                new MockEnvironment().withProperty("spring.profiles.active", "stage"));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("climateProvider", "openweathermap");
+    }
+
+    @Test
+    @DisplayName("health is down when openweather provider is configured without lookup bean")
+    void healthIsDownWhenOpenWeatherBeanIsMissing() {
+        SimulationServiceHealthIndicator indicator = new SimulationServiceHealthIndicator(
+                new SimulationClimateProperties("openweathermap"),
+                new WeatherServiceProperties("https://api.openweathermap.org", "real-key", Duration.ofSeconds(2),
+                        Duration.ofSeconds(3)),
+                new PvgisProperties("https://re.jrc.ec.europa.eu", null, null),
+                providerOf(null),
+                new MockEnvironment().withProperty("spring.profiles.active", "local"));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "missing_location_lookup_provider");
+    }
+
+    @Test
+    @DisplayName("health is down for invalid pvgis url")
+    void healthIsDownForInvalidPvgisUrl() {
+        SimulationServiceHealthIndicator indicator = new SimulationServiceHealthIndicator(
+                new SimulationClimateProperties("dummy"),
+                new WeatherServiceProperties("https://api.openweathermap.org", "dummy-key", Duration.ofSeconds(2),
+                        Duration.ofSeconds(3)),
+                new PvgisProperties("not-a-valid-url", null, null),
+                providerOf(null),
+                new MockEnvironment().withProperty("spring.profiles.active", "local"));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "invalid_pvgis_url");
+    }
+
+    private ObjectProvider<LocationLookupProvider> providerOf(LocationLookupProvider provider) {
+        return new ObjectProvider<>() {
+            @Override
+            public LocationLookupProvider getObject(Object... args) {
+                return provider;
+            }
+
+            @Override
+            public LocationLookupProvider getIfAvailable() {
+                return provider;
+            }
+
+            @Override
+            public LocationLookupProvider getIfUnique() {
+                return provider;
+            }
+
+            @Override
+            public LocationLookupProvider getObject() {
+                return provider;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What changed
- adds `SimulationServiceHealthIndicator` to expose bounded-context health for `simulation_service`
- validates operational readiness from configuration and wiring state instead of fragile remote pings
- adds focused unit tests for valid and invalid configuration states
- adds an actuator integration test proving that the `simulationService` contributor is exposed through `/actuator/health/simulationService` in `local`

## Why
Closes #201.

After resilience, observability and selective caching, the remaining hardening gap in `simulation_service` was an explicit operational guardrail for the bounded context itself. This PR adds a cheap and defendable health signal that reports whether simulation climate/provider configuration is sane and whether the module is wired well enough to operate.

## Validation
- `mvn -Dtest=SimulationServiceHealthIndicatorTest,SimulationServiceActuatorHealthIntegrationTest,ClimateConfigurationValidatorTest test`

## Notes for reviewers
- This PR intentionally avoids live remote health probes to OpenWeather/PVGIS; the goal here is bounded-context readiness and safe configuration validation, not an availability check that could make health unstable.
- The actuator integration test runs on `local` with `show-details=always` so we can verify contributor exposure without weakening the stage/prod security model.