### PR TITLE
refactor(simulation): add dependency-specific health indicators

### DIFF
--- a/src/main/java/com/renewsim/backend/simulation_service/create/application/SimulationCompletionAssembler.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/create/application/SimulationCompletionAssembler.java
@@ -1,6 +1,5 @@
 package com.renewsim.backend.simulation_service.create.application;
 
-import com.renewsim.backend.simulation_service.domain.model.Simulation;
 import com.renewsim.backend.simulation_service.domain.model.SimulationCompletion;
 import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import com.renewsim.backend.simulation_service.shared.application.port.out.SimulationResultSnapshotWriterPort;

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/adapter/out/external/PvgisSolarResourceAdapter.java
@@ -21,7 +21,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Supplier;
 
 /**

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/OpenWeatherSimulationHealthIndicator.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/OpenWeatherSimulationHealthIndicator.java
@@ -1,0 +1,61 @@
+package com.renewsim.backend.simulation_service.infrastructure.health;
+
+import com.renewsim.backend.simulation_service.infrastructure.config.SimulationClimateProperties;
+import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.stereotype.Component;
+
+@Component("openWeatherSimulation")
+public class OpenWeatherSimulationHealthIndicator implements HealthIndicator {
+
+    private final SimulationClimateProperties climateProperties;
+    private final WeatherServiceProperties weatherProperties;
+    private final ObjectProvider<LocationLookupProvider> locationLookupProvider;
+    private final Environment environment;
+
+    public OpenWeatherSimulationHealthIndicator(
+            SimulationClimateProperties climateProperties,
+            WeatherServiceProperties weatherProperties,
+            ObjectProvider<LocationLookupProvider> locationLookupProvider,
+            Environment environment) {
+        this.climateProperties = climateProperties;
+        this.weatherProperties = weatherProperties;
+        this.locationLookupProvider = locationLookupProvider;
+        this.environment = environment;
+    }
+
+    @Override
+    public Health health() {
+        String provider = SimulationHealthSupport.normalize(climateProperties.provider());
+        boolean strictProfile = environment.acceptsProfiles(Profiles.of("stage", "prod"));
+
+        if (!provider.equals("openweathermap")) {
+            return Health.unknown()
+                    .withDetail("provider", "openweathermap")
+                    .withDetail("reason", "provider_not_active")
+                    .build();
+        }
+
+        Health.Builder builder = Health.up()
+                .withDetail("provider", "openweathermap")
+                .withDetail("strictProfile", strictProfile)
+                .withDetail("locationLookupProviderPresent", locationLookupProvider.getIfAvailable() != null);
+
+        if (locationLookupProvider.getIfAvailable() == null) {
+            return builder.down().withDetail("reason", "missing_location_lookup_provider").build();
+        }
+        if (!SimulationHealthSupport.hasValidHttpUri(weatherProperties.url())) {
+            return builder.down().withDetail("reason", "invalid_openweather_url").build();
+        }
+        if (strictProfile && SimulationHealthSupport.isMissingOrDummy(weatherProperties.key())) {
+            return builder.down().withDetail("reason", "missing_openweather_api_key").build();
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/PvgisSimulationHealthIndicator.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/PvgisSimulationHealthIndicator.java
@@ -1,0 +1,27 @@
+package com.renewsim.backend.simulation_service.infrastructure.health;
+
+import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component("pvgisSimulation")
+public class PvgisSimulationHealthIndicator implements HealthIndicator {
+
+    private final PvgisProperties pvgisProperties;
+
+    public PvgisSimulationHealthIndicator(PvgisProperties pvgisProperties) {
+        this.pvgisProperties = pvgisProperties;
+    }
+
+    @Override
+    public Health health() {
+        if (!SimulationHealthSupport.hasValidHttpUri(pvgisProperties.url())) {
+            return Health.down()
+                    .withDetail("provider", "pvgis")
+                    .withDetail("reason", "invalid_pvgis_url")
+                    .build();
+        }
+        return Health.up().withDetail("provider", "pvgis").build();
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationHealthSupport.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationHealthSupport.java
@@ -1,0 +1,28 @@
+package com.renewsim.backend.simulation_service.infrastructure.health;
+
+import java.net.URI;
+
+final class SimulationHealthSupport {
+
+    private SimulationHealthSupport() {
+    }
+
+    static boolean hasValidHttpUri(String value) {
+        try {
+            URI uri = URI.create(value);
+            String scheme = normalize(uri.getScheme());
+            return (scheme.equals("http") || scheme.equals("https")) && uri.getHost() != null;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    static boolean isMissingOrDummy(String key) {
+        String normalized = normalize(key);
+        return normalized.isBlank() || normalized.equals("dummy-key");
+    }
+
+    static String normalize(String value) {
+        return value == null ? "" : value.trim().toLowerCase();
+    }
+}

--- a/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicator.java
+++ b/src/main/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceHealthIndicator.java
@@ -11,7 +11,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Component;
 
-import java.net.URI;
 import java.util.Set;
 
 @Component("simulationService")
@@ -40,7 +39,7 @@ public class SimulationServiceHealthIndicator implements HealthIndicator {
 
     @Override
     public Health health() {
-        String provider = normalize(climateProperties.provider());
+        String provider = SimulationHealthSupport.normalize(climateProperties.provider());
         boolean strictProfile = STRICT_PROFILES.stream()
                 .anyMatch(profile -> environment.acceptsProfiles(Profiles.of(profile)));
 
@@ -48,7 +47,7 @@ public class SimulationServiceHealthIndicator implements HealthIndicator {
                 .withDetail("climateProvider", provider.isBlank() ? "unset" : provider)
                 .withDetail("strictProfile", strictProfile)
                 .withDetail("locationLookupProviderPresent", locationLookupProvider.getIfAvailable() != null)
-                .withDetail("pvgisConfigured", hasValidUri(pvgisProperties.url()));
+                .withDetail("pvgisConfigured", SimulationHealthSupport.hasValidHttpUri(pvgisProperties.url()));
 
         if (!provider.isBlank() && !provider.equals("dummy") && !provider.equals("openweathermap")) {
             return builder.down()
@@ -62,43 +61,24 @@ public class SimulationServiceHealthIndicator implements HealthIndicator {
                         .withDetail("reason", "missing_location_lookup_provider")
                         .build();
             }
-            if (!hasValidUri(weatherProperties.url())) {
+            if (!SimulationHealthSupport.hasValidHttpUri(weatherProperties.url())) {
                 return builder.down()
                         .withDetail("reason", "invalid_openweather_url")
                         .build();
             }
-            if (strictProfile && isMissingOrDummy(weatherProperties.key())) {
+            if (strictProfile && SimulationHealthSupport.isMissingOrDummy(weatherProperties.key())) {
                 return builder.down()
                         .withDetail("reason", "missing_openweather_api_key")
                         .build();
             }
         }
 
-        if (!hasValidUri(pvgisProperties.url())) {
+        if (!SimulationHealthSupport.hasValidHttpUri(pvgisProperties.url())) {
             return builder.down()
                     .withDetail("reason", "invalid_pvgis_url")
                     .build();
         }
 
         return builder.build();
-    }
-
-    private boolean hasValidUri(String value) {
-        try {
-            URI uri = URI.create(value);
-            String scheme = normalize(uri.getScheme());
-            return (scheme.equals("http") || scheme.equals("https")) && uri.getHost() != null;
-        } catch (Exception ex) {
-            return false;
-        }
-    }
-
-    private boolean isMissingOrDummy(String key) {
-        String normalized = normalize(key);
-        return normalized.isBlank() || normalized.equals("dummy-key");
-    }
-
-    private String normalize(String value) {
-        return value == null ? "" : value.trim().toLowerCase();
     }
 }

--- a/src/test/java/com/renewsim/backend/scenario_service/application/service/ScenarioApplicationServiceTest.java
+++ b/src/test/java/com/renewsim/backend/scenario_service/application/service/ScenarioApplicationServiceTest.java
@@ -23,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicyTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/domain/policy/SimulationFinancialRiskPolicyTest.java
@@ -1,10 +1,8 @@
 package com.renewsim.backend.simulation_service.domain.policy;
 
-import com.renewsim.backend.simulation_service.shared.application.SimulationDetailsResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/OpenWeatherSimulationHealthIndicatorTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/OpenWeatherSimulationHealthIndicatorTest.java
@@ -1,0 +1,57 @@
+package com.renewsim.backend.simulation_service.infrastructure.health;
+
+import com.renewsim.backend.simulation_service.infrastructure.config.SimulationClimateProperties;
+import com.renewsim.backend.simulation_service.infrastructure.config.WeatherServiceProperties;
+import com.renewsim.backend.simulation_service.location_lookup.application.port.out.LocationLookupProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenWeatherSimulationHealthIndicatorTest {
+
+    @Test
+    @DisplayName("health is unknown when openweather provider is not active")
+    void healthIsUnknownWhenProviderIsNotActive() {
+        OpenWeatherSimulationHealthIndicator indicator = new OpenWeatherSimulationHealthIndicator(
+                new SimulationClimateProperties("dummy"),
+                new WeatherServiceProperties("https://api.openweathermap.org", "dummy-key", Duration.ofSeconds(2), Duration.ofSeconds(3)),
+                providerOf(null),
+                new MockEnvironment().withProperty("spring.profiles.active", "local"));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "provider_not_active");
+    }
+
+    @Test
+    @DisplayName("health is down when active openweather provider has no lookup bean")
+    void healthIsDownWhenLookupBeanIsMissing() {
+        OpenWeatherSimulationHealthIndicator indicator = new OpenWeatherSimulationHealthIndicator(
+                new SimulationClimateProperties("openweathermap"),
+                new WeatherServiceProperties("https://api.openweathermap.org", "real-key", Duration.ofSeconds(2), Duration.ofSeconds(3)),
+                providerOf(null),
+                new MockEnvironment().withProperty("spring.profiles.active", "local"));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "missing_location_lookup_provider");
+    }
+
+    private ObjectProvider<LocationLookupProvider> providerOf(LocationLookupProvider provider) {
+        return new ObjectProvider<>() {
+            @Override public LocationLookupProvider getObject(Object... args) { return provider; }
+            @Override public LocationLookupProvider getIfAvailable() { return provider; }
+            @Override public LocationLookupProvider getIfUnique() { return provider; }
+            @Override public LocationLookupProvider getObject() { return provider; }
+        };
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/PvgisSimulationHealthIndicatorTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/PvgisSimulationHealthIndicatorTest.java
@@ -1,0 +1,36 @@
+package com.renewsim.backend.simulation_service.infrastructure.health;
+
+import com.renewsim.backend.simulation_service.infrastructure.config.PvgisProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PvgisSimulationHealthIndicatorTest {
+
+    @Test
+    @DisplayName("health is up when pvgis url is valid")
+    void healthIsUpWhenPvgisUrlIsValid() {
+        PvgisSimulationHealthIndicator indicator = new PvgisSimulationHealthIndicator(
+                new PvgisProperties("https://re.jrc.ec.europa.eu", null, null));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("provider", "pvgis");
+    }
+
+    @Test
+    @DisplayName("health is down when pvgis url is invalid")
+    void healthIsDownWhenPvgisUrlIsInvalid() {
+        PvgisSimulationHealthIndicator indicator = new PvgisSimulationHealthIndicator(
+                new PvgisProperties("ftp://re.jrc.ec.europa.eu", null, null));
+
+        Health health = indicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "invalid_pvgis_url");
+    }
+}

--- a/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceActuatorHealthIntegrationTest.java
+++ b/src/test/java/com/renewsim/backend/simulation_service/infrastructure/health/SimulationServiceActuatorHealthIntegrationTest.java
@@ -51,6 +51,24 @@ class SimulationServiceActuatorHealthIntegrationTest {
                 .andExpect(jsonPath("$.details.pvgisConfigured").value(true));
     }
 
+    @Test
+    @DisplayName("local actuator exposes pvgis health contributor details")
+    void actuatorHealthExposesPvgisContributor() throws Exception {
+        mvc.perform(get("/actuator/health/pvgisSimulation"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.details.provider").value("pvgis"));
+    }
+
+    @Test
+    @DisplayName("local actuator exposes openweather contributor as unknown when provider is inactive")
+    void actuatorHealthExposesOpenWeatherContributorAsUnknown() throws Exception {
+        mvc.perform(get("/actuator/health/openWeatherSimulation"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UNKNOWN"))
+                .andExpect(jsonPath("$.details.reason").value("provider_not_active"));
+    }
+
     @SpringBootConfiguration
     @EnableAutoConfiguration(exclude = {
             DataSourceAutoConfiguration.class,
@@ -58,7 +76,8 @@ class SimulationServiceActuatorHealthIntegrationTest {
             FlywayAutoConfiguration.class
     })
     @Import({ ActuatorSecurityConfig.class, SecurityHeadersFilter.class, CorrelationIdFilter.class,
-            SimulationServiceHealthIndicator.class })
+            SimulationServiceHealthIndicator.class, OpenWeatherSimulationHealthIndicator.class,
+            PvgisSimulationHealthIndicator.class })
     static class TestApp {
 
         @Bean

--- a/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupServiceTest.java
+++ b/src/test/java/com/renewsim/backend/technology_service/application/service/TechnologyCatalogLookupServiceTest.java
@@ -1,7 +1,6 @@
 package com.renewsim.backend.technology_service.application.service;
 
 import com.renewsim.backend.technology_service.application.port.out.TechnologyRepositoryPort;
-import com.renewsim.backend.technology_service.domain.factory.TechnologyFactory;
 import com.renewsim.backend.technology_service.domain.model.Technology;
 import com.renewsim.backend.technology_service.domain.model.vo.CapacityFactor;
 import com.renewsim.backend.technology_service.domain.model.vo.Co2Reduction;


### PR DESCRIPTION
## What changed
- adds `OpenWeatherSimulationHealthIndicator` and `PvgisSimulationHealthIndicator` as dependency-specific health contributors for `simulation_service`
- extracts shared URL/config validation helpers into `SimulationHealthSupport`
- keeps `SimulationServiceHealthIndicator` as the bounded-context summary contributor while adding more granular dependency health signals
- extends the actuator integration test so `/actuator/health/openWeatherSimulation` and `/actuator/health/pvgisSimulation` are verified in `local`
- adds focused unit tests for both dependency indicators and validates unsupported URL schemes

## Why
Closes #205.

The base guardrail from `#201` already exposed bounded-context health, but the module still lacked dependency-level health signals that separated OpenWeather readiness from PVGIS readiness. This PR adds that granularity without moving into fragile remote probes.

## Validation
- `mvn -Dtest=SimulationServiceHealthIndicatorTest,OpenWeatherSimulationHealthIndicatorTest,PvgisSimulationHealthIndicatorTest,SimulationServiceActuatorHealthIntegrationTest,ClimateConfigurationValidatorTest test`

## Notes for reviewers
- These indicators are intentionally configuration/wiring-oriented, not remote availability checks.
- The goal is to improve health semantics for `simulation_service` dependencies while keeping actuator behavior stable and cheap.